### PR TITLE
Update bcprov-jdk15on to 1.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,12 +136,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <!--
-      jitsi-videobridge requires a patched version of ours from the branch
-      r1rv51-patched of gpolitis/bc-java (at GitHub).
-      Jicofo will use the same version.
-      -->
-      <version>1.51-jitsi-1</version>
+      <version>1.54</version>
       <scope>runtime</scope>
     </dependency>
     <!-- test -->


### PR DESCRIPTION
Quickly run tested with Firefox Nightly 46 and Chrome 47

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>