### PR TITLE
Sets only the name of the conference room in Jibri START IQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20160314.202948-11</version>
+      <version>2.9-20160322.163303-12</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -248,7 +248,10 @@ public class JibriRecorder
             startIq.setAction(JibriIq.Action.START);
 
             startIq.setStreamId(iq.getStreamId());
-            startIq.setUrl(iq.getUrl());
+
+            // Insert name of the room into Jibri START IQ
+            String roomName = MucUtil.extractRoomNameFromMucJid(senderMucJid);
+            startIq.setRoom(roomName);
 
             logger.debug("Starting Jibri recording: " + startIq.toXML());
 


### PR DESCRIPTION
instead of copying the url provided in the user request.