### PR TITLE
Update the documentation with the new config paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ authenticated domain.
 ```
 
 If you have Jicofo installed from the Debian package this should go directly to
-<b>/usr/share/jicofo/.sip-communicator/sip-communicator.properties</b> file:
+<b>/etc/jitsi/jicofo/sip-communicator.properties</b> file:
 ```
 org.jitsi.jicofo.auth.URL=XMPP:jitsi-meet.example.com
 ```

--- a/doc/reservation.md
+++ b/doc/reservation.md
@@ -18,7 +18,7 @@ org.jitsi.impl.reservation.rest.BASE_URL=http://reservation.example.com
 ```
 
 It can be either specified with <tt>-Darg=value</tt> when running from the
-command line directly or in <tt>/usr/share/jicofo/.sip-communicator/sip-communicator.properties</tt>
+command line directly or in <tt>/etc/jitsi/jicofo/sip-communicator.properties</tt>
 in case Jicofo has been installed from our [Debian package].
  
 [Debian package]: https://github.com/jitsi/jitsi-meet/blob/master/doc/quick-install.md

--- a/doc/reservation.md
+++ b/doc/reservation.md
@@ -18,7 +18,7 @@ org.jitsi.impl.reservation.rest.BASE_URL=http://reservation.example.com
 ```
 
 It can be either specified with <tt>-Darg=value</tt> when running from the
-command line directly or in <tt>/usr/share/jcofo/.sip-communicator/sip-communicator.properties</tt>
+command line directly or in <tt>/usr/share/jicofo/.sip-communicator/sip-communicator.properties</tt>
 in case Jicofo has been installed from our [Debian package].
  
 [Debian package]: https://github.com/jitsi/jitsi-meet/blob/master/doc/quick-install.md

--- a/doc/shibboleth.md
+++ b/doc/shibboleth.md
@@ -287,7 +287,7 @@ Before <b>\<ApplicationDefaults\></b> element append following config(replace
 
 ###Enable Shibboleth servlet in Jicofo
 
-Edit <b>/usr/share/jicofo/.sip-communicator/sip-communicator.properties</b> file
+Edit <b>/etc/jitsi/jicofo/sip-communicator.properties</b> file
 and add following lines:
 
 ```

--- a/resources/install/debian/postinst
+++ b/resources/install/debian/postinst
@@ -67,7 +67,7 @@ case "$1" in
 
         fi
 
-        OLD_JITSI_CONFIG="/usr/share/jicofo/.sip-communicator/sip-communicator.properties"
+        OLD_JITSI_CONFIG="/etc/jitsi/jicofo/sip-communicator.properties"
         NEW_JITSI_CONFIG="/etc/jitsi/jicofo/sip-communicator.properties"
         if [ -f $OLD_JITSI_CONFIG ]; then
             mv $OLD_JITSI_CONFIG $NEW_JITSI_CONFIG


### PR DESCRIPTION
Update the documentation with the new config path /etc/jitsi/jicofo used in the .deb files.