### PR TITLE
Fixes stop of init script to work even when process is missing.

### DIFF
--- a/resources/install/debian/init.d
+++ b/resources/install/debian/init.d
@@ -44,7 +44,7 @@ stop() {
     fi
     echo -n "Stopping $NAME: "
     if [ $PID ]; then
-        kill $PID
+        kill $PID || true
         rm $PIDFILE || true
         echo "$NAME stopped."
     else


### PR DESCRIPTION
Fixes stop of init script to work even if process is missing, otherwise it even fails to uninstall.