### PR TITLE
Adds RTX by default to offers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20160308.153702-107</version>
+      <version>1.0-20160329.203638-125</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -759,7 +759,7 @@ public class JitsiMeetConference
      * Allocates Colibri channels for given {@link Participant} by trying all
      * available bridges returned by {@link BridgeSelector}.
      *
-     * @param peer the for whom Colibri channel are to be allocated.
+     * @param peer the participant for whom Colibri channel are to be allocated.
      * @param contents the media offer description passed to the bridge.
      *
      * @return {@link ColibriConferenceIQ} that describes channels allocated for
@@ -930,19 +930,20 @@ public class JitsiMeetConference
 
         boolean disableIce = !peer.hasIceSupport();
         boolean useDtls = peer.hasDtlsSupport();
+        boolean useRtx = config.isRtxEnabled() && peer.hasRtxSupport();
 
         if (peer.hasAudioSupport())
         {
             contents.add(
                 JingleOfferFactory.createContentForMedia(
-                    MediaType.AUDIO, disableIce, useDtls));
+                    MediaType.AUDIO, disableIce, useDtls, useRtx));
         }
 
         if (peer.hasVideoSupport())
         {
             contents.add(
                 JingleOfferFactory.createContentForMedia(
-                    MediaType.VIDEO, disableIce, useDtls));
+                    MediaType.VIDEO, disableIce, useDtls, useRtx));
         }
 
         // Is SCTP enabled ?
@@ -953,7 +954,7 @@ public class JitsiMeetConference
         {
             contents.add(
                 JingleOfferFactory.createContentForMedia(
-                    MediaType.DATA, disableIce, useDtls));
+                    MediaType.DATA, disableIce, useDtls, useRtx));
         }
 
         boolean useBundle = peer.hasBundleSupport();

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConfig.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConfig.java
@@ -102,6 +102,11 @@ public class JitsiMeetConfig
      */
     public static final String START_VIDEO_MUTED = "startVideoMuted";
 
+    /**
+     * The name of the "disableRtx" property.
+     */
+    public static final String DISABLE_RTX_PNAME = "disableRtx";
+
     private final Map<String, String> properties;
 
     /**
@@ -178,6 +183,16 @@ public class JitsiMeetConfig
     {
         String mode = properties.get(SIMULCAST_MODE_PNAME);
         return SimulcastMode.fromString(mode);
+    }
+
+    /**
+     * @return {@code true} iff RTX is enabled in this {@link JitsiMeetConfig}.
+     */
+    public boolean isRtxEnabled()
+    {
+        String disableRtxStr = properties.get(DISABLE_RTX_PNAME);
+        return StringUtils.isNullOrEmpty(disableRtxStr)
+            || !Boolean.parseBoolean(disableRtxStr);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -375,6 +375,14 @@ public class Participant
     }
 
     /**
+     * Returns {@code true} iff this participant supports RTX.
+     */
+    public boolean hasRtxSupport()
+    {
+        return supportedFeatures.contains(DiscoveryUtil.FEATURE_RTX);
+    }
+
+    /**
      * FIXME: we need to remove "is SIP gateway code", but there are still 
      * situations where we need to know whether given peer is a human or not.
      * For example when we close browser window and only SIP gateway stays

--- a/src/main/java/org/jitsi/jicofo/discovery/DiscoveryUtil.java
+++ b/src/main/java/org/jitsi/jicofo/discovery/DiscoveryUtil.java
@@ -71,6 +71,12 @@ public class DiscoveryUtil
             = "urn:xmpp:jingle:transports:dtls-sctp:1";
 
     /**
+     * RTX (RFC4588) support.
+     */
+    public final static String FEATURE_RTX
+        = "urn:ietf:rfc:4588";
+
+    /**
      * The Jingle DTLS feature name (XEP-0320).
      */
     public final static String FEATURE_DTLS = "urn:xmpp:jingle:apps:dtls:0";

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -62,199 +62,11 @@ public class JingleOfferFactory
         // to construct the offer
         if (mediaType == MediaType.AUDIO)
         {
-            RtpDescriptionPacketExtension rtpDesc
-                = new RtpDescriptionPacketExtension();
-
-            rtpDesc.setMedia("audio");
-
-            RTPHdrExtPacketExtension ssrcAudioLevel
-                = new RTPHdrExtPacketExtension();
-            ssrcAudioLevel.setID("1");
-            ssrcAudioLevel.setURI(URI.create(RTPExtension.SSRC_AUDIO_LEVEL_URN));
-                           rtpDesc.addExtmap(ssrcAudioLevel);
-            RTPHdrExtPacketExtension absSendTime
-                    = new RTPHdrExtPacketExtension();
-            absSendTime.setID("3");
-            absSendTime.setURI(URI.create(RTPExtension.ABS_SEND_TIME_URN));
-            rtpDesc.addExtmap(absSendTime);
-
-            // a=rtpmap:111 opus/48000/2
-            PayloadTypePacketExtension opus
-                = new PayloadTypePacketExtension();
-            opus.setId(111);
-            opus.setName("opus");
-            opus.setClockrate(48000);
-            opus.setChannels(2);
-            rtpDesc.addPayloadType(opus);
-
-            // fmtp:111 minptime=10
-            ParameterPacketExtension opusMinptime
-                = new ParameterPacketExtension();
-            opusMinptime.setName("minptime");
-            opusMinptime.setValue("10");
-            opus.addParameter(opusMinptime);
-            ParameterPacketExtension opusFec
-                    = new ParameterPacketExtension();
-            opusFec.setName("useinbandfec");
-            opusFec.setValue("1");
-            opus.addParameter(opusFec);
-
-            // a=rtpmap:103 ISAC/16000
-            PayloadTypePacketExtension isac16
-                = new PayloadTypePacketExtension();
-            isac16.setId(103);
-            isac16.setName("ISAC");
-            isac16.setClockrate(16000);
-            rtpDesc.addPayloadType(isac16);
-
-            // a=rtpmap:104 ISAC/32000
-            PayloadTypePacketExtension isac32
-                = new PayloadTypePacketExtension();
-            isac32.setId(104);
-            isac32.setName("ISAC");
-            isac32.setClockrate(32000);
-            rtpDesc.addPayloadType(isac32);
-
-            // a=rtpmap:0 PCMU/8000
-            PayloadTypePacketExtension pcmu
-                = new PayloadTypePacketExtension();
-            pcmu.setId(0);
-            pcmu.setName("PCMU");
-            pcmu.setClockrate(8000);
-            rtpDesc.addPayloadType(pcmu);
-
-            // a=rtpmap:8 PCMA/8000
-            PayloadTypePacketExtension pcma
-                = new PayloadTypePacketExtension();
-            pcma.setId(8);
-            pcma.setName("PCMA");
-            pcma.setClockrate(8000);
-            rtpDesc.addPayloadType(pcma);
-
-            // a=rtpmap:106 CN/32000
-            PayloadTypePacketExtension cn
-                = new PayloadTypePacketExtension();
-            cn.setId(106);
-            cn.setName("CN");
-            cn.setClockrate(32000);
-            rtpDesc.addPayloadType(cn);
-
-            // a=rtpmap:105 CN/16000
-            PayloadTypePacketExtension cn16
-                = new PayloadTypePacketExtension();
-            cn16.setId(105);
-            cn16.setName("CN");
-            cn16.setClockrate(16000);
-            rtpDesc.addPayloadType(cn16);
-
-            // a=rtpmap:13 CN/8000
-            PayloadTypePacketExtension cn8
-                = new PayloadTypePacketExtension();
-            cn8.setId(13);
-            cn8.setName("CN");
-            cn8.setClockrate(8000);
-            rtpDesc.addPayloadType(cn8);
-
-            // rtpmap:126 telephone-event/8000
-            PayloadTypePacketExtension teleEvent
-                = new PayloadTypePacketExtension();
-            teleEvent.setId(126);
-            teleEvent.setName("telephone-event");
-            teleEvent.setClockrate(8000);
-            rtpDesc.addPayloadType(teleEvent);
-
-            // a=maxptime:60
-            rtpDesc.setAttribute("maxptime", "60");
-            content.addChildExtension(rtpDesc);
+            addAudioToContent(content);
         }
         else if (mediaType == MediaType.VIDEO)
         {
-            RtpDescriptionPacketExtension rtpDesc
-                = new RtpDescriptionPacketExtension();
-
-            rtpDesc.setMedia("video");
-
-            // This is currently disabled, because we don't support it in the
-            // bridge (and currently clients seem to not use it when
-            // abs-send-time is available).
-            // a=extmap:2 urn:ietf:params:rtp-hdrext:toffset
-            //RTPHdrExtPacketExtension toOffset
-            //    = new RTPHdrExtPacketExtension();
-            //toOffset.setID("2");
-            //toOffset.setURI(
-            //    URI.create("urn:ietf:params:rtp-hdrext:toffset"));
-            //rtpDesc.addExtmap(toOffset);
-
-            // a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
-            RTPHdrExtPacketExtension absSendTime
-                = new RTPHdrExtPacketExtension();
-            absSendTime.setID("3");
-            absSendTime.setURI(URI.create(RTPExtension.ABS_SEND_TIME_URN));
-            rtpDesc.addExtmap(absSendTime);
-
-            // a=rtpmap:100 VP8/90000
-            int vp8pt = 100;
-            PayloadTypePacketExtension vp8
-                = new PayloadTypePacketExtension();
-            vp8.setId(vp8pt);
-            vp8.setName(Constants.VP8);
-            vp8.setClockrate(90000);
-            rtpDesc.addPayloadType(vp8);
-
-            // a=rtpmap:96 rtx/90000
-            PayloadTypePacketExtension rtx
-                = new PayloadTypePacketExtension();
-            rtx.setId(96);
-            rtx.setName(Constants.RTX);
-            rtx.setClockrate(90000);
-            rtpDesc.addPayloadType(rtx);
-
-            // a=fmtp:96 apt=100
-            ParameterPacketExtension rtxApt
-                = new ParameterPacketExtension();
-            rtxApt.setName("apt");
-            rtxApt.setValue(String.valueOf(vp8pt));
-            vp8.addParameter(rtxApt);
-
-            // a=rtcp-fb:100 ccm fir
-            RtcpFbPacketExtension ccmFir = new RtcpFbPacketExtension();
-            ccmFir.setFeedbackType("ccm");
-            ccmFir.setFeedbackSubtype("fir");
-            vp8.addRtcpFeedbackType(ccmFir);
-
-            // a=rtcp-fb:100 nack
-            RtcpFbPacketExtension nack = new RtcpFbPacketExtension();
-            nack.setFeedbackType("nack");
-            vp8.addRtcpFeedbackType(nack);
-
-            // a=rtcp-fb:100 nack pli
-            RtcpFbPacketExtension nackPli = new RtcpFbPacketExtension();
-            nackPli.setFeedbackType("nack");
-            nackPli.setFeedbackSubtype("pli");
-            vp8.addRtcpFeedbackType(nackPli);
-
-            // a=rtcp-fb:100 goog-remb
-            RtcpFbPacketExtension remb = new RtcpFbPacketExtension();
-            remb.setFeedbackType("goog-remb");
-            vp8.addRtcpFeedbackType(remb);
-
-            // a=rtpmap:116 red/90000
-            PayloadTypePacketExtension red
-                = new PayloadTypePacketExtension();
-            red.setId(116);
-            red.setName("red");
-            red.setClockrate(90000);
-            rtpDesc.addPayloadType(red);
-
-            // a=rtpmap:117 ulpfec/90000
-            PayloadTypePacketExtension ulpfec
-                = new PayloadTypePacketExtension();
-            ulpfec.setId(117);
-            ulpfec.setName("ulpfec");
-            ulpfec.setClockrate(90000);
-            rtpDesc.addPayloadType(ulpfec);
-
-            content.addChildExtension(rtpDesc);
+            addVideoToContent(content);
         }
         else if (mediaType == MediaType.DATA)
         {
@@ -271,7 +83,9 @@ public class JingleOfferFactory
             content.addChildExtension(rdpe);
         }
         else
-            return null;
+        {
+            throw new IllegalArgumentException("mediaType");
+        }
 
         // DTLS-SRTP
         //setDtlsEncryptionOnContent(mediaType, content, null);
@@ -292,5 +106,213 @@ public class JingleOfferFactory
         }
 
         return content;
+    }
+
+    /**
+     * Adds the audio-related extensions for an offer to a
+     * {@link ContentPacketExtension}.
+     * @param content the {@link ContentPacketExtension} to add extensions to.
+     */
+    private static void addVideoToContent(ContentPacketExtension content)
+    {
+        RtpDescriptionPacketExtension rtpDesc
+            = new RtpDescriptionPacketExtension();
+
+        rtpDesc.setMedia("video");
+
+        // This is currently disabled, because we don't support it in the
+        // bridge (and currently clients seem to not use it when
+        // abs-send-time is available).
+        // a=extmap:2 urn:ietf:params:rtp-hdrext:toffset
+        //RTPHdrExtPacketExtension toOffset
+        //    = new RTPHdrExtPacketExtension();
+        //toOffset.setID("2");
+        //toOffset.setURI(
+        //    URI.create("urn:ietf:params:rtp-hdrext:toffset"));
+        //rtpDesc.addExtmap(toOffset);
+
+        // a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+        RTPHdrExtPacketExtension absSendTime
+            = new RTPHdrExtPacketExtension();
+        absSendTime.setID("3");
+        absSendTime.setURI(URI.create(RTPExtension.ABS_SEND_TIME_URN));
+        rtpDesc.addExtmap(absSendTime);
+
+        // a=rtpmap:100 VP8/90000
+        int vp8pt = 100;
+        PayloadTypePacketExtension vp8
+            = new PayloadTypePacketExtension();
+        vp8.setId(vp8pt);
+        vp8.setName(Constants.VP8);
+        vp8.setClockrate(90000);
+        rtpDesc.addPayloadType(vp8);
+
+        // a=rtpmap:96 rtx/90000
+        PayloadTypePacketExtension rtx
+            = new PayloadTypePacketExtension();
+        rtx.setId(96);
+        rtx.setName(Constants.RTX);
+        rtx.setClockrate(90000);
+        rtpDesc.addPayloadType(rtx);
+
+        // a=fmtp:96 apt=100
+        ParameterPacketExtension rtxApt
+            = new ParameterPacketExtension();
+        rtxApt.setName("apt");
+        rtxApt.setValue(String.valueOf(vp8pt));
+        vp8.addParameter(rtxApt);
+
+        // a=rtcp-fb:100 ccm fir
+        RtcpFbPacketExtension ccmFir = new RtcpFbPacketExtension();
+        ccmFir.setFeedbackType("ccm");
+        ccmFir.setFeedbackSubtype("fir");
+        vp8.addRtcpFeedbackType(ccmFir);
+
+        // a=rtcp-fb:100 nack
+        RtcpFbPacketExtension nack = new RtcpFbPacketExtension();
+        nack.setFeedbackType("nack");
+        vp8.addRtcpFeedbackType(nack);
+
+        // a=rtcp-fb:100 nack pli
+        RtcpFbPacketExtension nackPli = new RtcpFbPacketExtension();
+        nackPli.setFeedbackType("nack");
+        nackPli.setFeedbackSubtype("pli");
+        vp8.addRtcpFeedbackType(nackPli);
+
+        // a=rtcp-fb:100 goog-remb
+        RtcpFbPacketExtension remb = new RtcpFbPacketExtension();
+        remb.setFeedbackType("goog-remb");
+        vp8.addRtcpFeedbackType(remb);
+
+        // a=rtpmap:116 red/90000
+        PayloadTypePacketExtension red
+            = new PayloadTypePacketExtension();
+        red.setId(116);
+        red.setName("red");
+        red.setClockrate(90000);
+        rtpDesc.addPayloadType(red);
+
+        // a=rtpmap:117 ulpfec/90000
+        PayloadTypePacketExtension ulpfec
+            = new PayloadTypePacketExtension();
+        ulpfec.setId(117);
+        ulpfec.setName("ulpfec");
+        ulpfec.setClockrate(90000);
+        rtpDesc.addPayloadType(ulpfec);
+
+        content.addChildExtension(rtpDesc);
+    }
+
+    /**
+     * Adds the video-related extensions for an offer to a
+     * {@link ContentPacketExtension}.
+     * @param content the {@link ContentPacketExtension} to add extensions to.
+     */
+    private static void addAudioToContent(ContentPacketExtension content)
+    {
+        RtpDescriptionPacketExtension rtpDesc
+            = new RtpDescriptionPacketExtension();
+
+        rtpDesc.setMedia("audio");
+
+        RTPHdrExtPacketExtension ssrcAudioLevel
+            = new RTPHdrExtPacketExtension();
+        ssrcAudioLevel.setID("1");
+        ssrcAudioLevel.setURI(URI.create(RTPExtension.SSRC_AUDIO_LEVEL_URN));
+        rtpDesc.addExtmap(ssrcAudioLevel);
+        RTPHdrExtPacketExtension absSendTime
+                = new RTPHdrExtPacketExtension();
+        absSendTime.setID("3");
+        absSendTime.setURI(URI.create(RTPExtension.ABS_SEND_TIME_URN));
+        rtpDesc.addExtmap(absSendTime);
+
+        // a=rtpmap:111 opus/48000/2
+        PayloadTypePacketExtension opus
+            = new PayloadTypePacketExtension();
+        opus.setId(111);
+        opus.setName("opus");
+        opus.setClockrate(48000);
+        opus.setChannels(2);
+        rtpDesc.addPayloadType(opus);
+
+        // fmtp:111 minptime=10
+        ParameterPacketExtension opusMinptime
+            = new ParameterPacketExtension();
+        opusMinptime.setName("minptime");
+        opusMinptime.setValue("10");
+        opus.addParameter(opusMinptime);
+        ParameterPacketExtension opusFec
+                = new ParameterPacketExtension();
+        opusFec.setName("useinbandfec");
+        opusFec.setValue("1");
+        opus.addParameter(opusFec);
+
+        // a=rtpmap:103 ISAC/16000
+        PayloadTypePacketExtension isac16
+            = new PayloadTypePacketExtension();
+        isac16.setId(103);
+        isac16.setName("ISAC");
+        isac16.setClockrate(16000);
+        rtpDesc.addPayloadType(isac16);
+
+        // a=rtpmap:104 ISAC/32000
+        PayloadTypePacketExtension isac32
+            = new PayloadTypePacketExtension();
+        isac32.setId(104);
+        isac32.setName("ISAC");
+        isac32.setClockrate(32000);
+        rtpDesc.addPayloadType(isac32);
+
+        // a=rtpmap:0 PCMU/8000
+        PayloadTypePacketExtension pcmu
+            = new PayloadTypePacketExtension();
+        pcmu.setId(0);
+        pcmu.setName("PCMU");
+        pcmu.setClockrate(8000);
+        rtpDesc.addPayloadType(pcmu);
+
+        // a=rtpmap:8 PCMA/8000
+        PayloadTypePacketExtension pcma
+            = new PayloadTypePacketExtension();
+        pcma.setId(8);
+        pcma.setName("PCMA");
+        pcma.setClockrate(8000);
+        rtpDesc.addPayloadType(pcma);
+
+        // a=rtpmap:106 CN/32000
+        PayloadTypePacketExtension cn
+            = new PayloadTypePacketExtension();
+        cn.setId(106);
+        cn.setName("CN");
+        cn.setClockrate(32000);
+        rtpDesc.addPayloadType(cn);
+
+        // a=rtpmap:105 CN/16000
+        PayloadTypePacketExtension cn16
+            = new PayloadTypePacketExtension();
+        cn16.setId(105);
+        cn16.setName("CN");
+        cn16.setClockrate(16000);
+        rtpDesc.addPayloadType(cn16);
+
+        // a=rtpmap:13 CN/8000
+        PayloadTypePacketExtension cn8
+            = new PayloadTypePacketExtension();
+        cn8.setId(13);
+        cn8.setName("CN");
+        cn8.setClockrate(8000);
+        rtpDesc.addPayloadType(cn8);
+
+        // rtpmap:126 telephone-event/8000
+        PayloadTypePacketExtension teleEvent
+            = new PayloadTypePacketExtension();
+        teleEvent.setId(126);
+        teleEvent.setName("telephone-event");
+        teleEvent.setClockrate(8000);
+        rtpDesc.addPayloadType(teleEvent);
+
+        // a=maxptime:60
+        rtpDesc.setAttribute("maxptime", "60");
+        content.addChildExtension(rtpDesc);
     }
 }

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -20,6 +20,7 @@ package org.jitsi.jicofo.util;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 
 import org.jitsi.service.neomedia.*;
+import org.jitsi.service.neomedia.codec.*;
 
 import java.net.*;
 
@@ -85,6 +86,7 @@ public class JingleOfferFactory
             opus.setClockrate(48000);
             opus.setChannels(2);
             rtpDesc.addPayloadType(opus);
+
             // fmtp:111 minptime=10
             ParameterPacketExtension opusMinptime
                 = new ParameterPacketExtension();
@@ -96,6 +98,7 @@ public class JingleOfferFactory
             opusFec.setName("useinbandfec");
             opusFec.setValue("1");
             opus.addParameter(opusFec);
+
             // a=rtpmap:103 ISAC/16000
             PayloadTypePacketExtension isac16
                 = new PayloadTypePacketExtension();
@@ -103,6 +106,7 @@ public class JingleOfferFactory
             isac16.setName("ISAC");
             isac16.setClockrate(16000);
             rtpDesc.addPayloadType(isac16);
+
             // a=rtpmap:104 ISAC/32000
             PayloadTypePacketExtension isac32
                 = new PayloadTypePacketExtension();
@@ -110,6 +114,7 @@ public class JingleOfferFactory
             isac32.setName("ISAC");
             isac32.setClockrate(32000);
             rtpDesc.addPayloadType(isac32);
+
             // a=rtpmap:0 PCMU/8000
             PayloadTypePacketExtension pcmu
                 = new PayloadTypePacketExtension();
@@ -117,6 +122,7 @@ public class JingleOfferFactory
             pcmu.setName("PCMU");
             pcmu.setClockrate(8000);
             rtpDesc.addPayloadType(pcmu);
+
             // a=rtpmap:8 PCMA/8000
             PayloadTypePacketExtension pcma
                 = new PayloadTypePacketExtension();
@@ -124,6 +130,7 @@ public class JingleOfferFactory
             pcma.setName("PCMA");
             pcma.setClockrate(8000);
             rtpDesc.addPayloadType(pcma);
+
             // a=rtpmap:106 CN/32000
             PayloadTypePacketExtension cn
                 = new PayloadTypePacketExtension();
@@ -131,6 +138,7 @@ public class JingleOfferFactory
             cn.setName("CN");
             cn.setClockrate(32000);
             rtpDesc.addPayloadType(cn);
+
             // a=rtpmap:105 CN/16000
             PayloadTypePacketExtension cn16
                 = new PayloadTypePacketExtension();
@@ -138,6 +146,7 @@ public class JingleOfferFactory
             cn16.setName("CN");
             cn16.setClockrate(16000);
             rtpDesc.addPayloadType(cn16);
+
             // a=rtpmap:13 CN/8000
             PayloadTypePacketExtension cn8
                 = new PayloadTypePacketExtension();
@@ -145,6 +154,7 @@ public class JingleOfferFactory
             cn8.setName("CN");
             cn8.setClockrate(8000);
             rtpDesc.addPayloadType(cn8);
+
             // rtpmap:126 telephone-event/8000
             PayloadTypePacketExtension teleEvent
                 = new PayloadTypePacketExtension();
@@ -152,6 +162,7 @@ public class JingleOfferFactory
             teleEvent.setName("telephone-event");
             teleEvent.setClockrate(8000);
             rtpDesc.addPayloadType(teleEvent);
+
             // a=maxptime:60
             rtpDesc.setAttribute("maxptime", "60");
             content.addChildExtension(rtpDesc);
@@ -180,31 +191,53 @@ public class JingleOfferFactory
             absSendTime.setID("3");
             absSendTime.setURI(URI.create(RTPExtension.ABS_SEND_TIME_URN));
             rtpDesc.addExtmap(absSendTime);
+
             // a=rtpmap:100 VP8/90000
+            int vp8pt = 100;
             PayloadTypePacketExtension vp8
                 = new PayloadTypePacketExtension();
-            vp8.setId(100);
-            vp8.setName("VP8");
+            vp8.setId(vp8pt);
+            vp8.setName(Constants.VP8);
             vp8.setClockrate(90000);
             rtpDesc.addPayloadType(vp8);
+
+            // a=rtpmap:96 rtx/90000
+            PayloadTypePacketExtension rtx
+                = new PayloadTypePacketExtension();
+            rtx.setId(96);
+            rtx.setName(Constants.RTX);
+            rtx.setClockrate(90000);
+            rtpDesc.addPayloadType(rtx);
+
+            // a=fmtp:96 apt=100
+            ParameterPacketExtension rtxApt
+                = new ParameterPacketExtension();
+            rtxApt.setName("apt");
+            rtxApt.setValue(String.valueOf(vp8pt));
+            vp8.addParameter(rtxApt);
+
             // a=rtcp-fb:100 ccm fir
             RtcpFbPacketExtension ccmFir = new RtcpFbPacketExtension();
             ccmFir.setFeedbackType("ccm");
             ccmFir.setFeedbackSubtype("fir");
             vp8.addRtcpFeedbackType(ccmFir);
+
             // a=rtcp-fb:100 nack
             RtcpFbPacketExtension nack = new RtcpFbPacketExtension();
             nack.setFeedbackType("nack");
             vp8.addRtcpFeedbackType(nack);
+
             // a=rtcp-fb:100 nack pli
             RtcpFbPacketExtension nackPli = new RtcpFbPacketExtension();
             nackPli.setFeedbackType("nack");
             nackPli.setFeedbackSubtype("pli");
             vp8.addRtcpFeedbackType(nackPli);
+
             // a=rtcp-fb:100 goog-remb
             RtcpFbPacketExtension remb = new RtcpFbPacketExtension();
             remb.setFeedbackType("goog-remb");
             vp8.addRtcpFeedbackType(remb);
+
             // a=rtpmap:116 red/90000
             PayloadTypePacketExtension red
                 = new PayloadTypePacketExtension();
@@ -212,6 +245,7 @@ public class JingleOfferFactory
             red.setName("red");
             red.setClockrate(90000);
             rtpDesc.addPayloadType(red);
+
             // a=rtpmap:117 ulpfec/90000
             PayloadTypePacketExtension ulpfec
                 = new PayloadTypePacketExtension();

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -141,66 +141,81 @@ public class JingleOfferFactory
         // a=rtpmap:100 VP8/90000
         int vp8pt = 100;
         PayloadTypePacketExtension vp8
-            = new PayloadTypePacketExtension();
-        vp8.setId(vp8pt);
-        vp8.setName(Constants.VP8);
-        vp8.setClockrate(90000);
-        rtpDesc.addPayloadType(vp8);
+            = addPayloadTypeExtension(rtpDesc, vp8pt, Constants.VP8, 90000);
+
+        // a=rtcp-fb:100 ccm fir
+        vp8.addRtcpFeedbackType(createRtcpFbPacketExtension("ccm", "fir"));
+
+        // a=rtcp-fb:100 nack
+        vp8.addRtcpFeedbackType(createRtcpFbPacketExtension("nack", null));
+
+        // a=rtcp-fb:100 nack pli
+        vp8.addRtcpFeedbackType(createRtcpFbPacketExtension("nack", "pli"));
+
+        // a=rtcp-fb:100 goog-remb
+        vp8.addRtcpFeedbackType(createRtcpFbPacketExtension("goog-remb", null));
 
         // a=rtpmap:96 rtx/90000
         PayloadTypePacketExtension rtx
-            = new PayloadTypePacketExtension();
-        rtx.setId(96);
-        rtx.setName(Constants.RTX);
-        rtx.setClockrate(90000);
-        rtpDesc.addPayloadType(rtx);
+            = addPayloadTypeExtension(rtpDesc, 96, Constants.RTX, 90000);
 
         // a=fmtp:96 apt=100
         ParameterPacketExtension rtxApt
             = new ParameterPacketExtension();
         rtxApt.setName("apt");
         rtxApt.setValue(String.valueOf(vp8pt));
-        vp8.addParameter(rtxApt);
-
-        // a=rtcp-fb:100 ccm fir
-        RtcpFbPacketExtension ccmFir = new RtcpFbPacketExtension();
-        ccmFir.setFeedbackType("ccm");
-        ccmFir.setFeedbackSubtype("fir");
-        vp8.addRtcpFeedbackType(ccmFir);
-
-        // a=rtcp-fb:100 nack
-        RtcpFbPacketExtension nack = new RtcpFbPacketExtension();
-        nack.setFeedbackType("nack");
-        vp8.addRtcpFeedbackType(nack);
-
-        // a=rtcp-fb:100 nack pli
-        RtcpFbPacketExtension nackPli = new RtcpFbPacketExtension();
-        nackPli.setFeedbackType("nack");
-        nackPli.setFeedbackSubtype("pli");
-        vp8.addRtcpFeedbackType(nackPli);
-
-        // a=rtcp-fb:100 goog-remb
-        RtcpFbPacketExtension remb = new RtcpFbPacketExtension();
-        remb.setFeedbackType("goog-remb");
-        vp8.addRtcpFeedbackType(remb);
+        rtx.addParameter(rtxApt);
 
         // a=rtpmap:116 red/90000
-        PayloadTypePacketExtension red
-            = new PayloadTypePacketExtension();
-        red.setId(116);
-        red.setName("red");
-        red.setClockrate(90000);
-        rtpDesc.addPayloadType(red);
+        addPayloadTypeExtension(rtpDesc, 116, Constants.RED, 90000);
 
         // a=rtpmap:117 ulpfec/90000
-        PayloadTypePacketExtension ulpfec
-            = new PayloadTypePacketExtension();
-        ulpfec.setId(117);
-        ulpfec.setName("ulpfec");
-        ulpfec.setClockrate(90000);
-        rtpDesc.addPayloadType(ulpfec);
+        addPayloadTypeExtension(rtpDesc, 117, Constants.ULPFEC, 90000);
 
         content.addChildExtension(rtpDesc);
+    }
+
+    /**
+     * Creates an {@link RtcpFbPacketExtension} with the given type and subtype.
+     * @return the created extension.
+     */
+    private static RtcpFbPacketExtension createRtcpFbPacketExtension(
+        String type, String subtype)
+    {
+        RtcpFbPacketExtension rtcpFb = new RtcpFbPacketExtension();
+        if (type != null)
+        {
+            rtcpFb.setFeedbackType(type);
+        }
+        if (subtype != null)
+        {
+            rtcpFb.setFeedbackSubtype(subtype);
+        }
+
+        return rtcpFb;
+    }
+
+    /**
+     * Adds a {@link PayloadTypePacketExtension} to a
+     * {@link RtpDescriptionPacketExtension}.
+     * @param rtpDesc the {@link RtpDescriptionPacketExtension} to add to.
+     * @param id the ID of the {@link PayloadTypePacketExtension}.
+     * @param name the name of the {@link PayloadTypePacketExtension}.
+     * @param clockRate the clock rate of the {@link PayloadTypePacketExtension}.
+     * @return the added {@link PayloadTypePacketExtension}.
+     */
+    private static PayloadTypePacketExtension addPayloadTypeExtension(
+        RtpDescriptionPacketExtension rtpDesc, int id, String name,
+        int clockRate)
+    {
+        PayloadTypePacketExtension payloadTypePacketExtension
+            = new PayloadTypePacketExtension();
+        payloadTypePacketExtension.setId(id);
+        payloadTypePacketExtension.setName(name);
+        payloadTypePacketExtension.setClockrate(clockRate);
+
+        rtpDesc.addPayloadType(payloadTypePacketExtension);
+        return payloadTypePacketExtension;
     }
 
     /**
@@ -228,12 +243,8 @@ public class JingleOfferFactory
 
         // a=rtpmap:111 opus/48000/2
         PayloadTypePacketExtension opus
-            = new PayloadTypePacketExtension();
-        opus.setId(111);
-        opus.setName("opus");
-        opus.setClockrate(48000);
+            = addPayloadTypeExtension(rtpDesc, 111, Constants.OPUS, 48000);
         opus.setChannels(2);
-        rtpDesc.addPayloadType(opus);
 
         // fmtp:111 minptime=10
         ParameterPacketExtension opusMinptime
@@ -248,68 +259,28 @@ public class JingleOfferFactory
         opus.addParameter(opusFec);
 
         // a=rtpmap:103 ISAC/16000
-        PayloadTypePacketExtension isac16
-            = new PayloadTypePacketExtension();
-        isac16.setId(103);
-        isac16.setName("ISAC");
-        isac16.setClockrate(16000);
-        rtpDesc.addPayloadType(isac16);
+        addPayloadTypeExtension(rtpDesc, 103, "ISAC", 16000);
 
         // a=rtpmap:104 ISAC/32000
-        PayloadTypePacketExtension isac32
-            = new PayloadTypePacketExtension();
-        isac32.setId(104);
-        isac32.setName("ISAC");
-        isac32.setClockrate(32000);
-        rtpDesc.addPayloadType(isac32);
+        addPayloadTypeExtension(rtpDesc, 104, "ISAC", 32000);
 
         // a=rtpmap:0 PCMU/8000
-        PayloadTypePacketExtension pcmu
-            = new PayloadTypePacketExtension();
-        pcmu.setId(0);
-        pcmu.setName("PCMU");
-        pcmu.setClockrate(8000);
-        rtpDesc.addPayloadType(pcmu);
+        addPayloadTypeExtension(rtpDesc, 0, "PCMU", 8000);
 
         // a=rtpmap:8 PCMA/8000
-        PayloadTypePacketExtension pcma
-            = new PayloadTypePacketExtension();
-        pcma.setId(8);
-        pcma.setName("PCMA");
-        pcma.setClockrate(8000);
-        rtpDesc.addPayloadType(pcma);
+        addPayloadTypeExtension(rtpDesc, 8, "PCMA", 8000);
 
         // a=rtpmap:106 CN/32000
-        PayloadTypePacketExtension cn
-            = new PayloadTypePacketExtension();
-        cn.setId(106);
-        cn.setName("CN");
-        cn.setClockrate(32000);
-        rtpDesc.addPayloadType(cn);
+        addPayloadTypeExtension(rtpDesc, 106, "CN", 32000);
 
         // a=rtpmap:105 CN/16000
-        PayloadTypePacketExtension cn16
-            = new PayloadTypePacketExtension();
-        cn16.setId(105);
-        cn16.setName("CN");
-        cn16.setClockrate(16000);
-        rtpDesc.addPayloadType(cn16);
+        addPayloadTypeExtension(rtpDesc, 105, "CN", 16000);
 
         // a=rtpmap:13 CN/8000
-        PayloadTypePacketExtension cn8
-            = new PayloadTypePacketExtension();
-        cn8.setId(13);
-        cn8.setName("CN");
-        cn8.setClockrate(8000);
-        rtpDesc.addPayloadType(cn8);
+        addPayloadTypeExtension(rtpDesc, 13, "CN", 8000);
 
         // rtpmap:126 telephone-event/8000
-        PayloadTypePacketExtension teleEvent
-            = new PayloadTypePacketExtension();
-        teleEvent.setId(126);
-        teleEvent.setName("telephone-event");
-        teleEvent.setClockrate(8000);
-        rtpDesc.addPayloadType(teleEvent);
+        addPayloadTypeExtension(rtpDesc, 126, Constants.TELEPHONE_EVENT, 8000);
 
         // a=maxptime:60
         rtpDesc.setAttribute("maxptime", "60");

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -166,6 +166,21 @@ public class JingleOfferFactory
         rtxApt.setValue(String.valueOf(vp8pt));
         rtx.addParameter(rtxApt);
 
+        // Chrome doesn't have these when it creates an offer, but they were
+        // observed in a hangouts conference. Not sure whether they have any
+        // effect.
+        // a=rtcp-fb:96 ccm fir
+        rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("ccm", "fir"));
+
+        // a=rtcp-fb:96 nack
+        rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("nack", null));
+
+        // a=rtcp-fb:96 nack pli
+        rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("nack", "pli"));
+
+        // a=rtcp-fb:96 goog-remb
+        rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("goog-remb", null));
+
         // a=rtpmap:116 red/90000
         //addPayloadTypeExtension(rtpDesc, 116, Constants.RED, 90000);
 

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -264,21 +264,6 @@ public class JingleOfferFactory
         // a=rtpmap:104 ISAC/32000
         addPayloadTypeExtension(rtpDesc, 104, "ISAC", 32000);
 
-        // a=rtpmap:0 PCMU/8000
-        addPayloadTypeExtension(rtpDesc, 0, "PCMU", 8000);
-
-        // a=rtpmap:8 PCMA/8000
-        addPayloadTypeExtension(rtpDesc, 8, "PCMA", 8000);
-
-        // a=rtpmap:106 CN/32000
-        addPayloadTypeExtension(rtpDesc, 106, "CN", 32000);
-
-        // a=rtpmap:105 CN/16000
-        addPayloadTypeExtension(rtpDesc, 105, "CN", 16000);
-
-        // a=rtpmap:13 CN/8000
-        addPayloadTypeExtension(rtpDesc, 13, "CN", 8000);
-
         // rtpmap:126 telephone-event/8000
         addPayloadTypeExtension(rtpDesc, 126, Constants.TELEPHONE_EVENT, 8000);
 

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -49,7 +49,8 @@ public class JingleOfferFactory
      *         used in initial conference offer.
      */
     public static ContentPacketExtension createContentForMedia(
-            MediaType mediaType, boolean disableIce, boolean useDtls)
+            MediaType mediaType, boolean disableIce,
+            boolean useDtls, boolean useRtx)
     {
         ContentPacketExtension content
             = new ContentPacketExtension(
@@ -66,7 +67,7 @@ public class JingleOfferFactory
         }
         else if (mediaType == MediaType.VIDEO)
         {
-            addVideoToContent(content);
+            addVideoToContent(content, useRtx);
         }
         else if (mediaType == MediaType.DATA)
         {
@@ -113,7 +114,8 @@ public class JingleOfferFactory
      * {@link ContentPacketExtension}.
      * @param content the {@link ContentPacketExtension} to add extensions to.
      */
-    private static void addVideoToContent(ContentPacketExtension content)
+    private static void addVideoToContent(ContentPacketExtension content,
+                                          boolean useRtx)
     {
         RtpDescriptionPacketExtension rtpDesc
             = new RtpDescriptionPacketExtension();
@@ -155,31 +157,35 @@ public class JingleOfferFactory
         // a=rtcp-fb:100 goog-remb
         vp8.addRtcpFeedbackType(createRtcpFbPacketExtension("goog-remb", null));
 
-        // a=rtpmap:96 rtx/90000
-        PayloadTypePacketExtension rtx
-            = addPayloadTypeExtension(rtpDesc, 96, Constants.RTX, 90000);
+        if (useRtx)
+        {
+            // a=rtpmap:96 rtx/90000
+            PayloadTypePacketExtension rtx
+                = addPayloadTypeExtension(rtpDesc, 96, Constants.RTX, 90000);
 
-        // a=fmtp:96 apt=100
-        ParameterPacketExtension rtxApt
-            = new ParameterPacketExtension();
-        rtxApt.setName("apt");
-        rtxApt.setValue(String.valueOf(vp8pt));
-        rtx.addParameter(rtxApt);
+            // a=fmtp:96 apt=100
+            ParameterPacketExtension rtxApt
+                = new ParameterPacketExtension();
+            rtxApt.setName("apt");
+            rtxApt.setValue(String.valueOf(vp8pt));
+            rtx.addParameter(rtxApt);
 
-        // Chrome doesn't have these when it creates an offer, but they were
-        // observed in a hangouts conference. Not sure whether they have any
-        // effect.
-        // a=rtcp-fb:96 ccm fir
-        rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("ccm", "fir"));
+            // Chrome doesn't have these when it creates an offer, but they were
+            // observed in a hangouts conference. Not sure whether they have any
+            // effect.
+            // a=rtcp-fb:96 ccm fir
+            rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("ccm", "fir"));
 
-        // a=rtcp-fb:96 nack
-        rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("nack", null));
+            // a=rtcp-fb:96 nack
+            rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("nack", null));
 
-        // a=rtcp-fb:96 nack pli
-        rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("nack", "pli"));
+            // a=rtcp-fb:96 nack pli
+            rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("nack", "pli"));
 
-        // a=rtcp-fb:96 goog-remb
-        rtx.addRtcpFeedbackType(createRtcpFbPacketExtension("goog-remb", null));
+            // a=rtcp-fb:96 goog-remb
+            rtx.addRtcpFeedbackType(
+                createRtcpFbPacketExtension("goog-remb", null));
+        }
 
         // a=rtpmap:116 red/90000
         //addPayloadTypeExtension(rtpDesc, 116, Constants.RED, 90000);

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -167,10 +167,10 @@ public class JingleOfferFactory
         rtx.addParameter(rtxApt);
 
         // a=rtpmap:116 red/90000
-        addPayloadTypeExtension(rtpDesc, 116, Constants.RED, 90000);
+        //addPayloadTypeExtension(rtpDesc, 116, Constants.RED, 90000);
 
         // a=rtpmap:117 ulpfec/90000
-        addPayloadTypeExtension(rtpDesc, 117, Constants.ULPFEC, 90000);
+        //addPayloadTypeExtension(rtpDesc, 117, Constants.ULPFEC, 90000);
 
         content.addChildExtension(rtpDesc);
     }


### PR DESCRIPTION
Cleans up JingleOfferFactory. Removes RED, ULPFEC and some unused audio formats from the offer, and adds RTX. RTX is optionally disabled on a per-conference basis by setting disableRtx=true in the conference creation request (or adding #config.disableRtx=true to the URL in Jitsi-Meet).

Note: this needs jitsi-videobridge#209 (not directly, but stuff will be broken without it).