### PR TITLE
updated collect dump script with OOM heap dumps

### DIFF
--- a/resources/collect-dump-logs.sh
+++ b/resources/collect-dump-logs.sh
@@ -3,10 +3,13 @@
 # script that creates an archive in current folder
 # containing the heap and thread dump and the current log file
 
-PID=$(cat /var/run/jicofo.pid)
+JAVA_HEAPDUMP_PATH="/tmp/java_*.hprof"
+STAMP=`date +%Y-%m-%d-%H%M`
+PID_PATH="/var/run/jicofo.pid"
+
+[ -e $PID_PATH ] && PID=$(cat $PID_PATH)
 if [ $PID ]; then
     echo "Jicofo pid $PID"
-    STAMP=`date +%Y-%m-%d-%H%M`
     THREADS_FILE="/tmp/stack-${STAMP}-${PID}.threads"
     HEAP_FILE="/tmp/heap-${STAMP}-${PID}.bin"
     sudo -u jicofo jstack ${PID} > ${THREADS_FILE}
@@ -14,5 +17,11 @@ if [ $PID ]; then
     tar zcvf jicofo-dumps-${STAMP}-${PID}.tgz ${THREADS_FILE} ${HEAP_FILE} /var/log/jitsi/jicofo.log
     rm ${HEAP_FILE} ${THREADS_FILE}
 else
-    echo "Jicofo not running"
+    if [ -e $JAVA_HEAPDUMP_PATH ]; then
+        echo "Jicofo not running, but previous heap dump found."
+        tar zcvf jicofo-dumps-${STAMP}-crash.tgz $JAVA_HEAPDUMP_PATH /var/log/jitsi/jvb.log
+        rm ${JAVA_HEAPDUMP_PATH}
+    else
+        echo "Jicofo not running."
+    fi
 fi


### PR DESCRIPTION
updated collect dump script to include heap dumps from OOM crashes if they are present in /tmp

This script now grabs any heap dumps from /tmp if the running process isn't found.  This is intended to cover the case in which the java process crashed due to an out of memory error and we wish to collect the resulting dump for analysis.