### PR TITLE
Fix broken FF support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20160331.193913-13</version>
+      <version>2.9-20160406.213445-14</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -184,6 +184,8 @@ public class ColibriConferenceImpl
             if (logger.isDebugEnabled())
                 logger.debug(Thread.currentThread() + " sending alloc request");
 
+            logRequest("Channel allocate request", allocateRequest);
+
             // FIXME retry allocation on timeout ?
             Packet response = sendAllocRequest(endpointName, allocateRequest);
 


### PR DESCRIPTION
- update jitsi-protocol-jabber to fix RTP description updates(Firefox support was broken because of that)
- log in debug mode Colibri "channel allocate request"