### PR TITLE
Jibri

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20160303.220516-10</version>
+      <version>2.9-20160314.202948-11</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
@@ -61,6 +61,12 @@ public class ChatMemberImpl
      */
     private final String address;
 
+    /**
+     * Stores the last <tt>Presence</tt> processed by this
+     * <tt>ChatMemberImpl</tt>.
+     */
+    private Presence presence;
+
     private ChatRoomMemberRole role;
 
     /**
@@ -81,6 +87,15 @@ public class ChatMemberImpl
     public ChatRoom getChatRoom()
     {
         return chatRoom;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Presence getPresence()
+    {
+        return presence;
     }
 
     @Override
@@ -176,6 +191,8 @@ public class ChatMemberImpl
      */
     void processPresence(Presence presence)
     {
+        this.presence = presence;
+
         VideoMutedExtension videoMutedExt
             = (VideoMutedExtension)
                 presence.getExtension(

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
@@ -62,6 +62,12 @@ public class ChatMemberImpl
     private final String address;
 
     /**
+     * Caches real JID of the participant if we're able to see it(not the MUC
+     * address stored in {@link ChatMemberImpl#address}).
+     */
+    private String memberJid = null;
+
+    /**
      * Stores the last <tt>Presence</tt> processed by this
      * <tt>ChatMemberImpl</tt>.
      */
@@ -168,7 +174,11 @@ public class ChatMemberImpl
     @Override
     public String getJabberID()
     {
-        return chatRoom.getMemberJid(address);
+        if (memberJid == null)
+        {
+            memberJid = chatRoom.getMemberJid(address);
+        }
+        return memberJid;
     }
 
     @Override

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
@@ -20,10 +20,12 @@ package org.jitsi.impl.protocol.xmpp;
 import net.java.sip.communicator.impl.protocol.jabber.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.health.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jibri.*;
 import net.java.sip.communicator.service.protocol.*;
-
 import net.java.sip.communicator.service.protocol.jabber.*;
+
 import org.jitsi.impl.protocol.xmpp.extensions.*;
+
 import org.osgi.framework.*;
 
 import java.util.*;
@@ -52,8 +54,16 @@ public class XmppProtocolActivator
 
         // Constructors called to register extension providers
         new ConferenceIqProvider();
+        // Colibri
         new ColibriIQProvider();
+        // HealthChecks
         HealthCheckIQProvider.registerIQProvider();
+        // Jibri IQs
+        AbstractSmackInteroperabilityLayer.getInstance().addIQProvider(
+                JibriIq.ELEMENT_NAME,
+                JibriIq.NAMESPACE,
+                new JibriIqProvider());
+        JibriStatusPacketExt.registerExtensionProvider();
 
         // Override original Smack Version IQ class
         AbstractSmackInteroperabilityLayer.getInstance()

--- a/src/main/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeSelector.java
@@ -118,6 +118,8 @@ public class BridgeSelector
      */
     public BridgeSelector(OperationSetSubscription subscriptionOpSet)
     {
+        Assert.notNull(subscriptionOpSet, "subscriptionOpSet");
+
         this.subscriptionOpSet = subscriptionOpSet;
     }
 

--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -24,10 +24,10 @@ import net.java.sip.communicator.util.*;
 import net.java.sip.communicator.util.Logger;
 
 import org.jitsi.jicofo.log.*;
-import org.jitsi.protocol.xmpp.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.util.*;
 import org.jitsi.eventadmin.*;
+
 import org.jivesoftware.smack.provider.*;
 
 import org.osgi.framework.*;
@@ -186,9 +186,8 @@ public class FocusManager
 
         jitsiMeetServices
             = new JitsiMeetServices(
-                    focusUserDomain,
-                    protocolProviderHandler.getOperationSet(
-                            OperationSetSubscription.class));
+                    protocolProviderHandler,
+                    focusUserDomain);
         jitsiMeetServices.start(bundleContext);
 
         String statsPubSubNode

--- a/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
+++ b/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
@@ -26,6 +26,7 @@ import net.java.sip.communicator.util.Logger;
 import org.jitsi.impl.protocol.xmpp.extensions.*;
 import org.jitsi.jicofo.log.*;
 import org.jitsi.protocol.xmpp.*;
+import org.jitsi.protocol.xmpp.util.*;
 import org.jitsi.util.*;
 import org.jitsi.eventadmin.*;
 import org.jivesoftware.smack.*;
@@ -201,19 +202,9 @@ public class MeetExtensionsHandler
         return packet instanceof MuteIq;
     }
 
-    private String getRoomNameFromMucJid(String mucJid)
-    {
-        int atIndex = mucJid.indexOf("@");
-        int slashIndex = mucJid.indexOf("/");
-        if (atIndex == -1 || slashIndex == -1)
-            return null;
-
-        return mucJid.substring(0, slashIndex);
-    }
-
     private JitsiMeetConference getConferenceForMucJid(String mucJid)
     {
-        String roomName = getRoomNameFromMucJid(mucJid);
+        String roomName = MucUtil.extractRoomNameFromMucJid(mucJid);
         if (roomName == null)
         {
             return null;

--- a/src/main/java/org/jitsi/jicofo/recording/Recorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/Recorder.java
@@ -21,6 +21,7 @@ import org.jitsi.protocol.xmpp.*;
 
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.filter.*;
+
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.ColibriConferenceIQ.Recording.*;
 
 /**
@@ -36,7 +37,7 @@ public abstract class Recorder
     /**
      * Recorder component XMPP address.
      */
-    protected final String recorderComponentJid;
+    protected String recorderComponentJid;
 
     /**
      * Smack operation set for current XMPP connection.
@@ -50,6 +51,12 @@ public abstract class Recorder
         this.xmpp = xmpp;
         xmpp.addPacketHandler(this, this);
     }
+
+    /**
+     * Method called by {@link org.jitsi.jicofo.JitsiMeetConference} after it
+     * joins the MUC.
+     */
+    public void init() { }
 
     /**
      * Releases resources and stops any future processing.

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
@@ -1,0 +1,391 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.recording.jibri;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jibri.*;
+import net.java.sip.communicator.service.protocol.*;
+import net.java.sip.communicator.service.protocol.event.*;
+import net.java.sip.communicator.util.*;
+
+import org.jitsi.assertions.*;
+import org.jitsi.jicofo.*;
+import org.jitsi.protocol.xmpp.*;
+import org.jitsi.service.configuration.*;
+
+import org.jivesoftware.smack.packet.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * <tt>JibriDetector</tt> manages the pool of Jibri instances which exist in
+ * the current session. Does that by joining "brewery" room where Jibris connect
+ * to and publish their's status in MUC presence.
+ *
+ * @author Pawel Domas
+ */
+public class JibriDetector
+    implements ChatRoomMemberPresenceListener,
+               ChatRoomMemberPropertyChangeListener,
+               RegistrationStateChangeListener
+{
+    /**
+     * The logger
+     */
+    private static final Logger logger = Logger.getLogger(JibriDetector.class);
+
+    /**
+     * The name of config property which provides the name of the MUC room in
+     * which all Jibri instances.
+     */
+    private static final String JIBRI_ROOM_PNAME
+        = "org.jitsi.jicofo.jibri.BREWERY";
+
+    /**
+     * The name fo XMPP MUC room where all Jibris gather to brew together.
+     */
+    private final String jibriBrewery;
+
+    /**
+     * The <tt>ProtocolProviderHandler</tt> for Jicofo's XMPP connection.
+     */
+    private final ProtocolProviderHandler protocolProvider;
+
+    /**
+     * The <tt>ChatRoom</tt> instance for Jibri brewery.
+     */
+    private ChatRoom chatRoom;
+
+    /**
+     * The list of all currently known jibri instances.
+     */
+    private final List<Jibri> jibris = new CopyOnWriteArrayList<>();
+
+    /**
+     * The list of {@link JibriListener}.
+     */
+    private final List<JibriListener> jibriListeners
+        = new CopyOnWriteArrayList<>();
+
+    /**
+     * Loads the name of Jibri brewery MUC room from the configuration.
+     * @param config the instance of <tt>ConfigurationService</tt> which will be
+     *        used to read the properties required.
+     * @return the name of Jibri brewery or <tt>null</tt> if none configured.
+     */
+    static public String loadBreweryName(ConfigurationService config)
+    {
+        return config.getString(JIBRI_ROOM_PNAME);
+    }
+
+    /**
+     * Creates new instance of <tt>JibriDetector</tt>
+     * @param protocolProvider the instance fo <tt>ProtocolProviderHandler</tt>
+     *        for Jicofo's XMPP connection.
+     * @param jibriBreweryName the name of the Jibri brewery MUC room where all
+     *        Jibris will gather.
+     */
+    public JibriDetector(ProtocolProviderHandler protocolProvider,
+                         String jibriBreweryName)
+    {
+        Assert.notNull(protocolProvider, "protocolProvider");
+        Assert.notNullNorEmpty(jibriBreweryName, "jibriBreweryName");
+
+        this.protocolProvider = protocolProvider;
+        this.jibriBrewery = jibriBreweryName;
+    }
+
+    /**
+     * Selects first idle Jibri which can be used to start recording.
+     *
+     * @return XMPP address of idle Jibri instance or <tt>null</tt> if there are
+     *         no Jibris available currently.
+     */
+    synchronized public String selectJibri()
+    {
+        for (Jibri jibri : jibris)
+        {
+            if (JibriStatusPacketExt.Status.IDLE.equals(jibri.status))
+            {
+                return jibri.mucJid;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Initializes this instance.
+     */
+    public void init()
+    {
+        protocolProvider.addRegistrationListener(this);
+
+        maybeStart();
+    }
+
+    /**
+     * Starts the whole thing if we have XMPP connection up and running.
+     */
+    private void maybeStart()
+    {
+        if (chatRoom == null
+                && protocolProvider.getProtocolProvider().isRegistered())
+        {
+            start();
+        }
+    }
+
+    /**
+     * Stops and releases allocated resources.
+     */
+    public void dispose()
+    {
+        protocolProvider.removeRegistrationListener(this);
+
+        stop();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    synchronized public void registrationStateChanged(
+        RegistrationStateChangeEvent registrationStateChangeEvent)
+    {
+        RegistrationState newState = registrationStateChangeEvent.getNewState();
+
+        if (RegistrationState.REGISTERED.equals(newState))
+        {
+            maybeStart();
+        }
+        else if (RegistrationState.UNREGISTERED.equals(newState))
+        {
+            stop();
+        }
+    }
+
+    private void start()
+    {
+        try
+        {
+            OperationSetMultiUserChat muc
+                = protocolProvider.getOperationSet(
+                        OperationSetMultiUserChat.class);
+
+            Assert.notNull(muc, "OperationSetMultiUserChat");
+
+            chatRoom = muc.createChatRoom(jibriBrewery, null);
+            chatRoom.addMemberPresenceListener(this);
+            chatRoom.addMemberPropertyChangeListener(this);
+            chatRoom.join();
+
+            logger.info("Joined JIBRI room: " + jibriBrewery);
+        }
+        catch (OperationFailedException | OperationNotSupportedException e)
+        {
+            logger.error("Failed to create room: " + jibriBrewery, e);
+        }
+    }
+
+    private void stop()
+    {
+        if (chatRoom != null)
+        {
+            chatRoom.removeMemberPresenceListener(this);
+            chatRoom.removeMemberPropertyChangeListener(this);
+            chatRoom.leave();
+            chatRoom = null;
+
+            logger.info("Left JIBRI room: " + jibriBrewery);
+        }
+    }
+
+    @Override
+    synchronized public void memberPresenceChanged(
+        ChatRoomMemberPresenceChangeEvent presenceEvent)
+    {
+        XmppChatMember chatMember
+            = (XmppChatMember) presenceEvent.getChatRoomMember();
+        String eventType = presenceEvent.getEventType();
+        if (ChatRoomMemberPresenceChangeEvent.MEMBER_JOINED.equals(eventType))
+        {
+            // Process idle or busy
+            processMemberPresence(chatMember);
+        }
+        else if (ChatRoomMemberPresenceChangeEvent.MEMBER_LEFT.equals(eventType)
+            || ChatRoomMemberPresenceChangeEvent.MEMBER_KICKED.equals(eventType)
+            || ChatRoomMemberPresenceChangeEvent.MEMBER_QUIT.equals(eventType))
+        {
+            // Process offline status
+            onJibriStatusChanged(
+                chatMember.getContactAddress(),
+                JibriStatusPacketExt.Status.UNDEFINED);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    synchronized public void chatRoomPropertyChanged(
+        ChatRoomMemberPropertyChangeEvent memberPropertyEvent)
+    {
+        XmppChatMember member
+            = (XmppChatMember) memberPropertyEvent.getSourceChatRoomMember();
+
+        processMemberPresence(member);
+    }
+
+    private void processMemberPresence(XmppChatMember member)
+    {
+        Presence presence = member.getPresence();
+
+        if (presence == null)
+            return;
+
+        JibriStatusPacketExt jibriStatus
+            = (JibriStatusPacketExt) presence.getExtension(
+                    JibriStatusPacketExt.ELEMENT_NAME,
+                    JibriStatusPacketExt.NAMESPACE);
+
+        if (jibriStatus == null)
+            return;
+
+        onJibriStatusChanged(
+            member.getContactAddress(), jibriStatus.getStatus());
+    }
+
+    private void onJibriStatusChanged(String                      mucJid,
+                                      JibriStatusPacketExt.Status status)
+    {
+        Jibri jibri = findJibri(mucJid);
+
+        if (JibriStatusPacketExt.Status.UNDEFINED.equals(status))
+        {
+            if (jibri != null)
+            {
+                jibris.remove(jibri);
+
+                logger.info("Removed jibri: " + mucJid);
+
+                notifyJibriOffline(mucJid);
+            }
+        }
+        else
+        {
+            if (jibri == null)
+            {
+                jibri = new Jibri(mucJid, status);
+                jibris.add(jibri);
+
+                logger.info("Added jibri: " + mucJid);
+            }
+            else
+            {
+                jibri.status = status;
+            }
+
+            if (JibriStatusPacketExt.Status.IDLE.equals(status))
+            {
+                notifyJibriStatus(jibri.mucJid, true);
+            }
+            else if (JibriStatusPacketExt.Status.BUSY.equals(status))
+            {
+                notifyJibriStatus(jibri.mucJid, false);
+            }
+            else
+            {
+                logger.error(
+                        "Unknown Jibri status: " + status + " for " + mucJid);
+            }
+        }
+    }
+
+    private Jibri findJibri(String mucJid)
+    {
+        for (Jibri j : jibris)
+        {
+            if (j.mucJid.equals(mucJid))
+                return j;
+        }
+        return null;
+    }
+
+    /**
+     * Adds <tt>JibriListener</tt> that will be notified about Jibri status
+     * updates.
+     * @param l {@link JibriListener} instance which will be added to Jibri
+     *        listeners list.
+     */
+    public void addJibriListener(JibriListener l)
+    {
+        jibriListeners.add(l);
+    }
+
+    /**
+     * Removes given <tt>JibriListener</tt> from Jibri listeners list.
+     * @param l {@link JibriListener} instance which will be removed from Jibri
+     *        listeners list.
+     */
+    public void removeJibriListener(JibriListener l)
+    {
+        jibriListeners.remove(l);
+    }
+
+    private void notifyJibriStatus(String jibriJid, boolean available)
+    {
+        logger.info("Jibri " + jibriJid +" available: " + available);
+
+        for (JibriListener l : jibriListeners)
+        {
+            l.onJibriStatusChanged(jibriJid, available);
+        }
+    }
+
+    private void notifyJibriOffline(String jid)
+    {
+        logger.info("Jibri " + jid +" went offline");
+
+        for (JibriListener l : jibriListeners)
+        {
+            l.onJibriOffline(jid);
+        }
+    }
+
+    /**
+     * Internal structure for storing information about Jibri instances.
+     */
+    private class Jibri
+    {
+        /**
+         * Eg. "room@muc.server.net/nick"
+         */
+        final String mucJid;
+
+        /**
+         * One of {@link JibriStatusPacketExt.Status}
+         */
+        JibriStatusPacketExt.Status status;
+
+        Jibri(String mucJid, JibriStatusPacketExt.Status status)
+        {
+            this.mucJid = mucJid;
+            this.status = status;
+        }
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriListener.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriListener.java
@@ -1,0 +1,42 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.recording.jibri;
+
+/**
+ * The interface used to notify about the availability and busy/idle status
+ * updates of Jibri instances which exist in the current Jicofo session.
+ *
+ * @author Pawel Domas
+ */
+public interface JibriListener
+{
+    /**
+     * Notifies about Jibri busy/idle status changes.
+     * @param jibriJid the XMPP address of subject Jibri instance.
+     * @param idle <tt>true</tt> if the Jibri is idle or <tt>false</tt> when
+     *        it's busy(with recording).
+     */
+    void onJibriStatusChanged(String jibriJid, boolean idle);
+
+    /**
+     * Methods called when particular Jibri instance goes offline(disconnects).
+     * @param jibriJid the XMPP address of Jibri instance which just went
+     *        offline.
+     */
+    void onJibriOffline(String jibriJid);
+}

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -1,0 +1,484 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.recording.jibri;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jibri.*;
+import net.java.sip.communicator.service.protocol.*;
+import net.java.sip.communicator.util.Logger;
+
+import org.jitsi.jicofo.*;
+import org.jitsi.jicofo.recording.*;
+import org.jitsi.protocol.xmpp.*;
+import org.jitsi.protocol.xmpp.util.*;
+
+import org.jivesoftware.smack.packet.*;
+
+/**
+ * Handles conference recording through Jibri.
+ * Waits for updates from {@link JibriDetector} about recorder instance
+ * availability and publishes that information in Jicofo's MUC presence.
+ * Handles incoming Jibri IQs coming from conference moderator to
+ * start/stop the recording.
+ *
+ * @author Pawel Domas
+ */
+public class JibriRecorder
+    extends Recorder
+    implements JibriListener
+{
+    /**
+     * The logger.
+     */
+    static private final Logger logger = Logger.getLogger(JibriRecorder.class);
+
+    /**
+     * Recorded <tt>JitsiMeetConference</tt>.
+     */
+    private final JitsiMeetConference conference;
+
+    /**
+     * Meet tools instance used to inject packet extensions to Jicofo's MUC
+     * presence.
+     */
+    private final OperationSetJitsiMeetTools meetTools;
+
+    /**
+     * Jibri detector which notifies about Jibri status changes.
+     */
+    private final JibriDetector jibriDetector;
+
+    /**
+     * Current Jibri recording status.
+     */
+    private JibriIq.Status jibriStatus = JibriIq.Status.UNDEFINED;
+
+    /**
+     * Creates new instance of <tt>JibriRecorder</tt>.
+     * @param conference <tt>JitsiMeetConference</tt> to be recorded by new
+     *        instance.
+     * @param xmpp XMPP operation set which wil be used to send XMPP queries.
+     */
+    public JibriRecorder(JitsiMeetConference conference,
+                         OperationSetDirectSmackXmpp xmpp)
+    {
+        super(null, xmpp);
+
+        this.conference = conference;
+
+        ProtocolProviderService protocolService = conference.getXmppProvider();
+
+        meetTools
+            = protocolService.getOperationSet(OperationSetJitsiMeetTools.class);
+
+        jibriDetector = conference.getServices().getJibriDetector();
+    }
+
+    /**
+     * Starts listening for Jibri updates and initializes Jicofo presence.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public void init()
+    {
+        super.init();
+
+        jibriDetector.addJibriListener(this);
+
+        setJibriStatus(
+                jibriDetector.selectJibri() != null ?
+                    JibriIq.Status.OFF : JibriIq.Status.UNDEFINED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void dispose()
+    {
+        XMPPError error = sendStopIQ();
+        if (error != null)
+        {
+            logger.error("Error when sending stop request: " + error.toXML());
+        }
+
+        jibriDetector.removeJibriListener(this);
+
+        super.dispose();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRecording()
+    {
+        return JibriIq.Status.ON.equals(jibriStatus);
+    }
+
+    /**
+     * Not implemented in Jibri Recorder
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean setRecording(String from, String token,
+                                ColibriConferenceIQ.Recording.State doRecord,
+                                String path)
+    {
+        // NOT USED
+
+        return false;
+    }
+
+    /**
+     * Accepts only {@link JibriIq}
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean accept(Packet packet)
+    {
+        return packet instanceof JibriIq;
+    }
+
+    /**
+     * <tt>JibriIq</tt> processing.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    synchronized public void processPacket(Packet packet)
+    {
+        JibriIq iq = (JibriIq) packet;
+
+        String from = iq.getFrom();
+
+        if (logger.isDebugEnabled())
+            logger.debug("Got Jibri packet: " + packet.toXML());
+
+        if (recorderComponentJid != null &&
+            (from.equals(recorderComponentJid) ||
+
+            (from +"/").startsWith(recorderComponentJid)))
+        {
+            processJibriIqFromJibri(iq);
+        }
+        else
+        {
+            String roomName = MucUtil.extractRoomNameFromMucJid(from);
+            if (roomName == null)
+            {
+                return;
+            }
+
+            if (!conference.getRoomName().equals(roomName))
+            {
+                logger.debug(
+                        "Ignored packet from: " + roomName
+                            + ", my room: " + conference.getRoomName()
+                            + " p: " + packet.toXML());
+                return;
+            }
+
+            XmppChatMember chatMember
+                = conference.getChatRoom().findChatMember(from);
+            if (chatMember == null)
+            {
+                logger.error("ERROR chat member not found for: " + from);
+                return;
+            }
+
+            processJibriIqFromMeet(iq, chatMember);
+        }
+    }
+
+    private void processJibriIqFromMeet(JibriIq iq, XmppChatMember sender)
+    {
+        JibriIq.Action action = iq.getAction();
+
+        if (JibriIq.Action.UNDEFINED.equals(action))
+            return;
+
+        String senderMucJid = sender.getContactAddress();
+
+        logger.debug(
+                "Jibri request from " + senderMucJid + " iq: " + iq.toXML());
+
+        // start ?
+        if (JibriIq.Action.START.equals(action) &&
+            JibriIq.Status.OFF.equals(jibriStatus) &&
+            recorderComponentJid == null)
+        {
+            if (!verifyModeratorRole(iq))
+            {
+                logger.warn(
+                        "Ignored Jibri request from non-moderator: "
+                            + senderMucJid);
+                return;
+            }
+
+            // Check if we have Jibri available
+            String jibriJid = jibriDetector.selectJibri();
+            if (jibriJid == null)
+            {
+                sendErrorResponse(
+                    iq, XMPPError.Condition.service_unavailable, null);
+                return;
+            }
+
+            JibriIq startIq = new JibriIq();
+            startIq.setTo(jibriJid);
+            startIq.setType(IQ.Type.SET);
+            startIq.setAction(JibriIq.Action.START);
+
+            startIq.setStreamId(iq.getStreamId());
+            startIq.setUrl(iq.getUrl());
+
+            logger.debug("Starting Jibri recording: " + startIq.toXML());
+
+            IQ startReply
+                = (IQ) xmpp.getXmppConnection()
+                        .sendPacketAndGetReply(startIq);
+
+            logger.debug("Start response: " + startReply.toXML());
+
+            if (startReply == null)
+            {
+                sendErrorResponse(
+                        iq, XMPPError.Condition.request_timeout, null);
+                return;
+            }
+
+            if (IQ.Type.RESULT.equals(startReply.getType()))
+            {
+                recorderComponentJid = jibriJid;
+
+                setJibriStatus(JibriIq.Status.PENDING);
+
+                sendResultResponse(iq);
+                return;
+            }
+            else
+            {
+                XMPPError error = startReply.getError();
+                if (error == null)
+                {
+                    error = new XMPPError(
+                            XMPPError.Condition.interna_server_error);
+                }
+                sendPacket(IQ.createErrorResponse(iq, error));
+                return;
+            }
+        }
+        // stop ?
+        else if (JibriIq.Action.STOP.equals(action) &&
+            recorderComponentJid != null &&
+            (JibriIq.Status.ON.equals(jibriStatus) ||
+             JibriIq.Status.PENDING.equals(jibriStatus)))
+        {
+            if (!verifyModeratorRole(iq))
+                return;
+
+            XMPPError error = sendStopIQ();
+            sendPacket(
+                error == null
+                    ? IQ.createResultIQ(iq)
+                    : IQ.createErrorResponse(iq, error));
+            return;
+        }
+
+        logger.warn(
+            "Discarded: " + iq.toXML() + " - nothing to be done, " +
+            "recording status:" + jibriStatus);
+
+        // Bad request
+        sendErrorResponse(
+            iq, XMPPError.Condition.bad_request,
+            "Unable to handle: '" + action
+                + "' in state: '" + jibriStatus + "'");
+    }
+
+    private boolean verifyModeratorRole(JibriIq iq)
+    {
+        String from = iq.getFrom();
+        ChatRoomMemberRole role = conference.getRoleForMucJid(from);
+
+        if (role == null)
+        {
+            // Only room members are allowed to send requests
+            sendErrorResponse(iq, XMPPError.Condition.forbidden, null);
+            return false;
+        }
+
+        if (ChatRoomMemberRole.MODERATOR.compareTo(role) < 0)
+        {
+            // Moderator permission is required
+            sendErrorResponse(iq, XMPPError.Condition.not_allowed, null);
+            return false;
+        }
+        return true;
+    }
+
+    private void sendPacket(Packet packet)
+    {
+        xmpp.getXmppConnection().sendPacket(packet);
+    }
+
+    private void sendResultResponse(IQ request)
+    {
+        sendPacket(
+            IQ.createResultIQ(request));
+    }
+
+    private void sendErrorResponse(IQ request,
+                                   XMPPError.Condition condition,
+                                   String msg)
+    {
+        sendPacket(
+            IQ.createErrorResponse(
+                request,
+                new XMPPError(condition, msg)
+            )
+        );
+    }
+
+    private void processJibriIqFromJibri(JibriIq iq)
+    {
+        if (IQ.Type.RESULT.equals(iq.getType()))
+            return;
+
+        // We have something from Jibri - let's update recording status
+        JibriIq.Status status = iq.getStatus();
+        if (!JibriIq.Status.UNDEFINED.equals(status))
+        {
+            logger.info("Updating status from Jibri: " + iq.toXML()
+                + " for " + conference.getRoomName());
+
+            setJibriStatus(status);
+        }
+
+        sendPacket(IQ.createResultIQ(iq));
+    }
+
+    synchronized private void setJibriStatus(JibriIq.Status newStatus)
+    {
+        jibriStatus = newStatus;
+
+        RecordingStatus recordingStatus = new RecordingStatus();
+
+        recordingStatus.setStatus(newStatus);
+
+        logger.info(
+            "Publish new Jibri status: " + recordingStatus.toXML() +
+            " in: " + conference.getRoomName());
+
+        ChatRoom2 chatRoom2 = conference.getChatRoom();
+
+        // Publish that in the presence
+        if (chatRoom2 != null)
+        {
+            meetTools.sendPresenceExtension(
+                chatRoom2,
+                recordingStatus);
+        }
+    }
+
+    // Send stop IQ when recording initiator leaves the room
+    private XMPPError sendStopIQ()
+    {
+        if (recorderComponentJid == null)
+            return null;
+
+        JibriIq stopRequest = new JibriIq();
+
+        stopRequest.setType(IQ.Type.SET);
+        stopRequest.setTo(recorderComponentJid);
+        stopRequest.setAction(JibriIq.Action.STOP);
+
+        logger.debug("Trying to stop: " + stopRequest.toXML());
+
+        IQ stopReply
+            = (IQ) xmpp.getXmppConnection()
+                    .sendPacketAndGetReply(stopRequest);
+
+        logger.debug(
+                "Stop response: "
+                    + (stopReply != null ? stopReply.toXML() : "timeout"));
+
+        if (stopReply == null)
+        {
+            return new XMPPError(XMPPError.Condition.request_timeout, null);
+        }
+
+        if (IQ.Type.RESULT.equals(stopReply.getType()))
+        {
+            setJibriStatus(JibriIq.Status.OFF);
+
+            recorderComponentJid = null;
+            return null;
+        }
+        else
+        {
+            XMPPError error = stopReply.getError();
+            if (error == null)
+            {
+                error
+                    = new XMPPError(XMPPError.Condition.interna_server_error);
+            }
+            return error;
+        }
+    }
+
+    @Override
+    public void onJibriStatusChanged(String jibriJid, boolean idle)
+    {
+        // If we're recording then we listen to status coming from our Jibri
+        // through IQs
+        if (recorderComponentJid != null)
+            return;
+
+        String jibri = jibriDetector.selectJibri();
+        if (jibri != null)
+        {
+            logger.info("Recording enabled");
+            setJibriStatus(JibriIq.Status.OFF);
+        }
+        else
+        {
+            logger.info("Recording disabled - all jibris are busy");
+            setJibriStatus(JibriIq.Status.UNDEFINED);
+        }
+    }
+
+    @Override
+    public void onJibriOffline(String jibriJid)
+    {
+        if (jibriJid.equals(recorderComponentJid))
+        {
+            logger.warn("Our recorder went offline: " + recorderComponentJid);
+            recorderComponentJid = null;
+        }
+
+        String jibri = jibriDetector.selectJibri();
+        if (jibri == null && recorderComponentJid == null)
+        {
+            setJibriStatus(JibriIq.Status.UNDEFINED);
+        }
+    }
+}

--- a/src/main/java/org/jitsi/protocol/xmpp/XmppChatMember.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/XmppChatMember.java
@@ -19,6 +19,8 @@ package org.jitsi.protocol.xmpp;
 
 import net.java.sip.communicator.service.protocol.*;
 
+import org.jivesoftware.smack.packet.*;
+
 /**
  * XMPP extended interface of {@link ChatRoomMember}.
  *
@@ -37,6 +39,14 @@ public interface XmppChatMember
      * @return number based on the order of joining of the members in the room.
      */
     int getJoinOrderNumber();
+
+    /**
+     * Obtains the last MUC <tt>Presence</tt> seen for this chat member.
+     * @return the last {@link Presence} packet received for this
+     *         <tt>XmppChatMember</tt> or <tt>null</tt> if we haven't received
+     *         it yet.
+     */
+    Presence getPresence();
 
     /**
      * Check for video muted status.

--- a/src/main/java/org/jitsi/protocol/xmpp/util/MucUtil.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/MucUtil.java
@@ -62,4 +62,23 @@ public class MucUtil
         }
         return mucJid.substring(slashIdx + 1);
     }
+
+    /**
+     * Extracts full room address from MUC participant's address.
+     *
+     * @param mucMemberJid peer's full MUC address:
+     *                     {room_name}@{muc.server.net}/{nick}
+     *
+     * @return full MUC room address address extracted from peer's MUC address:
+     *         {room_name}@{muc.server.net}/{nick}
+     */
+    public static String extractRoomNameFromMucJid(String mucMemberJid)
+    {
+        int atIndex = mucMemberJid.indexOf("@");
+        int slashIndex = mucMemberJid.indexOf("/");
+        if (atIndex == -1 || slashIndex == -1)
+            return null;
+
+        return mucMemberJid.substring(0, slashIndex);
+    }
 }

--- a/src/test/java/mock/muc/MockRoomMember.java
+++ b/src/test/java/mock/muc/MockRoomMember.java
@@ -24,6 +24,7 @@ import net.java.sip.communicator.service.protocol.globalstatus.*;
 
 import org.jitsi.jicofo.discovery.*;
 import org.jitsi.protocol.xmpp.*;
+import org.jivesoftware.smack.packet.*;
 
 import java.util.*;
 
@@ -150,6 +151,13 @@ public class MockRoomMember
 
     @Override
     public Boolean hasVideoMuted()
+    {
+        // FIXME: not implemented
+        return null;
+    }
+
+    @Override
+    public Presence getPresence()
     {
         // FIXME: not implemented
         return null;


### PR DESCRIPTION
The whole thing is activated by specifying "org.jitsi.jicofo.jibri.BREWERY" config property which is the address of MUC room where Jibri instances publish their idle/busy status. JibriDetector class will join that room track Jibri status changes which will be published further through JibriListener interface. Currently only JibriRecorder implements that and it's instance is created for every JitsiMeetConference.

JibriRecorder will publish the info about current recording status in Jicofo's MUC presence:
- "undefined" when there are no Jibris available
- "off" when recording is stopped and there are some Jibri available to start recording
- "pending" recording is starting and we're waiting for confirmation from Jibri(this takes some time)
- "on" recording is in progress

Recording is controlled by sending Jibri IQ from conference moderator user to Jicofo which then does select Jibri instance and starts the recording.