### PR TITLE
Removes synchronized statements from VersionBroadcaster

### DIFF
--- a/src/main/java/org/jitsi/jicofo/VersionBroadcaster.java
+++ b/src/main/java/org/jitsi/jicofo/VersionBroadcaster.java
@@ -77,7 +77,7 @@ public class VersionBroadcaster
      * {@inheritDoc}
      */
     @Override
-    synchronized public void start(BundleContext bundleContext)
+    public void start(BundleContext bundleContext)
         throws Exception
     {
         focusManager
@@ -102,7 +102,7 @@ public class VersionBroadcaster
      * {@inheritDoc}
      */
     @Override
-    synchronized public void stop(BundleContext bundleContext)
+    public void stop(BundleContext bundleContext)
         throws Exception
     {
         super.stop(bundleContext);
@@ -119,7 +119,7 @@ public class VersionBroadcaster
      * {@inheritDoc}
      */
     @Override
-    synchronized public void handleEvent(Event event)
+    public void handleEvent(Event event)
     {
         String topic = event.getTopic();
         if (!topic.equals(EventFactory.FOCUS_JOINED_ROOM_TOPIC)


### PR DESCRIPTION
This PR should fix a deadlock described by the thread dump at the bottom.

In order to fix that I removed the synchronised from start/stop/handleEvent. The reason for that is that it's not a problem when two events will execute at the same time and originally these synchronised statements were protecting against simultaneous execution of start()/stop() and handleEvent(), but probably that does not make sense since OSGi executes BundleActivator.start/stop synchronously. Also if OSGi is being stopped then EventAdmin will also be stopped,so handleEvent will not be invoked.

Java stack information for the threads listed above:
===================================================
"qtp1020005132-349":
	at org.jitsi.jicofo.FocusManager.getConference(FocusManager.java:419)
	- waiting to lock <0x0000000700bc2b80> (a org.jitsi.jicofo.FocusManager)
	at org.jitsi.jicofo.rest.Health.check(Health.java:98)
	at org.jitsi.jicofo.rest.Health.getJSON(Health.java:181)
	at org.jitsi.jicofo.rest.HandlerImpl.doGetHealthJSON(HandlerImpl.java:70)
	at org.jitsi.rest.AbstractJSONHandler.handleHealthJSON(AbstractJSONHandler.java:369)
	at org.jitsi.rest.AbstractJSONHandler.handleJSON(AbstractJSONHandler.java:399)
	at org.jitsi.rest.AbstractJSONHandler.handle(AbstractJSONHandler.java:341)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
	at org.eclipse.jetty.server.Server.handle(Server.java:370)
	at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:494)
	at org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:971)
	at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:1033)
	at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:644)
	at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:235)
	at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82)
	at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:696)
	at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:53)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)
	at java.lang.Thread.run(Thread.java:745)
"qtp1020005132-51":
	at org.jitsi.jicofo.VersionBroadcaster.handleEvent(VersionBroadcaster.java:124)
	- waiting to lock <0x0000000700f5d1c8> (a org.jitsi.jicofo.VersionBroadcaster)
	at org.jitsi.eventadmin.EventAdminImpl.callEventHandler(EventAdminImpl.java:207)
	at org.jitsi.eventadmin.EventAdminImpl.eventImpl(EventAdminImpl.java:178)
	at org.jitsi.eventadmin.EventAdminImpl.sendEvent(EventAdminImpl.java:157)
	at org.jitsi.jicofo.JitsiMeetConference.joinTheRoom(JitsiMeetConference.java:413)
	at org.jitsi.jicofo.JitsiMeetConference.start(JitsiMeetConference.java:323)
	- locked <0x0000000781bea108> (a org.jitsi.jicofo.JitsiMeetConference)
	at org.jitsi.jicofo.FocusManager.createConference(FocusManager.java:331)
	at org.jitsi.jicofo.FocusManager.conferenceRequest(FocusManager.java:274)
	- locked <0x0000000700bc2b80> (a org.jitsi.jicofo.FocusManager)
	at org.jitsi.jicofo.rest.Health.check(Health.java:101)
	at org.jitsi.jicofo.rest.Health.getJSON(Health.java:181)
	at org.jitsi.jicofo.rest.HandlerImpl.doGetHealthJSON(HandlerImpl.java:70)
	at org.jitsi.rest.AbstractJSONHandler.handleHealthJSON(AbstractJSONHandler.java:369)
	at org.jitsi.rest.AbstractJSONHandler.handleJSON(AbstractJSONHandler.java:399)
	at org.jitsi.rest.AbstractJSONHandler.handle(AbstractJSONHandler.java:341)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
	at org.eclipse.jetty.server.Server.handle(Server.java:370)
	at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:494)
	at org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:971)
	at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:1033)
	at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:644)
	at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:235)
	at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82)
	at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:696)
	at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:53)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)
	at java.lang.Thread.run(Thread.java:745)
"pool-3-thread-19":
	at org.jitsi.jicofo.FocusManager.getConference(FocusManager.java:419)
	- waiting to lock <0x0000000700bc2b80> (a org.jitsi.jicofo.FocusManager)
	at org.jitsi.jicofo.VersionBroadcaster.handleEvent(VersionBroadcaster.java:134)
	- locked <0x0000000700f5d1c8> (a org.jitsi.jicofo.VersionBroadcaster)
	at org.jitsi.eventadmin.EventAdminImpl.callEventHandler(EventAdminImpl.java:207)
	at org.jitsi.eventadmin.EventAdminImpl.eventImpl(EventAdminImpl.java:178)
	at org.jitsi.eventadmin.EventAdminImpl.sendEvent(EventAdminImpl.java:157)
	at org.jitsi.jicofo.JitsiMeetConference.allocateChannels(JitsiMeetConference.java:848)
	at org.jitsi.jicofo.JitsiMeetConference.createOffer(JitsiMeetConference.java:961)
	at org.jitsi.jicofo.JitsiMeetConference.discoverFeaturesAndInvite(JitsiMeetConference.java:692)
	at org.jitsi.jicofo.JitsiMeetConference.access$000(JitsiMeetConference.java:65)
	at org.jitsi.jicofo.JitsiMeetConference$1.run(JitsiMeetConference.java:594)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

Found 1 deadlock.

