### PR TITLE
Optionally returns JVB list in REST health response.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeSelector.java
@@ -517,6 +517,25 @@ public class BridgeSelector
     }
 
     /**
+     * Lists all operational JVB instance JIDs currently known to this
+     * <tt>BridgeSelector</tt> instance.
+     *
+     * @return a <tt>List</tt> of <tt>String</tt> with bridges JIDs.
+     */
+    synchronized public List<String> listKnownBridges()
+    {
+        ArrayList<String> listing = new ArrayList<>(bridges.size());
+        for (BridgeState bridge : bridges.values())
+        {
+            if (bridge.isOperational())
+            {
+                listing.add(bridge.jid);
+            }
+        }
+        return listing;
+    }
+
+    /**
      * Adds <tt>BridgeListener</tt> to the bridge observers list.
      *
      * @param listener the bridge listener instance to be registered for bridges

--- a/src/main/java/org/jitsi/jicofo/rest/Health.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Health.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.server.*;
 
 import org.jitsi.jicofo.*;
 import org.jitsi.util.*;
+import org.json.simple.*;
 
 /**
  * Checks the health of {@link FocusManager}.
@@ -163,10 +164,9 @@ public class Health
                 if (bridgeSelector == null)
                     throw new NullPointerException("bridgeSelector");
 
-                for (String bridge : bridgeSelector.listKnownBridges())
-                {
-                    response.getWriter().append(bridge).append("\n");
-                }
+                JSONObject jsonRoot = new JSONObject();
+                jsonRoot.put("jvbs", bridgeSelector.listKnownBridges());
+                response.getWriter().append(jsonRoot.toJSONString());
             }
 
             status = HttpServletResponse.SC_OK;

--- a/src/main/java/org/jitsi/jicofo/rest/Health.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Health.java
@@ -150,8 +150,7 @@ public class Health
             // JVBs known to this Jicofo instance
             String listJvbParam = request.getParameter(LIST_JVB_PARAM_NAME);
 
-            if (!StringUtils.isNullOrEmpty(listJvbParam)
-                && "true".equals(listJvbParam.toLowerCase()))
+            if (Boolean.parseBoolean(listJvbParam))
             {
                 JitsiMeetServices services
                     = focusManager.getJitsiMeetServices();

--- a/src/main/java/org/jitsi/jicofo/rest/Health.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Health.java
@@ -42,6 +42,12 @@ public class Health
         = Collections.emptyMap();
 
     /**
+     * The name of the parameter that triggers known bridges listing in health
+     * check response;
+     */
+    private static final String LIST_JVB_PARAM_NAME = "list_jvb";
+
+    /**
      * The {@code Logger} utilized by the {@code Health} class to print
      * debug-related information.
      */
@@ -138,6 +144,31 @@ public class Health
         try
         {
             check(focusManager);
+
+            // At this point the health check has passed - now eventually list
+            // JVBs known to this Jicofo instance
+            String listJvbParam = request.getParameter(LIST_JVB_PARAM_NAME);
+
+            if (!StringUtils.isNullOrEmpty(listJvbParam)
+                && "true".equals(listJvbParam.toLowerCase()))
+            {
+                JitsiMeetServices services
+                    = focusManager.getJitsiMeetServices();
+
+                if (services == null)
+                    throw new NullPointerException("services");
+
+                BridgeSelector bridgeSelector = services.getBridgeSelector();
+
+                if (bridgeSelector == null)
+                    throw new NullPointerException("bridgeSelector");
+
+                for (String bridge : bridgeSelector.listKnownBridges())
+                {
+                    response.getWriter().append(bridge).append("\n");
+                }
+            }
+
             status = HttpServletResponse.SC_OK;
         }
         catch (Exception ex)


### PR DESCRIPTION
If you run Jicofo locally open http://localhost:8888/about/health?list_jvb=true to see Jitsi videobridges known to your Jicofo instance.