### PR TITLE
Pubsub rediscovery fix

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -620,7 +620,9 @@ public class XmppProtocolProvider
             connection.sendPacket(packet);
 
             //FIXME: retry allocation on timeout
-            Packet response = packetCollector.nextResult(20000);
+            Packet response
+                = packetCollector.nextResult(
+                        SmackConfiguration.getPacketReplyTimeout());
 
             packetCollector.cancel();
 

--- a/src/main/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeSelector.java
@@ -352,8 +352,9 @@ public class BridgeSelector
             if (bridgeState == null)
             {
                 logger.warn(
-                    "No bridge registered or " +
-                        "missing mapping for node: " + node);
+                        "Received PubSub update for unknown bridge: "
+                            + itemId + " node: "
+                            + (node == null ? "'shared'" : node));
                 return;
             }
         }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetServices.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetServices.java
@@ -61,6 +61,21 @@ public class JitsiMeetServices
         };
 
     /**
+     * Feature set advertised by videobridge which does support health-checks.
+     */
+    public static final String[] VIDEOBRIDGE_FEATURES2 = new String[]
+        {
+            ColibriConferenceIQ.NAMESPACE,
+            DiscoveryUtil.FEATURE_HEALTH_CHECK,
+            ProtocolProviderServiceJabberImpl
+                .URN_XMPP_JINGLE_DTLS_SRTP,
+            ProtocolProviderServiceJabberImpl
+                .URN_XMPP_JINGLE_ICE_UDP_1,
+            ProtocolProviderServiceJabberImpl
+                .URN_XMPP_JINGLE_RAW_UDP_0
+        };
+
+    /**
      * The XMPP Service Discovery features of MUC service provided by the XMPP
      * server.
      */

--- a/src/main/java/org/jitsi/jicofo/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/JvbDoctor.java
@@ -447,9 +447,12 @@ public class JvbDoctor
                 if (IQ.Type.ERROR.equals(responseType))
                 {
                     XMPPError error = responseIQ.getError();
+                    String condition = error.getCondition();
 
                     if (XMPPError.Condition.interna_server_error.toString()
-                            .equals(error.getCondition()))
+                            .equals(condition)
+                        || XMPPError.Condition.service_unavailable.toString()
+                            .equals(condition))
                     {
                         // Health check failure
                         notifyHealthCheckFailed(bridgeJid);

--- a/src/main/java/org/jitsi/jicofo/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/JvbDoctor.java
@@ -126,7 +126,7 @@ public class JvbDoctor
      */
     public JvbDoctor()
     {
-        super(new String[] { "org/jitsi/jicofo/JVB/*"});
+        super(new String[] { BridgeEvent.BRIDGE_UP, BridgeEvent.BRIDGE_DOWN });
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/JvbDoctor.java
@@ -287,7 +287,7 @@ public class JvbDoctor
         healthTask.cancel(true);
     }
 
-    private void notifyHealthCheckFailed(String bridgeJid)
+    private void notifyHealthCheckFailed(String bridgeJid, XMPPError error)
     {
         EventAdmin eventAdmin = eventAdminRef.get();
         if (eventAdmin == null)
@@ -298,7 +298,8 @@ public class JvbDoctor
             return;
         }
 
-        logger.warn("Health check failed on " + bridgeJid);
+        logger.warn("Health check failed on: " + bridgeJid + " error: "
+                + (error != null ? error.toXML() : "timeout"));
 
         eventAdmin.sendEvent(BridgeEvent.createHealthFailed(bridgeJid));
     }
@@ -430,7 +431,7 @@ public class JvbDoctor
                     }
                     else
                     {
-                        notifyHealthCheckFailed(bridgeJid);
+                        notifyHealthCheckFailed(bridgeJid, null);
                     }
                     return;
                 }
@@ -455,7 +456,7 @@ public class JvbDoctor
                             .equals(condition))
                     {
                         // Health check failure
-                        notifyHealthCheckFailed(bridgeJid);
+                        notifyHealthCheckFailed(bridgeJid, error);
                     }
                     else
                     {


### PR DESCRIPTION
This PR adds improvements to JVB health-check handling and also fixes an issue where JVB will not be rediscovered through PubSub even though it's sending correct stats. That's because bridge state was not cleared in https://github.com/jitsi/jicofo/commit/9cc8a6cb9678a8908e144e2152072ded2325781e#diff-80f25cc18c7310215af69b04ba73f331R556 when health-check has failed.