### PR TITLE
Fixes ConcurrentModificationException on shutdown

### DIFF
--- a/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
+++ b/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
@@ -508,9 +508,9 @@ public class ComponentsDiscovery
             {
                 Map.Entry<String, Long> bridge = bridges.next();
 
-                bridgeWentOffline(bridge.getKey());
-
                 bridges.remove();
+
+                bridgeWentOffline(bridge.getKey());
             }
 
             bridgesMap.clear();


### PR DESCRIPTION
bridges.remove() must be called before we propagate bridgeWentOffline, so that we clear internal state and won't handle the event second time.