### PR TITLE
Avoid NPE when XMPP response is null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jicoco</artifactId>
-      <version>1.0-20160307.212517-27</version>
+      <version>1.0-20160420.185019-32</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -24,6 +24,8 @@ import net.java.sip.communicator.service.protocol.event.*;
 import net.java.sip.communicator.util.Logger;
 
 import org.jitsi.protocol.xmpp.*;
+import org.jitsi.xmpp.util.*;
+
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.packet.*;
 import org.jivesoftware.smackx.*;
@@ -674,13 +676,13 @@ public class ChatRoomImpl
                 = provider.getConnectionAdapter();
 
         IQ reply = (IQ) connection.sendPacketAndGetReply(admin);
-        if (reply.getType() != IQ.Type.RESULT)
+        if (reply == null || reply.getType() != IQ.Type.RESULT)
         {
             // FIXME: we should have checked exceptions for all operations in
             // ChatRoom interface which are expected to fail.
             // OperationFailedException maybe ?
             throw new RuntimeException(
-                    "Failed to grant owner: " + reply.getError());
+                    "Failed to grant owner: " + IQUtils.responseToXML(reply));
         }
     }
 

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -28,6 +28,7 @@ import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.protocol.xmpp.util.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
+import org.jitsi.xmpp.util.*;
 
 import org.jivesoftware.smack.packet.*;
 
@@ -354,7 +355,7 @@ public class ColibriConferenceImpl
         if (!logger.isDebugEnabled())
             return;
 
-        String responseXml = response != null ? response.toXML() : "TIMEOUT";
+        String responseXml = IQUtils.responseToXML(response);
 
         responseXml = responseXml.replace(">",">\n");
 

--- a/src/main/java/org/jitsi/jicofo/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/JvbDoctor.java
@@ -29,6 +29,7 @@ import org.jitsi.jicofo.osgi.*;
 import org.jitsi.osgi.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.util.Logger;
+import org.jitsi.xmpp.util.*;
 
 import org.jivesoftware.smack.packet.*;
 
@@ -472,9 +473,7 @@ public class JvbDoctor
 
                 logger.debug(
                         "Health check response from: " + bridgeJid + ": "
-                            + (response == null
-                                ? "timeout"
-                                : response.toXML()));
+                            + IQUtils.responseToXML(response));
 
                 if (!(response instanceof IQ))
                 {

--- a/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
+++ b/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
@@ -338,10 +338,19 @@ public class MeetExtensionsHandler
         IQ reply
             = (IQ) smackXmpp.getXmppConnection().sendPacketAndGetReply(dialIq);
 
-        // Send Jigasi response back to the client
-        reply.setFrom(null);
-        reply.setTo(from);
-        reply.setPacketID(originalPacketId);
+        if (reply != null)
+        {
+            // Send Jigasi response back to the client
+            reply.setFrom(null);
+            reply.setTo(from);
+            reply.setPacketID(originalPacketId);
+        }
+        else
+        {
+            reply = createErrorResponse(
+                    dialIq,
+                    new XMPPError(XMPPError.Condition.remote_server_timeout));
+        }
 
         smackXmpp.getXmppConnection().sendPacket(reply);
     }

--- a/src/main/java/org/jitsi/jicofo/discovery/DiscoveryUtil.java
+++ b/src/main/java/org/jitsi/jicofo/discovery/DiscoveryUtil.java
@@ -23,6 +23,7 @@ import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.util.*;
 
 import org.jitsi.protocol.xmpp.*;
+import org.jitsi.xmpp.util.*;
 
 import org.jivesoftware.smack.packet.*;
 
@@ -180,8 +181,7 @@ public class DiscoveryUtil
                 logger.error(
                         "Failed to discover version, req: " + versionIq.toXML()
                             + ", response: "
-                            + (response != null ?
-                            response.toXML() : "null(timeout)"));
+                            + IQUtils.responseToXML(response));
             }
         }
         return null;

--- a/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
@@ -23,6 +23,7 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.Colibri
 import org.jitsi.jicofo.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.util.*;
+import org.jitsi.xmpp.util.*;
 
 import org.jivesoftware.smack.packet.*;
 
@@ -142,7 +143,8 @@ public class JireconRecorder
             }
             else
             {
-                logger.error("Unexpected response: " + reply.toXML());
+                logger.error(
+                        "Unexpected response: " + IQUtils.responseToXML(reply));
             }
         }
         else if (isRecording() && doRecord.equals(State.OFF))

--- a/src/main/java/org/jitsi/jicofo/recording/JvbRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/JvbRecorder.java
@@ -22,6 +22,7 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.Colibri
 import net.java.sip.communicator.util.*;
 
 import org.jitsi.protocol.xmpp.*;
+import org.jitsi.xmpp.util.*;
 
 import org.jivesoftware.smack.packet.*;
 
@@ -101,8 +102,7 @@ public class JvbRecorder
         Packet reply
             = xmpp.getXmppConnection()
                     .sendPacketAndGetReply(toggleRecordingIq);
-        logger.info("REC reply received: "
-            + (reply != null ? reply.toXML() : "timeout"));
+        logger.info("REC reply received: " + IQUtils.responseToXML(reply));
         if (reply instanceof ColibriConferenceIQ)
         {
             ColibriConferenceIQ colibriReply = (ColibriConferenceIQ) reply;
@@ -123,8 +123,8 @@ public class JvbRecorder
         else
         {
             logger.error(
-                conferenceId
-                    + " unexpected response received: " + reply.toXML());
+                    conferenceId + " unexpected response received: "
+                        + IQUtils.responseToXML(reply));
         }
         return true;
     }

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -27,6 +27,7 @@ import org.jitsi.jicofo.*;
 import org.jitsi.jicofo.recording.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.util.*;
+import org.jitsi.xmpp.util.*;
 
 import org.jivesoftware.smack.packet.*;
 
@@ -289,7 +290,8 @@ public class JibriRecorder
                 = (IQ) xmpp.getXmppConnection()
                         .sendPacketAndGetReply(startIq);
 
-            logger.debug("Start response: " + startReply.toXML());
+            logger.debug(
+                    "Start response: " + IQUtils.responseToXML(startReply));
 
             if (startReply == null)
             {
@@ -492,9 +494,7 @@ public class JibriRecorder
             = (IQ) xmpp.getXmppConnection()
                     .sendPacketAndGetReply(stopRequest);
 
-        logger.debug(
-                "Stop response: "
-                    + (stopReply != null ? stopReply.toXML() : "timeout"));
+        logger.debug("Stop response: " + IQUtils.responseToXML(stopReply));
 
         if (stopReply == null)
         {


### PR DESCRIPTION
This PR uses IQUtils to print response XML to handle "null" response case. It also bumps Jicoco version which will result in having some other changes merged like InfluxDb version upgrade.