### PR TITLE
Simplify 'source-remove' notification

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -1169,6 +1169,14 @@ public class JitsiMeetConference
         ssrcsToRemove = removedSSRCs;
         ssrcGroupsToRemove = removedGroups;
 
+        // We remove all ssrc params from SourcePacketExtension as we want
+        // the client to simply remove all lines corresponding to given SSRC and
+        // not care about parameter's values we send.
+        // Some params might get out of sync for various reasons like for
+        // example Chrome coming up with 'default' value for missing 'mslabel'
+        // or when we'll be doing lip-sync stream merge
+        SSRCSignaling.deleteSSRCParams(ssrcsToRemove);
+
         // Updates SSRC Groups on the bridge
         ColibriConference colibriConference = this.colibriConference;
         // We may hit null here during conference restart, but that's not

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
@@ -24,6 +24,8 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.jitsimeet.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 
+import org.jivesoftware.smack.packet.*;
+
 import java.util.*;
 
 /**
@@ -52,6 +54,37 @@ public class SSRCSignaling
         {
             dstParam.setValue(srcParam.getValue());
         }
+    }
+
+    /**
+     * Call will remove all {@link ParameterPacketExtension}s from all
+     * <tt>SourcePacketExtension</tt>s stored in given <tt>MediaSSRCMap</tt>.
+     *
+     * @param ssrcMap the <tt>MediaSSRCMap</tt> which contains the SSRC packet
+     * extensions to be stripped out of their parameters.
+     */
+    public static void deleteSSRCParams(MediaSSRCMap ssrcMap)
+    {
+        for (String media : ssrcMap.getMediaTypes())
+        {
+            for (SourcePacketExtension ssrc : ssrcMap.getSSRCsForMedia(media))
+            {
+                deleteSSRCParams(ssrc);
+            }
+        }
+    }
+
+    /**
+     * Removes all child <tt>ParameterPacketExtension</tt>s from given
+     * <tt>SourcePacketExtension</tt>.
+     *
+     * @param ssrcPe the instance of <tt>SourcePacketExtension</tt> which will
+     * be stripped off all parameters.
+     */
+    public static void deleteSSRCParams(SourcePacketExtension ssrcPe)
+    {
+        List<? extends PacketExtension> peList = ssrcPe.getChildExtensions();
+        peList.removeAll(ssrcPe.getParameters());
     }
 
     /**


### PR DESCRIPTION
SSRC parameters are no longer included in removed SSRC's
description as we don't want the clients to care about them.