### PR TITLE
Restart the conference without reloading the page

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/DefaultJingleRequestHandler.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/DefaultJingleRequestHandler.java
@@ -60,9 +60,23 @@ public class DefaultJingleRequestHandler
     }
 
     @Override
+    public void onTransportAccept(JingleSession jingleSession,
+                                  List<ContentPacketExtension> contents)
+    {
+        logger.warn("Ignored Jingle 'transport-accept'");
+    }
+
+    @Override
     public void onTransportInfo(JingleSession jingleSession,
                                 List<ContentPacketExtension> contents)
     {
         logger.warn("Ignored Jingle 'transport-info'");
+    }
+
+    @Override
+    public void onTransportReject(JingleSession jingleSession,
+                                  JingleIQ      rejectIQ)
+    {
+        logger.warn("Ignored Jingle 'transport-reject'");
     }
 }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -574,10 +574,7 @@ public class ColibriConferenceImpl
     @Override
     public void dispose()
     {
-        synchronized (syncRoot)
-        {
-            this.disposed = true;
-        }
+        this.disposed = true;
     }
 
     /**

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -44,13 +44,14 @@ import java.util.*;
 public class ColibriConferenceImpl
     implements ColibriConference
 {
-    private final static net.java.sip.communicator.util.Logger logger
-            = Logger.getLogger(ColibriConferenceImpl.class);
+    private final static Logger logger
+        = Logger.getLogger(ColibriConferenceImpl.class);
 
     /**
      * The instance of XMPP connection.
      */
     private final XmppConnection connection;
+
     /**
      * XMPP address of videobridge component.
      */
@@ -138,7 +139,7 @@ public class ColibriConferenceImpl
         if (!StringUtils.isNullOrEmpty(conferenceState.getID()))
         {
             throw new IllegalStateException(
-                "Can not change the bridge on active conference");
+                "Cannot change the bridge on active conference");
         }
         this.jitsiVideobridge = videobridgeJid;
     }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -116,17 +116,17 @@ public class ColibriConferenceImpl
      * @param operationName the name of the operation that will not happen and
      * should be mentioned in the warning message.
      *
-     * @return <tt>true</tt> if this instance has not been disposed yet or
+     * @return <tt>true</tt> if this instance has been disposed already or
      * <tt>false</tt> otherwise.
      */
-    private boolean assertNotDisposed(String operationName)
+    private boolean checkIfDisposed(String operationName)
     {
         if (disposed)
         {
             logger.warn("Not doing " + operationName + " - instance disposed");
-            return false;
+            return true;
         }
-        return true;
+        return false;
     }
 
     /**
@@ -198,7 +198,7 @@ public class ColibriConferenceImpl
             synchronized (syncRoot)
             {
                 // Only if not in 'disposed' state
-                if (!assertNotDisposed("createColibriChannels"))
+                if (checkIfDisposed("createColibriChannels"))
                     return null;
 
                 acquireCreateConferenceSemaphore(endpointName);
@@ -363,7 +363,7 @@ public class ColibriConferenceImpl
         synchronized (syncRoot)
         {
             // Only if not in 'disposed' state
-            if (!assertNotDisposed("expireChannels"))
+            if (checkIfDisposed("expireChannels"))
                 return;
 
             colibriBuilder.reset();
@@ -394,7 +394,7 @@ public class ColibriConferenceImpl
         synchronized (syncRoot)
         {
             // Only if not in 'disposed' state
-            if (!assertNotDisposed("updateRtpDescription"))
+            if (checkIfDisposed("updateRtpDescription"))
                 return;
 
             colibriBuilder.reset();
@@ -424,7 +424,7 @@ public class ColibriConferenceImpl
 
         synchronized (syncRoot)
         {
-            if (!assertNotDisposed("updateTransportInfo"))
+            if (checkIfDisposed("updateTransportInfo"))
                 return;
 
             colibriBuilder.reset();
@@ -454,7 +454,7 @@ public class ColibriConferenceImpl
 
         synchronized (syncRoot)
         {
-            if (!assertNotDisposed("updateSourcesInfo"))
+            if (checkIfDisposed("updateSourcesInfo"))
                 return;
 
             if (StringUtils.isNullOrEmpty(conferenceState.getID()))
@@ -507,7 +507,7 @@ public class ColibriConferenceImpl
 
         synchronized (syncRoot)
         {
-            if (!assertNotDisposed("updateBundleTransportInfo"))
+            if (checkIfDisposed("updateBundleTransportInfo"))
                 return;
 
             colibriBuilder.reset();
@@ -536,7 +536,7 @@ public class ColibriConferenceImpl
 
         synchronized (syncRoot)
         {
-            if (!assertNotDisposed("expireConference"))
+            if (checkIfDisposed("expireConference"))
                 return;
 
             colibriBuilder.reset();
@@ -593,7 +593,7 @@ public class ColibriConferenceImpl
     public boolean muteParticipant(ColibriConferenceIQ channelsInfo,
                                    boolean mute)
     {
-        if (!assertNotDisposed("muteParticipant"))
+        if (checkIfDisposed("muteParticipant"))
             return false;
 
         ColibriConferenceIQ request = new ColibriConferenceIQ();
@@ -685,7 +685,7 @@ public class ColibriConferenceImpl
 
         synchronized (syncRoot)
         {
-            if (!assertNotDisposed("updateChannelsInfo"))
+            if (checkIfDisposed("updateChannelsInfo"))
                 return;
 
             colibriBuilder.reset();

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -1,0 +1,648 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jitsimeet.*;
+import net.java.sip.communicator.impl.protocol.jabber.jinglesdp.*;
+import net.java.sip.communicator.service.protocol.*;
+
+import org.jitsi.impl.protocol.xmpp.extensions.*;
+import org.jitsi.jicofo.discovery.*;
+import org.jitsi.jicofo.util.*;
+import org.jitsi.protocol.xmpp.*;
+import org.jitsi.protocol.xmpp.colibri.*;
+import org.jitsi.service.neomedia.*;
+import org.jitsi.util.*;
+
+import java.util.*;
+
+/**
+ * The class is a thread that does the job of allocating Colibri channels on
+ * the bridge and invites participant with Jingle 'session-initiate'. Also
+ * bridge election happens here with some help of {@link BridgeSelector}.
+ *
+ * @author Pawel Domas
+ */
+public class ChannelAllocator implements Runnable
+{
+    /**
+     * Error code used in {@link OperationFailedException} when there are no
+     * working videobridge bridges.
+     * FIXME: consider moving to OperationFailedException ?
+     */
+    private final static int BRIDGE_FAILURE_ERR_CODE = 20;
+
+    /**
+     * The logger instance used in this class.
+     */
+    private final static Logger logger
+        = Logger.getLogger(ChannelAllocator.class);
+
+    /**
+     * Parent {@link JitsiMeetConference}.
+     */
+    private final JitsiMeetConference meetConference;
+
+    /**
+     * <tt>ColibriConference</tt> instance used by this thread to allocate
+     * channels on the bridge.
+     */
+    private final ColibriConference colibriConference;
+
+    /**
+     * A participant that is to be invited by this instance to the conference.
+     */
+    private final Participant newParticipant;
+
+    /**
+     * First argument stands for "start audio muted" and the second one for
+     * "start video muted". The information is included as a custom extension in
+     * 'session-initiate' sent to the user.
+     */
+    private final boolean[] startMuted;
+
+    /**
+     * Creates new instance of <tt>ChannelAllocator</tt> which is meant to
+     * invite given <tt>Participant</tt> into the given
+     * <tt>JitsiMeetConference</tt>.
+     *
+     * @param meetConference <tt>JitsiMeetConference</tt> where
+     * <tt>newParticipant</tt> will be invited
+     * @param colibriConference <tt>ColibriConference</tt> instance valid for
+     * the invite to be performed by the instance being created
+     * @param newParticipant to be invited participant
+     * @param startMuted an array which must have the size of 2 where the first
+     * value stands for "start audio muted" and the second one for "video
+     * muted". This is to be included in client's offer.
+     */
+    public ChannelAllocator(JitsiMeetConference    meetConference,
+                            ColibriConference      colibriConference,
+                            Participant            newParticipant,
+                            boolean[]              startMuted)
+    {
+        this.meetConference = meetConference;
+        this.colibriConference = colibriConference;
+        this.newParticipant = newParticipant;
+        this.startMuted = startMuted;
+    }
+
+    private OperationSetJitsiMeetTools getMeetTools()
+    {
+        return meetConference.getXmppProvider().getOperationSet(
+                OperationSetJitsiMeetTools.class);
+    }
+
+    private OperationSetJingle getJingle()
+    {
+        return meetConference.getXmppProvider().getOperationSet(
+                OperationSetJingle.class);
+    }
+
+    /**
+     * Entry point for <tt>ChannelAllocator</tt> task.
+     */
+    @Override
+    public void run()
+    {
+        try
+        {
+            discoverFeaturesAndInvite();
+        }
+        catch (Exception e)
+        {
+            logger.error("Exception on participant invite", e);
+        }
+    }
+
+    /**
+     * Method does feature discovery and channel allocation for participant.
+     */
+    private void discoverFeaturesAndInvite()
+    {
+        String address = newParticipant.getMucJid();
+
+        // Feature discovery
+        List<String> features = DiscoveryUtil.discoverParticipantFeatures(
+                    meetConference.getXmppProvider(), address);
+
+        newParticipant.setSupportedFeatures(features);
+
+        logger.info(
+            address + " has bundle ? " + newParticipant.hasBundleSupport());
+
+        List<ContentPacketExtension> offer;
+        try
+        {
+            offer = createOffer();
+            if (offer == null)
+            {
+                logger.info("Channel allocation cancelled for " + address);
+                return;
+            }
+        }
+        catch (OperationFailedException e)
+        {
+            //FIXME: retry ? sometimes it's just timeout
+            logger.error("Failed to allocate channels for " + address, e);
+
+            // Notify users about bridge is down event
+            ChatRoom chatRoom = meetConference.getChatRoom();
+            if (BRIDGE_FAILURE_ERR_CODE == e.getErrorCode() && chatRoom != null)
+            {
+                OperationSetJitsiMeetTools meetTools = getMeetTools();
+                if (meetTools != null)
+                {
+                    meetTools.sendPresenceExtension(
+                            chatRoom, new BridgeIsDownPacketExt());
+                }
+            }
+            // Cancel - no channels allocated
+            return;
+        }
+        /*
+           This check makes sure that when we're trying to invite
+           new participant:
+           - the conference has not been disposed in the meantime
+           - he's still in the room
+           - we have managed to send Jingle session-initiate
+           We usually expire channels when participant leaves the MUC, but we
+           may not have channel information set, so we have to expire it
+           here.
+        */
+        boolean expireChannels = false;
+
+        ChatRoom chatRoom = meetConference.getChatRoom();
+        if (chatRoom == null)
+        {
+            // Conference disposed
+            logger.info(
+                    "Expiring " + address + " channels - conference disposed");
+
+            expireChannels = true;
+        }
+        else if (meetConference.findMember(address) == null)
+        {
+            // Participant has left the room
+            logger.info(
+                    "Expiring " + address + " channels - participant has left");
+
+            expireChannels = true;
+        }
+        else
+        {
+            boolean ack
+                = getJingle().initiateSession(
+                        newParticipant.hasBundleSupport(),
+                        address,
+                        offer,
+                        meetConference,
+                        startMuted);
+            if (!ack)
+            {
+                // Failed to invite
+                logger.info(
+                        "Expiring " + address + " channels - no RESULT for "
+                            + "session-invite");
+                expireChannels = true;
+            }
+        }
+
+        if (expireChannels)
+        {
+            meetConference.expireParticipantChannels(
+                    colibriConference, newParticipant);
+        }
+    }
+
+    /**
+     * Creates Jingle offer for given {@link Participant}.
+     *
+     * @throws OperationFailedException if we fail to allocate channels
+     * or something goes wrong.
+     */
+    private List<ContentPacketExtension> createOffer()
+        throws OperationFailedException
+    {
+        List<ContentPacketExtension> contents = new ArrayList<>();
+
+        boolean disableIce = !newParticipant.hasIceSupport();
+        boolean useDtls = newParticipant.hasDtlsSupport();
+
+        if (newParticipant.hasAudioSupport())
+        {
+            contents.add(
+                    JingleOfferFactory.createContentForMedia(
+                            MediaType.AUDIO, disableIce, useDtls));
+        }
+
+        if (newParticipant.hasVideoSupport())
+        {
+            contents.add(
+                    JingleOfferFactory.createContentForMedia(
+                            MediaType.VIDEO, disableIce, useDtls));
+        }
+
+        JitsiMeetConfig config = meetConference.getConfig();
+        // Is SCTP enabled ?
+        boolean openSctp = Boolean.TRUE.equals(config.openSctp());
+        if (openSctp && newParticipant.hasSctpSupport())
+        {
+            contents.add(
+                    JingleOfferFactory.createContentForMedia(
+                            MediaType.DATA, disableIce, useDtls));
+        }
+
+        ColibriConferenceIQ peerChannels = allocateChannels(contents);
+
+        if (peerChannels == null)
+            return null;
+
+        newParticipant.setColibriChannelsInfo(peerChannels);
+
+        craftOffer(contents, peerChannels);
+
+        return contents;
+    }
+
+    /**
+     * Allocates Colibri channels for given {@link Participant} by trying all
+     * available bridges returned by {@link BridgeSelector}.
+     *
+     * @return {@link ColibriConferenceIQ} that describes channels allocated for
+     * given <tt>peer</tt>. <tt>null</tt> is returned if conference is disposed
+     * before we manage to allocate the channels.
+     *
+     * @throws OperationFailedException if we have failed to allocate channels
+     * using existing bridge and we can not switch to another bridge.
+     */
+    private ColibriConferenceIQ allocateChannels(
+            List<ContentPacketExtension> contents)
+        throws OperationFailedException
+    {
+        if (colibriConference.isDisposed())
+        {
+            // Nope - the conference has been disposed, before the thread got
+            // the chance to do anything
+            return null;
+        }
+
+        JitsiMeetConfig config = meetConference.getConfig();
+
+        BridgeSelector bridgeSelector
+            = meetConference.getServices().getBridgeSelector();
+
+        // Set initial bridge if we haven't used any yet
+        synchronized (colibriConference)
+        {
+            if (StringUtils.isNullOrEmpty(
+                        colibriConference.getJitsiVideobridge()))
+            {
+                String bridge;
+
+                // Check for enforced bridge
+
+                if (!StringUtils.isNullOrEmpty(config.getEnforcedVideobridge()))
+                {
+                    bridge = config.getEnforcedVideobridge();
+                    logger.info(
+                            "Will force bridge: " + bridge
+                                    + " on: " + meetConference.getRoomName());
+                }
+                else
+                {
+                    bridge = bridgeSelector.selectVideobridge();
+                }
+
+                if (StringUtils.isNullOrEmpty(bridge))
+                {
+                    throw new OperationFailedException(
+                        "Failed to allocate channels - no bridge configured",
+                        BRIDGE_FAILURE_ERR_CODE);
+                }
+
+                colibriConference.setJitsiVideobridge(bridge);
+            }
+        }
+
+        String jvb = null;
+
+        // We keep trying until the conference is disposed
+        // This can happen either when this JitsiMeetConference is being
+        // disposed or if the bridge already set on ColibriConference by other
+        // allocator thread dies before this thread get the chance to allocate
+        // anything, then it will cancel and channels for this Participant will
+        // be allocated from 'restartConference'
+        while (!colibriConference.isDisposed())
+        {
+            try
+            {
+                synchronized (colibriConference)
+                {
+                    jvb = colibriConference.getJitsiVideobridge();
+                }
+
+                logger.info(
+                        "Using " + jvb + " to allocate channels for: "
+                                 + newParticipant.getMucJid());
+
+                ColibriConferenceIQ peerChannels
+                    = colibriConference.createColibriChannels(
+                            newParticipant.hasBundleSupport(),
+                            newParticipant.getEndpointId(),
+                            true /* initiator */, contents);
+
+                // null means cancelled, because colibriConference has been
+                // disposed by another thread
+                if (peerChannels == null)
+                    return null;
+
+                bridgeSelector.updateBridgeOperationalStatus(jvb, true);
+
+                if (colibriConference.hasJustAllocated())
+                {
+                    meetConference.onColibriConferenceAllocated(
+                            colibriConference, jvb);
+                }
+                return peerChannels;
+            }
+            catch(OperationFailedException exc)
+            {
+                logger.error(
+                        "Failed to allocate channels using bridge: " + jvb,
+                        exc);
+
+                bridgeSelector.updateBridgeOperationalStatus(jvb, false);
+
+                // Check if the conference is in progress
+                if (!StringUtils.isNullOrEmpty(
+                            colibriConference.getConferenceId()))
+                {
+                    // Restart the conference
+                    meetConference.onBridgeDown(jvb);
+
+                    // This thread will end after returning null here
+                    return null;
+                }
+
+                // Try next bridge - synchronize on conference instance
+                synchronized (colibriConference)
+                {
+                    if (StringUtils.isNullOrEmpty(
+                                config.getEnforcedVideobridge()))
+                    {
+                        jvb = bridgeSelector.selectVideobridge();
+                    }
+                    else
+                    {
+                        // If the "enforced" bridge has failed we do not try
+                        // any other bridges, but fail immediately
+                        jvb = null;
+                    }
+
+                    if (!StringUtils.isNullOrEmpty(jvb))
+                    {
+                        colibriConference.setJitsiVideobridge(jvb);
+                    }
+                    else
+                    {
+                        // No more bridges to try
+                        throw new OperationFailedException(
+                                "Failed to allocate channels "
+                                    + "- all bridges are faulty",
+                                BRIDGE_FAILURE_ERR_CODE);
+                    }
+                }
+            }
+        }
+        // If we reach this point it means that the conference has been disposed
+        // before we've managed to allocate anything
+        return null;
+    }
+
+    /**
+     * Fills given list of Jingle contents with transport information for
+     * Colibri channels and SSRCs of other conference participants.
+     *
+     * @param contents the list which contains Jingle content to be included in
+     *        the offer.
+     * @param peerChannels <tt>ColibriConferenceIQ</tt> which is a Colibri
+     *        channels description.
+     */
+    private void craftOffer(List<ContentPacketExtension>    contents,
+                            ColibriConferenceIQ             peerChannels)
+    {
+        boolean useBundle = newParticipant.hasBundleSupport();
+
+        for (ContentPacketExtension cpe : contents)
+        {
+            ColibriConferenceIQ.Content colibriContent
+                = peerChannels.getContent(cpe.getName());
+
+            if (colibriContent == null)
+                continue;
+
+            // Channels
+            for (ColibriConferenceIQ.Channel channel
+                    : colibriContent.getChannels())
+            {
+                IceUdpTransportPacketExtension transport;
+
+                if (useBundle)
+                {
+                    ColibriConferenceIQ.ChannelBundle bundle
+                        = peerChannels.getChannelBundle(
+                                channel.getChannelBundleId());
+
+                    if (bundle == null)
+                    {
+                        logger.error(
+                            "No bundle for " + channel.getChannelBundleId());
+                        continue;
+                    }
+
+                    transport = bundle.getTransport();
+
+                    if (!transport.isRtcpMux())
+                    {
+                        transport.addChildExtension(
+                                new RtcpmuxPacketExtension());
+                    }
+                }
+                else
+                {
+                    transport = channel.getTransport();
+                }
+
+                try
+                {
+                    // Remove empty transport PE
+                    IceUdpTransportPacketExtension empty
+                        = cpe.getFirstChildOfType(
+                                IceUdpTransportPacketExtension.class);
+                    cpe.getChildExtensions().remove(empty);
+
+                    cpe.addChildExtension(
+                            IceUdpTransportPacketExtension
+                                .cloneTransportAndCandidates(transport, true));
+                }
+                catch (Exception e)
+                {
+                    logger.error(e, e);
+                }
+            }
+            // SCTP connections
+            for (ColibriConferenceIQ.SctpConnection sctpConn
+                    : colibriContent.getSctpConnections())
+            {
+                IceUdpTransportPacketExtension transport;
+
+                if (useBundle)
+                {
+                    ColibriConferenceIQ.ChannelBundle bundle
+                        = peerChannels.getChannelBundle(
+                                sctpConn.getChannelBundleId());
+
+                    if (bundle == null)
+                    {
+                        logger.error(
+                            "No bundle for " + sctpConn.getChannelBundleId());
+                        continue;
+                    }
+
+                    transport = bundle.getTransport();
+                }
+                else
+                {
+                    transport = sctpConn.getTransport();
+                }
+
+                try
+                {
+                    // Remove empty transport
+                    IceUdpTransportPacketExtension empty
+                        = cpe.getFirstChildOfType(
+                                IceUdpTransportPacketExtension.class);
+                    cpe.getChildExtensions().remove(empty);
+
+                    IceUdpTransportPacketExtension copy
+                        = IceUdpTransportPacketExtension
+                            .cloneTransportAndCandidates(transport, true);
+
+                    // FIXME: hardcoded
+                    SctpMapExtension sctpMap = new SctpMapExtension();
+                    sctpMap.setPort(5000);
+                    sctpMap.setProtocol(
+                            SctpMapExtension.Protocol.WEBRTC_CHANNEL);
+                    sctpMap.setStreams(1024);
+
+                    copy.addChildExtension(sctpMap);
+
+                    cpe.addChildExtension(copy);
+                }
+                catch (Exception e)
+                {
+                    logger.error(e, e);
+                }
+            }
+            // Existing peers SSRCs
+            RtpDescriptionPacketExtension rtpDescPe
+                = JingleUtils.getRtpDescription(cpe);
+            if (rtpDescPe != null)
+            {
+                if (useBundle)
+                {
+                    // rtcp-mux
+                    rtpDescPe.addChildExtension(
+                            new RtcpmuxPacketExtension());
+                }
+
+                // Copy SSRC sent from the bridge(only the first one)
+                for (ColibriConferenceIQ.Channel channel
+                        : colibriContent.getChannels())
+                {
+                    SourcePacketExtension ssrcPe
+                        = channel.getSources().size() > 0
+                            ? channel.getSources().get(0) : null;
+                    if (ssrcPe == null)
+                        continue;
+
+                    try
+                    {
+                        String contentName = colibriContent.getName();
+                        SourcePacketExtension ssrcCopy = ssrcPe.copy();
+
+                        // FIXME: not all parameters are used currently
+                        ssrcCopy.addParameter(
+                                new ParameterPacketExtension("cname","mixed"));
+                        ssrcCopy.addParameter(
+                                new ParameterPacketExtension(
+                                        "label",
+                                        "mixedlabel" + contentName + "0"));
+                        ssrcCopy.addParameter(
+                                new ParameterPacketExtension(
+                                        "msid",
+                                        "mixedmslabel mixedlabel"
+                                            + contentName + "0"));
+                        ssrcCopy.addParameter(
+                                new ParameterPacketExtension(
+                                        "mslabel", "mixedmslabel"));
+
+                        // Mark 'jvb' as SSRC owner
+                        SSRCInfoPacketExtension ssrcInfo
+                            = new SSRCInfoPacketExtension();
+                        ssrcInfo.setOwner("jvb");
+                        ssrcCopy.addChildExtension(ssrcInfo);
+
+                        rtpDescPe.addChildExtension(ssrcCopy);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.error("Copy SSRC error", e);
+                    }
+                }
+
+                // Include all peers SSRCs
+                List<SourcePacketExtension> mediaSources
+                    = meetConference.getAllSSRCs(cpe.getName());
+
+                for (SourcePacketExtension ssrc : mediaSources)
+                {
+                    try
+                    {
+                        rtpDescPe.addChildExtension(ssrc.copy());
+                    }
+                    catch (Exception e)
+                    {
+                        logger.error("Copy SSRC error", e);
+                    }
+                }
+
+                // Include SSRC groups
+                List<SourceGroupPacketExtension> sourceGroups
+                    = meetConference.getAllSSRCGroups(cpe.getName());
+
+                for(SourceGroupPacketExtension ssrcGroup : sourceGroups)
+                {
+                    rtpDescPe.addChildExtension(ssrcGroup);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -277,31 +277,34 @@ public class ChannelAllocator implements Runnable
     {
         List<ContentPacketExtension> contents = new ArrayList<>();
 
+        JitsiMeetConfig config = meetConference.getConfig();
+
         boolean disableIce = !newParticipant.hasIceSupport();
         boolean useDtls = newParticipant.hasDtlsSupport();
+        boolean useRtx
+            = config.isRtxEnabled() && newParticipant.hasRtxSupport();
 
         if (newParticipant.hasAudioSupport())
         {
             contents.add(
                     JingleOfferFactory.createContentForMedia(
-                            MediaType.AUDIO, disableIce, useDtls));
+                            MediaType.AUDIO, disableIce, useDtls, useRtx));
         }
 
         if (newParticipant.hasVideoSupport())
         {
             contents.add(
                     JingleOfferFactory.createContentForMedia(
-                            MediaType.VIDEO, disableIce, useDtls));
+                            MediaType.VIDEO, disableIce, useDtls, useRtx));
         }
 
-        JitsiMeetConfig config = meetConference.getConfig();
         // Is SCTP enabled ?
         boolean openSctp = Boolean.TRUE.equals(config.openSctp());
         if (openSctp && newParticipant.hasSctpSupport())
         {
             contents.add(
                     JingleOfferFactory.createContentForMedia(
-                            MediaType.DATA, disableIce, useDtls));
+                            MediaType.DATA, disableIce, useDtls, useRtx));
         }
 
         ColibriConferenceIQ peerChannels = allocateChannels(contents);

--- a/src/main/java/org/jitsi/jicofo/ConferenceUtility.java
+++ b/src/main/java/org/jitsi/jicofo/ConferenceUtility.java
@@ -50,7 +50,8 @@ public class ConferenceUtility
     public String getJvbConferenceId()
     {
         ColibriConference colibriConference = conference.getColibriConference();
-        return colibriConference.getConferenceId();
+        return colibriConference != null
+            ? colibriConference.getConferenceId() : null;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -19,8 +19,6 @@ package org.jitsi.jicofo;
 
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
-import net.java.sip.communicator.impl.protocol.jabber.extensions.jitsimeet.*;
-import net.java.sip.communicator.impl.protocol.jabber.jinglesdp.*;
 import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import net.java.sip.communicator.util.*;
@@ -28,15 +26,12 @@ import net.java.sip.communicator.util.Logger;
 
 import org.jitsi.assertions.*;
 import org.jitsi.impl.protocol.xmpp.extensions.*;
-import org.jitsi.jicofo.discovery.*;
 import org.jitsi.jicofo.event.*;
 import org.jitsi.jicofo.log.*;
 import org.jitsi.jicofo.reservation.*;
-import org.jitsi.jicofo.util.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.protocol.xmpp.util.*;
-import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 import org.jitsi.eventadmin.*;
 
@@ -67,13 +62,6 @@ public class JitsiMeetConference
      */
     private final static Logger logger
         = Logger.getLogger(JitsiMeetConference.class);
-
-    /**
-     * Error code used in {@link OperationFailedException} when there are no
-     * working videobridge bridges.
-     * FIXME: consider moving to OperationFailedException ?
-     */
-    private final static int BRIDGE_FAILURE_ERR_CODE = 20;
 
     /**
      * Format used to print the date into the focus identifier string.
@@ -123,18 +111,6 @@ public class JitsiMeetConference
      * flag to skip channel expiration step when conference is being disposed.
      */
     private boolean bridgeHasFailed;
-
-    /**
-     * Synchronization root for currently selected bridge for the
-     * {@link #colibriConference}.
-     */
-    private final Object bridgeSelectSync = new Object();
-
-    /**
-     * The instance of <tt>BridgeSelector</tt> we use to select JVB for this
-     * conference.
-     */
-    private BridgeSelector bridgeSelector;
 
     /**
      * The name of XMPP user used by the focus to login.
@@ -241,6 +217,7 @@ public class JitsiMeetConference
                                JitsiMeetGlobalConfig    globalConfig)
     {
         Assert.notNull(protocolProviderHandler, "protocolProviderHandler");
+        Assert.notNull(config, "config");
 
         this.id = ID_DATE_FORMAT.format(new Date()) + "_" + hashCode();
         this.roomName = roomName;
@@ -291,15 +268,13 @@ public class JitsiMeetConference
 
             recording = new JitsiMeetRecording(this, services);
 
-            bridgeSelector = services.getBridgeSelector();
-
             // Set pre-configured videobridge
             String preConfiguredBridge = config.getPreConfiguredVideobridge();
 
             if (!StringUtils.isNullOrEmpty(preConfiguredBridge))
             {
-                bridgeSelector.setPreConfiguredBridge(
-                        preConfiguredBridge);
+                services.getBridgeSelector()
+                    .setPreConfiguredBridge(preConfiguredBridge);
             }
 
             // Set pre-configured SIP gateway
@@ -468,14 +443,14 @@ public class JitsiMeetConference
                     = hasToStartMuted(
                             member, member == chatRoomMember /* justJoined */);
 
-                inviteChatMember(member, startMuted);
+                inviteChatMember(member, startMuted, colibriConference);
             }
         }
         // Only the one who has just joined
         else
         {
             final boolean[] startMuted = hasToStartMuted(chatRoomMember, true);
-            inviteChatMember(chatRoomMember, startMuted);
+            inviteChatMember(chatRoomMember, startMuted, colibriConference);
         }
     }
 
@@ -487,8 +462,9 @@ public class JitsiMeetConference
      * @param startMuted array with values for audio and video that indicates
      * whether the participant should start muted.
      */
-    private void inviteChatMember(final ChatRoomMember    chatRoomMember,
-                                  final boolean[]         startMuted)
+    private void inviteChatMember(final ChatRoomMember       chatRoomMember,
+                                  final boolean[]            startMuted,
+                                  final ColibriConference    colibriConference)
     {
         if (isFocusMember(chatRoomMember))
             return;
@@ -512,22 +488,9 @@ public class JitsiMeetConference
 
         // Invite peer takes time because of channel allocation, so schedule
         // this on separate thread.
-        FocusBundleActivator.getSharedThreadPool().submit(new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                try
-                {
-                    discoverFeaturesAndInvite(
-                            newParticipant, address, startMuted);
-                }
-                catch (Exception e)
-                {
-                    logger.error("Exception on participant invite", e);
-                }
-            }
-        });
+        FocusBundleActivator.getSharedThreadPool().submit(
+                new ChannelAllocator(
+                        this, colibriConference, newParticipant, startMuted));
     }
 
     /**
@@ -584,511 +547,6 @@ public class JitsiMeetConference
         }
 
         return startMuted;
-    }
-
-    /**
-     * Methods executed on thread pool is time consuming as is doing feature
-     * discovery and channel allocation for new participants.
-     * @param newParticipant new <tt>Participant</tt> instance.
-     * @param address new participant full MUC address.
-     * @param startMuted if the first element is <tt>true</tt> the participant
-     * will start audio muted. if the second element is <tt>true</tt> the
-     * participant will start video muted.
-     */
-    private void discoverFeaturesAndInvite(Participant     newParticipant,
-                                           String          address,
-                                           boolean[]       startMuted)
-    {
-        // Feature discovery
-        List<String> features
-            = DiscoveryUtil.discoverParticipantFeatures(
-                    getXmppProvider(), address);
-
-        newParticipant.setSupportedFeatures(features);
-
-        logger.info(
-            address + " has bundle ? " + newParticipant.hasBundleSupport());
-
-        // Store instance here as it is set to null when conference is disposed
-        ColibriConference conference = this.colibriConference;
-        List<ContentPacketExtension> offer;
-
-        try
-        {
-            offer = createOffer(newParticipant);
-            if (offer == null)
-            {
-                logger.info("Channel allocation cancelled for " + address);
-                return;
-            }
-        }
-        catch (OperationFailedException e)
-        {
-            //FIXME: retry ? sometimes it's just timeout
-            logger.error("Failed to allocate channels for " + address, e);
-
-            // Notify users about bridge is down event
-            if (BRIDGE_FAILURE_ERR_CODE == e.getErrorCode() && chatRoom != null)
-            {
-                meetTools.sendPresenceExtension(
-                    chatRoom, new BridgeIsDownPacketExt());
-            }
-            // Cancel - no channels allocated
-            return;
-        }
-        /*
-           This check makes sure that at the point when we're trying to
-           invite new participant:
-           - the conference has not been disposed in the meantime
-           - he's still in the room
-           - we have managed to send Jingle session-initiate
-           Otherwise we expire allocated channels.
-        */
-        boolean expireChannels = false;
-
-        if (chatRoom == null)
-        {
-            // Conference disposed
-            logger.info(
-                "Expiring " + address + " channels - conference disposed");
-
-            expireChannels = true;
-        }
-        else if (findMember(address) == null)
-        {
-            // Participant has left the room
-            logger.info(
-                "Expiring " + address + " channels - participant has left");
-
-            expireChannels = true;
-        }
-        else if (!jingle.initiateSession(
-                     newParticipant.hasBundleSupport(), address, offer, this,
-                     startMuted))
-        {
-            // Failed to invite
-            logger.info(
-                "Expiring " + address +
-                    " channels - no RESULT for session-invite");
-
-            expireChannels = true;
-        }
-
-        if (expireChannels)
-        {
-            conference.expireChannels(
-                newParticipant.getColibriChannelsInfo());
-        }
-    }
-
-    /**
-     * Allocates Colibri channels for given {@link Participant} by trying all
-     * available bridges returned by {@link BridgeSelector}.
-     *
-     * @param peer the for whom Colibri channel are to be allocated.
-     * @param contents the media offer description passed to the bridge.
-     *
-     * @return {@link ColibriConferenceIQ} that describes channels allocated for
-     *         given <tt>peer</tt>. <tt>null</tt> is returned if conference is
-     *         disposed before we manage to allocate the channels.
-     *
-     * @throws OperationFailedException if we have failed to allocate channels
-     *         using existing bridge and we can not switch to another bridge.
-     */
-    private ColibriConferenceIQ allocateChannels(
-            Participant                     peer,
-            List<ContentPacketExtension>    contents)
-        throws OperationFailedException
-    {
-        // This method is executed on thread pool.
-
-        // Store colibri instance here to be able to free the channels even
-        // after the conference has been disposed.
-        ColibriConference colibriConference = this.colibriConference;
-        if (this.colibriConference == null)
-        {
-            // Nope - the conference has been disposed, before the thread got
-            // the chance to do anything
-            return null;
-        }
-
-        // Set initial bridge if we haven't used any yet
-        synchronized (bridgeSelectSync)
-        {
-            if (StringUtils.isNullOrEmpty(
-                    colibriConference.getJitsiVideobridge()))
-            {
-                String bridge = null;
-
-                if (!StringUtils.isNullOrEmpty(config.getEnforcedVideobridge()))
-                {
-                    bridge = config.getEnforcedVideobridge();
-                    logger.info(
-                        "Will force bridge: " + bridge
-                            + " on: " + getRoomName());
-                }
-                else
-                {
-                    bridge = bridgeSelector.selectVideobridge();
-                }
-
-                if (StringUtils.isNullOrEmpty(bridge))
-                {
-                    throw new OperationFailedException(
-                        "Failed to allocate channels - no bridge configured",
-                        BRIDGE_FAILURE_ERR_CODE);
-                }
-
-                colibriConference.setJitsiVideobridge(bridge);
-            }
-        }
-
-        String jvb = null;
-
-        while (this.colibriConference != null)
-        {
-            try
-            {
-                synchronized (bridgeSelectSync)
-                {
-                    jvb = colibriConference.getJitsiVideobridge();
-                }
-
-                logger.info(
-                    "Using " + jvb + " to allocate channels for: "
-                        + peer.getChatMember().getContactAddress());
-
-                ColibriConferenceIQ peerChannels
-                    = colibriConference.createColibriChannels(
-                            peer.hasBundleSupport(),
-                            peer.getEndpointId(),
-                            true, contents);
-
-                bridgeSelector.updateBridgeOperationalStatus(jvb, true);
-
-                if (colibriConference.hasJustAllocated())
-                {
-                    EventAdmin eventAdmin
-                            = FocusBundleActivator.getEventAdmin();
-                    if (eventAdmin != null)
-                    {
-                        eventAdmin.sendEvent(
-                            EventFactory.conferenceRoom(
-                                    colibriConference.getConferenceId(),
-                                    roomName,
-                                    getId(),
-                                    jvb));
-                    }
-
-                    if (recording != null)
-                        recording.onConferenceAllocated();
-                }
-                return peerChannels;
-            }
-            catch(OperationFailedException exc)
-            {
-                logger.error(
-                    "Failed to allocate channels using bridge: " + jvb, exc);
-
-                bridgeSelector.updateBridgeOperationalStatus(jvb, false);
-
-                // Check if the conference is in progress
-                if (!StringUtils.isNullOrEmpty(
-                        colibriConference.getConferenceId()))
-                {
-                    // Restart
-                    logger.error("Bridge failure - stopping the conference");
-                    stop();
-                }
-
-                // Try next bridge
-                synchronized (bridgeSelectSync)
-                {
-                    if (StringUtils.isNullOrEmpty(
-                            config.getEnforcedVideobridge()))
-                    {
-                        jvb = bridgeSelector.selectVideobridge();
-                    }
-                    else
-                    {
-                        // If the "enforced" bridge has failed we do not try
-                        // any other bridges, but fail immediately
-                        jvb = null;
-                    }
-
-                    // Is it the same which has just failed ?
-                    // (we do not always call iterator.next() at the beginning)
-                    //if (faultyBridge.equals(nextBridge))
-                    //    nextBridge = null;
-                    if (!StringUtils.isNullOrEmpty(jvb))
-                    {
-                        colibriConference.setJitsiVideobridge(jvb);
-                    }
-                    else
-                    {
-                        // No more bridges to try
-                        throw new OperationFailedException(
-                            "Failed to allocate channels " +
-                                "- all bridges are faulty",
-                                BRIDGE_FAILURE_ERR_CODE);
-                    }
-                }
-            }
-        }
-        // If we reach this point it means that the conference has been disposed
-        // before we've managed to allocate anything
-        return null;
-    }
-
-    /**
-     * Creates Jingle offer for given {@link Participant}.
-     *
-     * @param peer the participant for whom Jingle offer will be created.
-     *
-     * @return the list of contents describing conference Jingle offer or
-     *         <tt>null</tt> if the conference has been disposed before we've
-     *         managed to allocate Colibri channels.
-     *
-     * @throws OperationFailedException if focus fails to allocate channels
-     *         or something goes wrong.
-     */
-    private List<ContentPacketExtension> createOffer(Participant peer)
-        throws OperationFailedException
-    {
-        List<ContentPacketExtension> contents = new ArrayList<>();
-
-        boolean disableIce = !peer.hasIceSupport();
-        boolean useDtls = peer.hasDtlsSupport();
-
-        if (peer.hasAudioSupport())
-        {
-            contents.add(
-                JingleOfferFactory.createContentForMedia(
-                    MediaType.AUDIO, disableIce, useDtls));
-        }
-
-        if (peer.hasVideoSupport())
-        {
-            contents.add(
-                JingleOfferFactory.createContentForMedia(
-                    MediaType.VIDEO, disableIce, useDtls));
-        }
-
-        // Is SCTP enabled ?
-        boolean openSctp = config == null || config.openSctp() == null
-                ? true : config.openSctp();
-
-        if (openSctp && peer.hasSctpSupport())
-        {
-            contents.add(
-                JingleOfferFactory.createContentForMedia(
-                    MediaType.DATA, disableIce, useDtls));
-        }
-
-        boolean useBundle = peer.hasBundleSupport();
-
-        ColibriConferenceIQ peerChannels = allocateChannels(peer, contents);
-
-        if (peerChannels == null)
-            return null;
-
-        peer.setColibriChannelsInfo(peerChannels);
-
-        for (ContentPacketExtension cpe : contents)
-        {
-            ColibriConferenceIQ.Content colibriContent
-                = peerChannels.getContent(cpe.getName());
-
-            if (colibriContent == null)
-                continue;
-
-            // Channels
-            for (ColibriConferenceIQ.Channel channel
-                : colibriContent.getChannels())
-            {
-                IceUdpTransportPacketExtension transport;
-
-                if (useBundle)
-                {
-                    ColibriConferenceIQ.ChannelBundle bundle
-                        = peerChannels.getChannelBundle(
-                                channel.getChannelBundleId());
-
-                    if (bundle == null)
-                    {
-                        logger.error(
-                            "No bundle for " + channel.getChannelBundleId());
-                        continue;
-                    }
-
-                    transport = bundle.getTransport();
-
-                    if (!transport.isRtcpMux())
-                    {
-                        transport.addChildExtension(
-                            new RtcpmuxPacketExtension());
-                    }
-                }
-                else
-                {
-                    transport = channel.getTransport();
-                }
-
-                try
-                {
-                    // Remove empty transport
-                    IceUdpTransportPacketExtension empty
-                        = cpe.getFirstChildOfType(
-                                IceUdpTransportPacketExtension.class);
-                    cpe.getChildExtensions().remove(empty);
-
-                    cpe.addChildExtension(
-                        IceUdpTransportPacketExtension
-                            .cloneTransportAndCandidates(transport, true));
-                }
-                catch (Exception e)
-                {
-                    logger.error(e, e);
-                }
-            }
-            // SCTP connections
-            for (ColibriConferenceIQ.SctpConnection sctpConn
-                : colibriContent.getSctpConnections())
-            {
-                IceUdpTransportPacketExtension transport;
-
-                if (useBundle)
-                {
-                    ColibriConferenceIQ.ChannelBundle bundle
-                        = peerChannels.getChannelBundle(
-                                sctpConn.getChannelBundleId());
-
-                    if (bundle == null)
-                    {
-                        logger.error(
-                            "No bundle for " + sctpConn.getChannelBundleId());
-                        continue;
-                    }
-
-                    transport = bundle.getTransport();
-                }
-                else
-                {
-                    transport = sctpConn.getTransport();
-                }
-
-                try
-                {
-                    // Remove empty transport
-                    IceUdpTransportPacketExtension empty
-                        = cpe.getFirstChildOfType(
-                                IceUdpTransportPacketExtension.class);
-                    cpe.getChildExtensions().remove(empty);
-
-                    IceUdpTransportPacketExtension copy
-                        = IceUdpTransportPacketExtension
-                            .cloneTransportAndCandidates(transport, true);
-
-                    // FIXME: hardcoded
-                    SctpMapExtension sctpMap = new SctpMapExtension();
-                    sctpMap.setPort(5000);
-                    sctpMap.setProtocol(
-                            SctpMapExtension.Protocol.WEBRTC_CHANNEL);
-                    sctpMap.setStreams(1024);
-
-                    copy.addChildExtension(sctpMap);
-
-                    cpe.addChildExtension(copy);
-                }
-                catch (Exception e)
-                {
-                    logger.error(e, e);
-                }
-            }
-            // Existing peers SSRCs
-            RtpDescriptionPacketExtension rtpDescPe
-                = JingleUtils.getRtpDescription(cpe);
-            if (rtpDescPe != null)
-            {
-                if (useBundle)
-                {
-                    // rtcp-mux
-                    rtpDescPe.addChildExtension(
-                        new RtcpmuxPacketExtension());
-                }
-
-                // Copy SSRC sent from the bridge(only the first one)
-                for (ColibriConferenceIQ.Channel channel
-                    : colibriContent.getChannels())
-                {
-                    SourcePacketExtension ssrcPe
-                        = channel.getSources().size() > 0
-                                ? channel.getSources().get(0) : null;
-                    if (ssrcPe == null)
-                        continue;
-
-                    try
-                    {
-                        String contentName = colibriContent.getName();
-                        SourcePacketExtension ssrcCopy = ssrcPe.copy();
-
-                        // FIXME: not all parameters are used currently
-                        ssrcCopy.addParameter(
-                            new ParameterPacketExtension("cname","mixed"));
-                        ssrcCopy.addParameter(
-                            new ParameterPacketExtension(
-                                "label",
-                                "mixedlabel" + contentName + "0"));
-                        ssrcCopy.addParameter(
-                            new ParameterPacketExtension(
-                                "msid",
-                                "mixedmslabel mixedlabel"
-                                    + contentName + "0"));
-                        ssrcCopy.addParameter(
-                            new ParameterPacketExtension(
-                                "mslabel", "mixedmslabel"));
-
-                        // Mark 'jvb' as SSRC owner
-                        SSRCInfoPacketExtension ssrcInfo
-                            = new SSRCInfoPacketExtension();
-                        ssrcInfo.setOwner("jvb");
-                        ssrcCopy.addChildExtension(ssrcInfo);
-
-                        rtpDescPe.addChildExtension(ssrcCopy);
-                    }
-                    catch (Exception e)
-                    {
-                        logger.error("Copy SSRC error", e);
-                    }
-                }
-
-                // Include all peers SSRCs
-                List<SourcePacketExtension> mediaSources
-                    = getAllSSRCs(cpe.getName());
-
-                for (SourcePacketExtension ssrc : mediaSources)
-                {
-                    try
-                    {
-                        rtpDescPe.addChildExtension(ssrc.copy());
-                    }
-                    catch (Exception e)
-                    {
-                        logger.error("Copy SSRC error", e);
-                    }
-                }
-
-                // Include SSRC groups
-                List<SourceGroupPacketExtension> sourceGroups
-                    = getAllSSRCGroups(cpe.getName());
-                for(SourceGroupPacketExtension ssrcGroup : sourceGroups)
-                {
-                    rtpDescPe.addChildExtension(ssrcGroup);
-                }
-            }
-        }
-
-        return contents;
     }
 
     /**
@@ -1238,14 +696,7 @@ public class JitsiMeetConference
                         leftPeer.getSSRCGroupsCopy(),
                         false /* no JVB update - will expire */);
 
-                ColibriConferenceIQ peerChannels
-                        = leftPeer.getColibriChannelsInfo();
-                if (!bridgeHasFailed && peerChannels != null)
-                {
-                    logger.info("Expiring channels for: " + contactAddress);
-                    colibriConference.expireChannels(
-                        leftPeer.getColibriChannelsInfo());
-                }
+                expireParticipantChannels(colibriConference, leftPeer);
             }
             boolean removed = participants.remove(leftPeer);
             logger.info(
@@ -1259,6 +710,29 @@ public class JitsiMeetConference
         if (participants.size() == 0)
         {
             stop();
+        }
+    }
+
+    /**
+     * Expires channels for given participant unless there are some
+     * circumstances that prevents us from doing it.
+     *
+     * @param colibriConference <tt>ColibriConference</tt> instance that owns
+     *        the channels to be expired.
+     * @param participant the <tt>Participant</tt> for whom Colibri channels are
+     *        to be expired.
+     */
+    void expireParticipantChannels(ColibriConference colibriConference,
+                                   Participant       participant)
+    {
+        ColibriConferenceIQ channelsInfo
+            = participant.getColibriChannelsInfo();
+
+        if (channelsInfo != null && colibriConference != null
+                && !bridgeHasFailed)
+        {
+            logger.info("Expiring channels for: " + participant.getMucJid());
+            colibriConference.expireChannels(channelsInfo);
         }
     }
 
@@ -1579,10 +1053,10 @@ public class JitsiMeetConference
     {
         Participant sourcePeer
             = findParticipantForJingleSession(sourceJingleSession);
+        String peerAddress = sourceJingleSession.getAddress();
         if (sourcePeer == null)
         {
-            logger.error("Remove-source: no session for "
-                             + sourceJingleSession.getAddress());
+            logger.error("Remove-source: no session for " + peerAddress);
             return;
         }
 
@@ -1595,8 +1069,7 @@ public class JitsiMeetConference
         if (removedSSRCs.isEmpty() && removedGroups.isEmpty())
         {
             logger.warn(
-                "No ssrcs or groups to be removed from: "
-                    + sourceJingleSession.getAddress());
+                    "No ssrcs or groups to be removed from: "+ peerAddress);
             return;
         }
 
@@ -1605,7 +1078,11 @@ public class JitsiMeetConference
         ssrcGroupsToRemove = removedGroups;
 
         // Updates SSRC Groups on the bridge
-        if (updateChannels)
+        ColibriConference colibriConference = this.colibriConference;
+        // We may hit null here during conference restart, but that's not
+        // important since the bridge for this instance will not be used
+        // anymore and state is synced up soon after channels are allocated
+        if (updateChannels && colibriConference != null)
         {
             colibriConference.updateSourcesInfo(
                     sourcePeer.getSSRCsCopy(),
@@ -1613,9 +1090,7 @@ public class JitsiMeetConference
                     sourcePeer.getColibriChannelsInfo());
         }
 
-        logger.info(
-            "Removing " + sourceJingleSession.getAddress()
-                + " SSRCs " + ssrcsToRemove);
+        logger.info("Removing " + peerAddress + " SSRCs " + ssrcsToRemove);
 
         for (Participant peer : participants)
         {
@@ -1626,8 +1101,7 @@ public class JitsiMeetConference
             if (jingleSessionToNotify == null)
             {
                 logger.warn(
-                    "Remove source: no jingle session for "
-                        + peer.getChatMember().getContactAddress());
+                        "Remove source: no jingle session for " + peerAddress);
 
                 peer.scheduleSSRCsToRemove(ssrcsToRemove);
 
@@ -1650,7 +1124,7 @@ public class JitsiMeetConference
      * @return the list of all SSRCs of given media type that exist in current
      *         conference state.
      */
-    private List<SourcePacketExtension> getAllSSRCs(String media)
+    List<SourcePacketExtension> getAllSSRCs(String media)
     {
         List<SourcePacketExtension> mediaSSRCs = new ArrayList<>();
 
@@ -1675,7 +1149,7 @@ public class JitsiMeetConference
      * @return the list of all SSRC groups of given media type that exist in
      *         current conference state.
      */
-    private List<SourceGroupPacketExtension> getAllSSRCGroups(String media)
+    List<SourceGroupPacketExtension> getAllSSRCGroups(String media)
     {
         List<SourceGroupPacketExtension> ssrcGroups = new ArrayList<>();
 
@@ -1857,7 +1331,7 @@ public class JitsiMeetConference
      * Handles on bridge down event by shutting down the conference if it's the
      * one we're using here.
      */
-    private void onBridgeDown(String bridgeJid)
+    void onBridgeDown(String bridgeJid)
     {
         if (colibriConference != null
                 && bridgeJid.equals(colibriConference.getJitsiVideobridge()))
@@ -1880,6 +1354,15 @@ public class JitsiMeetConference
     }
 
     /**
+     * Returns config for this conference.
+     * @return <tt>JitsiMeetConfig</tt> instance used in this conference.
+     */
+    public JitsiMeetConfig getConfig()
+    {
+        return config;
+    }
+
+    /**
      * Returns <tt>JitsiMeetRecording</tt> for this conference.
      * @return <tt>JitsiMeetRecording</tt> instance for this conference or
      *         <tt>null</tt> if it's not available yet(should be after we join
@@ -1888,6 +1371,34 @@ public class JitsiMeetConference
     public JitsiMeetRecording getRecording()
     {
         return recording;
+    }
+
+    /**
+     * Methods called by {@link ChannelAllocator} just after it has created new
+     * Colibri conference on the JVB.
+     *
+     * @param colibriConference <tt>ColibriConference</tt> instance which just
+     * has been allocated on the bridge
+     * @param videobridgeJid the JID of the JVB where given
+     * <tt>ColibriConference</tt> has been allocated
+     */
+    public void onColibriConferenceAllocated(
+            ColibriConference    colibriConference,
+            String               videobridgeJid)
+    {
+        EventAdmin eventAdmin = FocusBundleActivator.getEventAdmin();
+        if (eventAdmin != null)
+        {
+            eventAdmin.sendEvent(
+                    EventFactory.conferenceRoom(
+                            colibriConference.getConferenceId(),
+                            roomName,
+                            getId(),
+                            videobridgeJid));
+        }
+
+        if (recording != null)
+            recording.onConferenceAllocated();
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -740,13 +740,13 @@ public class JitsiMeetConference
     }
 
     /**
-     * Expires channels for given participant unless there are some
+     * Expires channels for given {@link Participant} unless there are some
      * circumstances that prevents us from doing it.
      *
      * @param colibriConference <tt>ColibriConference</tt> instance that owns
      *        the channels to be expired.
-     * @param participant the <tt>Participant</tt> for whom Colibri channels are
-     *        to be expired.
+     * @param participant the <tt>Participant</tt> whose Colibri channels are to
+     *        be expired.
      */
     void expireParticipantChannels(ColibriConference colibriConference,
                                    Participant       participant)
@@ -1559,8 +1559,10 @@ public class JitsiMeetConference
     }
 
     /**
-     * Sets <tt>startMuted</tt> property.
-     * @param startMuted the new value to be set.
+     * Sets the value of the <tt>startMuted</tt> property of this instance.
+     *
+     * @param startMuted the new value to set on this instance. The specified
+     * array is copied.
      */
     public void setStartMuted(boolean[] startMuted)
     {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -195,7 +195,7 @@ public class JitsiMeetConference
      * will start audio muted. if the second element is <tt>true</tt> the
      * participant will start video muted.
      */
-    private boolean[] startMuted = new boolean[] {false, false};
+    private boolean[] startMuted = { false, false };
 
     /**
      * The name of shared Etherpad document. Is advertised through MUC Presence
@@ -717,16 +717,18 @@ public class JitsiMeetConference
 
                 jingle.terminateSession(peerJingleSession, Reason.GONE);
 
-                removeSSRCs(peerJingleSession,
+                removeSSRCs(
+                        peerJingleSession,
                         leftPeer.getSSRCsCopy(),
                         leftPeer.getSSRCGroupsCopy(),
                         false /* no JVB update - will expire */);
 
                 expireParticipantChannels(colibriConference, leftPeer);
             }
+
             boolean removed = participants.remove(leftPeer);
             logger.info(
-                "Removed participant: " + removed + ", " + contactAddress);
+                    "Removed participant: " + removed + ", " + contactAddress);
         }
         else
         {
@@ -848,11 +850,12 @@ public class JitsiMeetConference
     {
         Participant participant
             = findParticipantForJingleSession(peerJingleSession);
+        String peerJingleSessionAddress = peerJingleSession.getAddress();
 
         if (participant == null)
         {
             logger.error(
-                "No participant found for: " + peerJingleSession.getAddress());
+                    "No participant found for: " + peerJingleSessionAddress);
             return;
         }
 
@@ -861,7 +864,7 @@ public class JitsiMeetConference
             //FIXME: we should reject it ?
             logger.error(
                     "Reassigning jingle session for participant: "
-                        + peerJingleSession.getAddress());
+                        + peerJingleSessionAddress);
         }
 
         // XXX We will be acting on the received session-accept bellow.
@@ -881,7 +884,7 @@ public class JitsiMeetConference
         participant.addSSRCGroupsFromContent(answer);
 
         logger.info(
-                "Received SSRCs from " + peerJingleSession.getAddress() + " "
+                "Received SSRCs from " + peerJingleSessionAddress + " "
                     + participant.getSSRCS());
 
         // Update channel info
@@ -904,8 +907,8 @@ public class JitsiMeetConference
             if (jingleSessionToNotify == null)
             {
                 logger.warn(
-                    "No jingle session yet for "
-                        + peerToNotify.getChatMember().getContactAddress());
+                        "No jingle session yet for "
+                            + peerToNotify.getChatMember().getContactAddress());
 
                 peerToNotify.scheduleSSRCsToAdd(participant.getSSRCS());
                 peerToNotify.scheduleSSRCGroupsToAdd(
@@ -1306,8 +1309,7 @@ public class JitsiMeetConference
 
     ChatRoomMember findMember(String from)
     {
-        return chatRoom != null ?
-            chatRoom.findChatMember(from) : null;
+        return chatRoom == null ? null : chatRoom.findChatMember(from);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
+++ b/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
@@ -26,6 +26,7 @@ import net.java.sip.communicator.util.Logger;
 import org.jitsi.impl.protocol.xmpp.extensions.*;
 import org.jitsi.jicofo.log.*;
 import org.jitsi.protocol.xmpp.*;
+import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.protocol.xmpp.util.*;
 import org.jitsi.util.*;
 import org.jitsi.eventadmin.*;
@@ -388,13 +389,24 @@ public class MeetExtensionsHandler
                     String content = LogUtil.getContent(log);
                     if (content != null)
                     {
-                        Event event =
-                            EventFactory.peerConnectionStats(
-                                conference.getColibriConference().getConferenceId(),
-                                participant.getEndpointId(),
-                                content);
-                        if (event != null)
-                            eventAdmin.sendEvent(event);
+                        ColibriConference colibriConference
+                            = conference.getColibriConference();
+                        if (colibriConference != null)
+                        {
+                            Event event =
+                                EventFactory.peerConnectionStats(
+                                    colibriConference.getConferenceId(),
+                                    participant.getEndpointId(),
+                                    content);
+                            if (event != null)
+                                eventAdmin.sendEvent(event);
+                        }
+                        else
+                        {
+                            logger.warn(
+                                    "Unhandled log request"
+                                        + "- no valid Colibri conference");
+                        }
                     }
                 }
                 else
@@ -459,11 +471,11 @@ public class MeetExtensionsHandler
 
         Participant participant
                 = conference.findParticipantForRoomJid(presence.getFrom());
-        if (participant != null)
+        ColibriConference colibriConference = conference.getColibriConference();
+        if (participant != null && colibriConference != null)
         {
             // Check if this conference is valid
-            String conferenceId
-                = conference.getColibriConference().getConferenceId();
+            String conferenceId = colibriConference.getConferenceId();
             if (StringUtils.isNullOrEmpty(conferenceId))
             {
                 logger.error(

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -729,4 +729,13 @@ public class Participant
     {
         this.displayName = displayName;
     }
+
+    /**
+     * Returns MUC JID of this <tt>Participant</tt>
+     * @return full MUC address eg. "room1@muc.server.net/nickname"
+     */
+    public String getMucJid()
+    {
+        return roomMember.getContactAddress();
+    }
 }

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -739,8 +739,8 @@ public class Participant
     }
 
     /**
-     * Returns MUC JID of this <tt>Participant</tt>
-     * @return full MUC address eg. "room1@muc.server.net/nickname"
+     * Returns the MUC JID of this <tt>Participant</tt>.
+     * @return full MUC address e.g. "room1@muc.server.net/nickname"
      */
     public String getMucJid()
     {

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -47,7 +47,7 @@ public abstract class AbstractOperationSetJingle
     /**
      * The list of active Jingle sessions.
      */
-    protected Map<String, JingleSession> sessions = new HashMap<>();
+    protected final Map<String, JingleSession> sessions = new HashMap<>();
 
     /**
      * Implementing classes should return our JID here.

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -104,8 +104,9 @@ public abstract class AbstractOperationSetJingle
 
         sessions.put(sid, session);
 
-        JingleIQ inviteIQ = createInviteIQ(
-                sid, useBundle, address, contents, startMuted);
+        JingleIQ inviteIQ
+            = createInviteIQ(
+                    sid, useBundle, address, contents, startMuted);
 
         IQ reply = (IQ) getConnection().sendPacketAndGetReply(inviteIQ);
 

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -38,13 +38,14 @@ public abstract class AbstractOperationSetJingle
     implements OperationSetJingle
 {
     /**
-     * The logger.
+     * The {@code Logger} used by the class {@code AbstractOperationSetJingle}
+     * and its instances to print debug-related information.
      */
     private static final Logger logger
         = Logger.getLogger(AbstractOperationSetJingle.class);
 
     /**
-     * The list of active Jingle session.
+     * The list of active Jingle sessions.
      */
     protected Map<String, JingleSession> sessions = new HashMap<>();
 
@@ -65,7 +66,7 @@ public abstract class AbstractOperationSetJingle
     /**
      * Finds Jingle session for given session identifier.
      *
-     * @param sid the identifier of the session for which we're looking for.
+     * @param sid the identifier of the session which we're looking for.
      *
      * @return Jingle session for given session identifier or <tt>null</tt>
      *         if no such session exists.
@@ -168,16 +169,17 @@ public abstract class AbstractOperationSetJingle
     }
 
     /**
-     * Checks based on supplied <tt>reply</tt> IQ value whether or not given
-     * <tt>JingleSession</tt> has been accepted by the client.
+     * Determines whether a specific {@limk JingleSession} has been accepted by
+     * the client judging by a specific {@code reply} {@link IQ} (received in
+     * reply to an invite IQ sent withing the specified {@code JingleSession}).
      *
      * @param session <tt>JingleSession</tt> instance for which we're evaluating
      * the response value.
      * @param reply <tt>IQ</tt> response to Jingle invite IQ or <tt>null</tt> in
      * case of timeout.
      *
-     * @return <tt>true</tt> if invite IQ for which we're evaluating the value
-     * of response packet is considered accepted or <tt>false</tt> otherwise.
+     * @return <tt>true</tt> if the invite IQ to which {@code reply} replies is
+     * considered accepted; <tt>false</tt>, otherwise.
      */
     private boolean wasInviteAccepted(JingleSession session, IQ reply)
     {
@@ -253,7 +255,7 @@ public abstract class AbstractOperationSetJingle
     }
 
     /**
-     * The logic for processing received JingleIQs.
+     * The logic for processing received <tt>JingleIQ</tt>s.
      *
      * @param iq the <tt>JingleIQ</tt> to process.
      */

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -106,8 +106,7 @@ public abstract class AbstractOperationSetJingle
         sessions.put(sid, session);
 
         JingleIQ inviteIQ
-            = createInviteIQ(
-                    sid, useBundle, address, contents, startMuted);
+            = createInviteIQ(sid, useBundle, address, contents, startMuted);
 
         IQ reply = (IQ) getConnection().sendPacketAndGetReply(inviteIQ);
 
@@ -183,7 +182,6 @@ public abstract class AbstractOperationSetJingle
      */
     private boolean wasInviteAccepted(JingleSession session, IQ reply)
     {
-        String address = session.getAddress();
         if (reply == null)
         {
             // XXX By the time the acknowledgement timeout occurs, we may have
@@ -203,7 +201,7 @@ public abstract class AbstractOperationSetJingle
                 logger.error(
                         "Timeout waiting for RESULT response to "
                             + "'session-initiate' request from "
-                            + address);
+                            + session.getAddress());
                 return false;
             }
         }
@@ -214,8 +212,9 @@ public abstract class AbstractOperationSetJingle
         else
         {
             logger.error(
-                    "Failed to send 'session-initiate' to " + address
-                        + ", error: " + reply.getError());
+                    "Failed to send 'session-initiate' to "
+                        + session.getAddress() + ", error: "
+                        + reply.getError());
             return false;
         }
     }

--- a/src/main/java/org/jitsi/protocol/xmpp/JingleRequestHandler.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/JingleRequestHandler.java
@@ -73,4 +73,21 @@ public interface JingleRequestHandler
      */
     void onTransportInfo(JingleSession jingleSession,
                          List<ContentPacketExtension> contents);
+
+    /**
+     * Called when 'transport-accept' IQ is received from the client.
+     *
+     * @param jingleSession the session that has received the notification
+     * @param contents content list that contains media transport description
+     */
+    void onTransportAccept(JingleSession jingleSession,
+                           List<ContentPacketExtension> contents);
+
+    /**
+     * Called when 'transport-reject' IQ is received from the client.
+     *
+     * @param jingleSession the session that has received the notification
+     * @param rejectIq full reject IQ provided for further analysis purposes
+     */
+    void onTransportReject(JingleSession jingleSession, JingleIQ rejectIq);
 }

--- a/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
@@ -60,6 +60,24 @@ public interface OperationSetJingle
             boolean[] startMuted);
 
     /**
+     * Sends 'transport-replace' IQ to the client.
+     *
+     * @param useBundle <tt>true</tt> if bundled transport is being used or
+     * <tt>false</tt> otherwise
+     * @param session the <tt>JingleSession</tt> used to send the notification.
+     * @param contents the list of Jingle contents which describes the actual
+     * offer
+     * @param startMuted an array where the first value stands for "start with
+     * audio muted" and the seconds one for "start video muted"
+     *
+     * @return <tt>true</tt> if have have received RESULT response to the IQ.
+     */
+    boolean replaceTransport(boolean                         useBundle,
+                             JingleSession                   session,
+                             List<ContentPacketExtension>    contents,
+                             boolean[]                       startMuted);
+
+    /**
      * Sends 'source-add' proprietary notification.
      *
      * @param ssrcMap the media SSRCs map which will be included in

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -62,19 +62,19 @@ public interface ColibriConference
      * @param config <tt>JitsiMeetConfig</tt> to be used for allocating
      *               Colibri channels in this conference.
      */
-    public void setConfig(JitsiMeetConfig config);
+    void setConfig(JitsiMeetConfig config);
 
     /**
      * Sets world readable name that identifies the conference.
      * @param name the new name.
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets world readable name that identifies the conference.
      * @return the name.
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns <tt>true</tt> if conference has been allocated during last
@@ -85,7 +85,7 @@ public interface ColibriConference
      * conference ID == null before operation, so it can't be used to detect
      * conference created event.
      */
-    public boolean hasJustAllocated();
+    boolean hasJustAllocated();
 
     /**
      * Creates channels on the videobridge for given parameters.
@@ -102,11 +102,11 @@ public interface ColibriConference
      *                                  network or bridge failure.
      */
     ColibriConferenceIQ createColibriChannels(
-        boolean useBundle,
-        String endpointName,
-        boolean peerIsInitiator,
-        List<ContentPacketExtension> contents)
-        throws OperationFailedException;
+            boolean                         useBundle,
+            String                          endpointName,
+            boolean                         peerIsInitiator,
+            List<ContentPacketExtension>    contents)
+        throws    OperationFailedException;
 
     /**
      * Does Colibri channels update of RTP description, SSRC and transport
@@ -155,8 +155,8 @@ public interface ColibriConference
      * updated on the bridge.
      */
     void updateRtpDescription(
-            Map<String, RtpDescriptionPacketExtension> map,
-            ColibriConferenceIQ localChannelsInfo);
+            Map<String, RtpDescriptionPacketExtension>    map,
+            ColibriConferenceIQ                           localChannelsInfo);
 
     /**
      * Updates transport information for active channels
@@ -169,8 +169,8 @@ public interface ColibriConference
      *                          on the bridge.
      */
     void updateTransportInfo(
-        Map<String, IceUdpTransportPacketExtension> map,
-        ColibriConferenceIQ localChannelsInfo);
+            Map<String, IceUdpTransportPacketExtension>   map,
+            ColibriConferenceIQ                           localChannelsInfo);
 
     /**
      * Updates simulcast layers on the bridge.
@@ -182,9 +182,9 @@ public interface ColibriConference
      *                          on the bridge.</tt>
      */
     void updateSourcesInfo(
-        MediaSSRCMap ssrcs,
-        MediaSSRCGroupMap ssrcGroups,
-        ColibriConferenceIQ localChannelsInfo);
+            MediaSSRCMap           ssrcs,
+            MediaSSRCGroupMap      ssrcGroups,
+            ColibriConferenceIQ    localChannelsInfo);
 
     /**
      * Updates channel bundle transport information for channels described by
@@ -199,8 +199,8 @@ public interface ColibriConference
      *                          bundle group.
      */
     void updateBundleTransportInfo(
-        IceUdpTransportPacketExtension transport,
-        ColibriConferenceIQ localChannelsInfo);
+            IceUdpTransportPacketExtension    transport,
+            ColibriConferenceIQ               localChannelsInfo);
 
     /**
      * Expires the channels described by given <tt>ColibriConferenceIQ</tt>.

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -211,7 +211,9 @@ public interface ColibriConference
     void expireChannels(ColibriConferenceIQ channelInfo);
 
     /**
-     * Expires all channels in current conference and resets conference state.
+     * Expires all channels in current conference and this instance goes into
+     * disposed state(like calling {@link #dispose()} method). It must not be
+     * used anymore.
      */
     void expireConference();
 
@@ -225,4 +227,19 @@ public interface ColibriConference
      *         otherwise.
      */
     boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute);
+
+    /**
+     * Disposes of any resources allocated by this instance. Once disposed this
+     * instance must not be used anymore.
+     */
+    void dispose();
+
+    /**
+     * Checks whether or not this instance has been disposed. The instance must
+     * not be used for any Colibri operations once disposed.
+     *
+     * @return <tt>true</tt> if this instance is in "disposed" state or
+     *         <tt>false</tt> otherwise.
+     */
+    boolean isDisposed();
 }


### PR DESCRIPTION
This PR makes Jicofo move the conference to another bridge when the current one dies. This is done by sending 'transport-replace' message to the client which contains transport info for the new bridge.