### PR TITLE
Lipsync

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
@@ -198,9 +198,19 @@ public class ChatMemberImpl
      *
      * @param presence the instance of <tt>Presence</tt> packet extension sent
      *                 by this chat member.
+     *
+     * @throws IllegalArgumentException if given <tt>Presence</tt> does not
+     *         belong to this <tt>ChatMemberImpl</tt>.
      */
     void processPresence(Presence presence)
     {
+        if (!address.equals(presence.getFrom()))
+        {
+            throw new IllegalArgumentException(
+                    String.format("Presence for another member: %s, my jid: %s",
+                            presence.getFrom(), address));
+        }
+
         this.presence = presence;
 
         VideoMutedExtension videoMutedExt
@@ -220,5 +230,15 @@ public class ChatMemberImpl
                 videoMuted = newStatus;
             }
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString()
+    {
+        return String.format(
+                "ChatMember[%s, jid: %s]@%s", address, memberJid, hashCode());
     }
 }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -917,17 +917,17 @@ public class ChatRoomImpl
         implements ParticipantStatusListener
     {
         @Override
-        public void joined(String participant)
+        public void joined(String mucJid)
         {
             synchronized (members)
             {
                 if (logger.isDebugEnabled())
                 {
-                    logger.debug("Joined " + participant + " room: " + roomName);
+                    logger.debug("Joined " + mucJid + " room: " + roomName);
                 }
                 //logger.info(Thread.currentThread()+"JOINED ROOM: "+participant);
 
-                ChatMemberImpl member = addMember(participant);
+                ChatMemberImpl member = addMember(mucJid);
                 if (member == null)
                 {
                     logger.error("member is NULL");
@@ -945,14 +945,22 @@ public class ChatRoomImpl
                     return;
                 }
 
-                // Try to process presence cached in the roster to init fields
-                // like video muted
+                // Process presence cached in the roster to init fields
+                // like video muted etc.
                 Roster roster = connection.getRoster();
-                Presence cachedPresence
-                    = roster.getPresence(member.getContactAddress());
+                Presence cachedPresence = roster.getPresenceResource(mucJid);
                 if (cachedPresence != null)
                 {
+                    logger.debug(
+                            String.format(
+                                    "Initial presence for: %s, P: %s",
+                                    mucJid, cachedPresence.toXML()));
+
                     member.processPresence(cachedPresence);
+                }
+                else
+                {
+                    logger.error("No initial presence for: " + mucJid);
                 }
 
                 // Trigger participant "joined"

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -122,12 +122,6 @@ public class ChannelAllocator implements Runnable
                 OperationSetJitsiMeetTools.class);
     }
 
-    private OperationSetJingle getJingle()
-    {
-        return meetConference.getXmppProvider().getOperationSet(
-                OperationSetJingle.class);
-    }
-
     /**
      * Entry point for <tt>ChannelAllocator</tt> task.
      */
@@ -220,10 +214,11 @@ public class ChannelAllocator implements Runnable
         }
         else
         {
+            OperationSetJingle jingle = meetConference.getJingle();
             boolean ack;
             if (!reInvite)
             {
-                ack = getJingle().initiateSession(
+                ack = jingle.initiateSession(
                         newParticipant.hasBundleSupport(),
                         address,
                         offer,
@@ -232,7 +227,7 @@ public class ChannelAllocator implements Runnable
             }
             else
             {
-                ack = getJingle().replaceTransport(
+                ack = jingle.replaceTransport(
                         newParticipant.hasBundleSupport(),
                         newParticipant.getJingleSession(),
                         offer,

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -263,6 +263,11 @@ public class JitsiMeetConference
             jingle
                 = protocolProviderHandler.getOperationSet(
                         OperationSetJingle.class);
+
+            // Wraps OperationSetJingle in order to introduce
+            // our nasty "lip-sync" hack
+            jingle = new LipSyncHack(this, jingle);
+
             chatOpSet
                 = protocolProviderHandler.getOperationSet(
                         OperationSetMultiUserChat.class);

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -266,7 +266,10 @@ public class JitsiMeetConference
 
             // Wraps OperationSetJingle in order to introduce
             // our nasty "lip-sync" hack
-            jingle = new LipSyncHack(this, jingle);
+            if (getGlobalConfig().isLipSyncEnabled())
+            {
+                jingle = new LipSyncHack(this, jingle);
+            }
 
             chatOpSet
                 = protocolProviderHandler.getOperationSet(

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -883,9 +883,12 @@ public class JitsiMeetConference
         participant.addSSRCsFromContent(answer);
         participant.addSSRCGroupsFromContent(answer);
 
+        MediaSSRCMap peerSSRCs = participant.getSSRCsCopy();
+        MediaSSRCGroupMap peerGroupsMap = participant.getSSRCGroupsCopy();
+
         logger.info(
                 "Received SSRCs from " + peerJingleSessionAddress + " "
-                    + participant.getSSRCS());
+                    + peerSSRCs);
 
         // Update channel info
         if (colibriConference != null)
@@ -893,39 +896,14 @@ public class JitsiMeetConference
             colibriConference.updateChannelsInfo(
                     participant.getColibriChannelsInfo(),
                     participant.getRtpDescriptionMap(),
-                    participant.getSSRCsCopy(),
-                    participant.getSSRCGroupsCopy(),
+                    peerSSRCs,
+                    peerGroupsMap,
                     participant.getBundleTransport(),
                     participant.getTransportMap());
         }
 
-        for (Participant peerToNotify : participants)
-        {
-            JingleSession jingleSessionToNotify
-                = peerToNotify.getJingleSession();
-
-            if (jingleSessionToNotify == null)
-            {
-                logger.warn(
-                        "No jingle session yet for "
-                            + peerToNotify.getChatMember().getContactAddress());
-
-                peerToNotify.scheduleSSRCsToAdd(participant.getSSRCS());
-                peerToNotify.scheduleSSRCGroupsToAdd(
-                        participant.getSSRCGroups());
-
-                continue;
-            }
-
-            // Skip origin
-            if (peerJingleSession.equals(jingleSessionToNotify))
-                continue;
-
-            jingle.sendAddSourceIQ(
-                    participant.getSSRCS(),
-                    participant.getSSRCGroups(),
-                    jingleSessionToNotify);
-        }
+        // Loop over current participant and send 'source-add' notification
+        propagateNewSSRCs(participant, peerSSRCs, peerGroupsMap);
 
         // Notify the peer itself since it is now stable
         if (participant.hasSsrcsToAdd())
@@ -947,6 +925,46 @@ public class JitsiMeetConference
             participant.clearSsrcsToRemove();
         }
     }
+
+    /**
+     * Advertises new SSRCs across all conference participants by using
+     * 'source-add' Jingle notification.
+     *
+     * @param ssrcOwner the <tt>Participant</tt> who owns the SSRCs.
+     * @param ssrcsToAdd the <tt>MediaSSRCMap</tt> with the SSRCs to advertise.
+     * @param ssrcGroupsToAdd the <tt>MediaSSRCGroupMap</tt> with SSRC groups
+     *        to advertise.
+     */
+    private void propagateNewSSRCs(Participant          ssrcOwner,
+                                   MediaSSRCMap         ssrcsToAdd,
+                                   MediaSSRCGroupMap    ssrcGroupsToAdd)
+    {
+        for (Participant peerToNotify : participants)
+        {
+            // Skip origin
+            if (ssrcOwner == peerToNotify)
+                continue;
+
+            JingleSession jingleSessionToNotify
+                = peerToNotify.getJingleSession();
+            if (jingleSessionToNotify == null)
+            {
+                logger.warn(
+                        "No jingle session yet for "
+                            + peerToNotify.getChatMember().getContactAddress());
+
+                peerToNotify.scheduleSSRCsToAdd(ssrcsToAdd);
+
+                peerToNotify.scheduleSSRCGroupsToAdd(ssrcGroupsToAdd);
+
+                continue;
+            }
+
+            jingle.sendAddSourceIQ(
+                    ssrcsToAdd, ssrcGroupsToAdd, jingleSessionToNotify);
+        }
+    }
+
 
     /**
      * Callback called when we receive 'transport-info' from conference
@@ -1082,28 +1100,7 @@ public class JitsiMeetConference
                     participant.getColibriChannelsInfo());
         }
 
-        for (Participant peerToNotify : participants)
-        {
-            if (peerToNotify == participant)
-                continue;
-
-            JingleSession peerJingleSession = peerToNotify.getJingleSession();
-            if (peerJingleSession == null)
-            {
-                logger.warn(
-                        "Add source: no call for "
-                            + peerToNotify.getChatMember().getContactAddress());
-
-                peerToNotify.scheduleSSRCsToAdd(ssrcsToAdd);
-
-                peerToNotify.scheduleSSRCGroupsToAdd(ssrcGroupsToAdd);
-
-                continue;
-            }
-
-            jingle.sendAddSourceIQ(
-                    ssrcsToAdd, ssrcGroupsToAdd, peerJingleSession);
-        }
+        propagateNewSSRCs(participant, ssrcsToAdd, ssrcGroupsToAdd);
     }
 
     /**
@@ -1216,20 +1213,17 @@ public class JitsiMeetConference
     }
 
     /**
-     * Gathers the list of all SSRCs of given media type that exist in current
-     * conference state.
+     * Gathers the list of all SSRCs that exist in the current conference state.
      *
-     * @param media the media type of SSRCs that are being returned.
      * @param except optional <tt>Participant</tt> instance whose SSRCs will be
      *               excluded from the list
      *
-     * @return the list of all SSRCs of given media type that exist in current
-     *         conference state.
+     * @return <tt>MediaSSRCMap</tt> of all SSRCs of given media type that exist
+     * in the current conference state.
      */
-    List<SourcePacketExtension> getAllSSRCs(String         media,
-                                            Participant    except)
+    MediaSSRCMap getAllSSRCs(Participant except)
     {
-        List<SourcePacketExtension> mediaSSRCs = new ArrayList<>();
+        MediaSSRCMap mediaSSRCs = new MediaSSRCMap();
 
         for (Participant peer : participants)
         {
@@ -1237,21 +1231,15 @@ public class JitsiMeetConference
             if (peer == except)
                 continue;
 
-            List<SourcePacketExtension> peerSSRC
-                = peer.getSSRCS().getSSRCsForMedia(media);
-
-            if (peerSSRC != null)
-                mediaSSRCs.addAll(peerSSRC);
+            mediaSSRCs.add(peer.getSSRCsCopy());
         }
 
         return mediaSSRCs;
     }
 
     /**
-     * Gathers the list of all SSRC groups of given media type that exist in
-     * current conference state.
-     *
-     * @param media the media type of SSRC groups that are being returned.
+     * Gathers the list of all SSRC groups that exist in the current conference
+     * state.
      *
      * @param except optional <tt>Participant</tt> instance whose SSRC groups
      *               will be excluded from the list
@@ -1259,10 +1247,9 @@ public class JitsiMeetConference
      * @return the list of all SSRC groups of given media type that exist in
      *         current conference state.
      */
-    List<SourceGroupPacketExtension> getAllSSRCGroups(String         media,
-                                                      Participant    except)
+    MediaSSRCGroupMap getAllSSRCGroups(Participant except)
     {
-        List<SourceGroupPacketExtension> ssrcGroups = new ArrayList<>();
+        MediaSSRCGroupMap ssrcGroups = new MediaSSRCGroupMap();
 
         for (Participant peer : participants)
         {
@@ -1270,19 +1257,7 @@ public class JitsiMeetConference
             if (peer == except)
                 continue;
 
-            List<SSRCGroup> peerSSRCGroups = peer.getSSRCGroupsForMedia(media);
-
-            for (SSRCGroup ssrcGroup : peerSSRCGroups)
-            {
-                try
-                {
-                    ssrcGroups.add(ssrcGroup.getExtensionCopy());
-                }
-                catch (Exception e)
-                {
-                    logger.error("Error copying source group extension", e);
-                }
-            }
+            ssrcGroups.add(peer.getSSRCGroupsCopy());
         }
 
         return ssrcGroups;

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -1317,6 +1317,15 @@ public class JitsiMeetConference
     }
 
     /**
+     * Returns <tt>OperationSetJingle</tt> for the XMPP connection used in this
+     * <tt>JitsiMeetConference</tt> instance.
+     */
+    public OperationSetJingle getJingle()
+    {
+        return jingle;
+    }
+
+    /**
      * Returns {@link JitsiMeetServices} instance used in this conference.
      */
     public JitsiMeetServices getServices()

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetGlobalConfig.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetGlobalConfig.java
@@ -36,6 +36,12 @@ public class JitsiMeetGlobalConfig
         = Logger.getLogger(JitsiMeetGlobalConfig.class);
 
     /**
+     * The name of configuration property that enables the {@link LipSyncHack}.
+     */
+    private final static String ENABLE_LIPSYNC_CONFIG_PNAME
+        = "org.jitsi.jicofo.ENABLE_LIPSYNC";
+
+    /**
      * The name of configuration property that sets {@link #maxSSRCsPerUser}.
      */
     private final static String MAX_SSRC_PER_USER_CONFIG_PNAME
@@ -57,6 +63,11 @@ public class JitsiMeetGlobalConfig
      * The default value for {@link #PENDING_TIMEOUT_PROP_NAME}.
      */
     private static final int DEFAULT_PENDING_TIMEOUT = 30;
+
+    /**
+     * If set to <tt>true</tt> enables {@link LipSyncHack}.
+     */
+    private boolean isLipSyncEnabled;
 
     /**
      * Tells how many seconds we're going to wait for the Jibri to start
@@ -144,6 +155,12 @@ public class JitsiMeetGlobalConfig
         {
             logger.warn("Jibri PENDING timeouts are disabled");
         }
+
+        isLipSyncEnabled
+            = configService.getBoolean(ENABLE_LIPSYNC_CONFIG_PNAME, false);
+
+        if (isLipSyncEnabled)
+            logger.info("Lip-sync hack is enabled !");
     }
 
     /**
@@ -167,6 +184,14 @@ public class JitsiMeetGlobalConfig
     public int getMaxSSRCsPerUser()
     {
         return maxSSRCsPerUser;
+    }
+
+    /**
+     * Returns <tt>true</tt> if {@link LipSyncHack} should be enabled.
+     */
+    public boolean isLipSyncEnabled()
+    {
+        return isLipSyncEnabled;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -1,0 +1,339 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jitsimeet
+          .SSRCInfoPacketExtension;
+import net.java.sip.communicator.util.Logger;
+
+import org.jitsi.protocol.xmpp.*;
+import org.jitsi.protocol.xmpp.util.*;
+import org.jitsi.util.*;
+
+import java.util.*;
+
+/**
+ * Here we're doing audio + video stream merging in order to take advantage
+ * of WebRTC's lip-sync feature.
+ *
+ * In Jitsi-meet we obtain separate audio and video streams and send their SSRC
+ * description to Jicofo which then propagates that to other conference
+ * participants. Because they are separate stream, the WebRTC stack wil not try
+ * to synchronize audio and video streams which will often result in bad user
+ * experience.
+ *
+ * We are not merging the streams on the client which would result in all
+ * clients receiving them merged, because of few issues:
+ * 1. Chrome will not play audio for such merged stream if the user has video
+ *    muted: https://bugs.chromium.org/p/chromium/issues/detail?id=403710
+ *    So we will only merge the stream if the owner has his video unmuted at
+ *    the time when it's being advertised to other participant. This is subject
+ *    to some race conditions and will not always work. That's why this hack is
+ *    not enabled by default.
+ * 2. We need separate streams for doing video mute and screen streaming. When
+ *    video is being muted it's stream is being removed and added on unmute. And
+ *    when we're doing screen streaming the video stream is replaced with the
+ *    screen one. Now when the stream is merged audio and video are becoming
+ *    tracks of the same stream and on the client side we need to be able to see
+ *    when they change. Unfortunately "track added" and "track removed" events
+ *    are only supported by Chrome. Firefox will display the video fine after
+ *    track change, but there will be no event, Temasys has no events and track
+ *    changes are not supported.
+ *
+ * The class wraps {@link OperationSetJingle} and modifies some of the request
+ * in order to do stream merging when it's needed.
+ *
+ * @author Pawel Domas
+ */
+public class LipSyncHack implements OperationSetJingle
+{
+    /**
+     * The logger used in <tt>LipSyncHack</tt>.
+     */
+    static private final Logger logger = Logger.getLogger(LipSyncHack.class);
+
+    /**
+     * Parent conference for which this instance is doing stream merging.
+     */
+    private final JitsiMeetConference conference;
+
+    /**
+     * Underlying Jingle operation set.
+     */
+    private final OperationSetJingle jingleImpl;
+
+    /**
+     * Creates new instance of <tt>LipSyncHack</tt> for given conference.
+     *
+     * @param conference parent <tt>JitsiMeetConference</tt> for which this
+     *        instance will be doing lip-sync hack.
+     * @param jingleImpl the Jingle operations set that will be wrapped in order
+     *        to modify some of the Jingle requests.
+     */
+    public LipSyncHack(JitsiMeetConference    conference,
+                       OperationSetJingle     jingleImpl)
+    {
+        this.conference = conference;
+        this.jingleImpl = jingleImpl;
+    }
+
+    private MediaSSRCMap getParticipantSSRCMap(String mucJid)
+    {
+        Participant p = conference.findParticipantForRoomJid(mucJid);
+        if (p == null)
+        {
+            logger.warn("No participant found for: " + mucJid);
+            // Return empty to avoid null checks
+            return new MediaSSRCMap();
+        }
+        return p.getSSRCsCopy();
+    }
+
+    /**
+     * Decides whether or not it's ok to merge streams sent from one participant
+     * to another.
+     *
+     * @param participantJid the MUC JID of the participant to whom we're going
+     *        to send stream info.
+     * @param ownerJid the MUC JID of the owner of the streams which are to be
+     *        advertised to given <tt>participantJid</tt>
+     *
+     * @return <tt>true</tt> if it's OK to merge audio+video streams or
+     *         <tt>false</tt> otherwise.
+     */
+    private boolean isOkToMergeParticipantAV(String    participantJid,
+                                             String    ownerJid)
+    {
+        Participant participant
+            = conference.findParticipantForRoomJid(participantJid);
+        if (participant == null)
+        {
+            logger.error("No target participant found for: " + participantJid);
+            return false;
+        }
+
+        Participant streamsOwner
+            = conference.findParticipantForRoomJid(ownerJid);
+        if (streamsOwner == null)
+        {
+            logger.error(
+                    "Stream owner not a participant or not found for jid: "
+                        + ownerJid);
+            return false;
+        }
+
+        Boolean isVideoMuted = streamsOwner.isVideoMuted();
+        if (isVideoMuted == null)
+        {
+            logger.warn("No 'videomuted' presence extension for " + ownerJid);
+        }
+
+        boolean supportsLipSync = participant.hasLipSyncSupport();
+
+        // FIXME switch to debug level after some more testing
+        logger.info(String.format(
+                "Lips-sync From %s to %s, lip-sync: %s, video muted: %s",
+                participantJid, ownerJid, supportsLipSync, isVideoMuted));
+
+        return supportsLipSync && Boolean.FALSE.equals(isVideoMuted);
+    }
+
+    private void doMerge(String          participant,
+                         String          owner,
+                         MediaSSRCMap    ssrcs)
+    {
+        boolean merged = false;
+        if (isOkToMergeParticipantAV(participant, owner))
+        {
+            merged = SSRCSignaling.mergeVideoIntoAudio(ssrcs);
+        }
+        // FIXME switch to debug level after some more testing
+        logger.info(
+               (merged ? "Merging" : "Not merging")
+                    + " A/V streams from " + owner +" to " + participant);
+    }
+
+    /**
+     * Does the lip-sync processing of given Jingle content list that contains
+     * streams description for the whole conference which are about to be sent
+     * to one of the conference participants. It will do audio and video stream
+     * merging for the purpose of enabling lip-sync functionality on the client.
+     *
+     * @param contents a list of Jingle contents which describes audio and video
+     *        streams for the whole conference.
+     * @param mucJid the MUC JID of the participant to whom Jingle notification
+     *        will be sent.
+     */
+    private void processAllParticipantsSSRCs(
+            List<ContentPacketExtension>    contents,
+            String                          mucJid)
+    {
+        // Split into maps on per owner basis
+        Map<String, MediaSSRCMap> perOwnerMapping
+            = SSRCSignaling.ownerMapping(contents);
+
+        for (Map.Entry<String, MediaSSRCMap> ownerSSRCs
+                : perOwnerMapping.entrySet())
+        {
+            String ownerJid = ownerSSRCs.getKey();
+            if (!StringUtils.isNullOrEmpty(ownerJid))
+            {
+                MediaSSRCMap ssrcMap = ownerSSRCs.getValue();
+                if (ssrcMap != null)
+                {
+                    doMerge(mucJid, ownerJid, ssrcMap);
+                }
+                else
+                    logger.error("'ssrcMap' is null");
+            }
+            else
+                logger.warn("'owner' is null");
+        }
+    }
+
+    /**
+     * The <tt>LipSyncHack</tt> will attempt to merge all video streams into
+     * corresponding audio streams. A corresponding stream is the one that
+     * belongs to the same participant which we figure out by checking 'owner'
+     * included {@link SSRCInfoPacketExtension}. Once the processing is done
+     * the job is passed to the underlying Jingle operation set to send
+     * the notification.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean initiateSession(
+            boolean                         useBundle,
+            String                          address,
+            List<ContentPacketExtension>    contents,
+            JingleRequestHandler            requestHandler,
+            boolean[]                       startMuted)
+    {
+        processAllParticipantsSSRCs(contents, address);
+
+        return jingleImpl.initiateSession(
+                useBundle, address, contents, requestHandler, startMuted);
+    }
+
+    /**
+     * We're doing the same thing as in {@link #initiateSession}. So go there
+     * for more docs.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean replaceTransport(
+            boolean                         useBundle,
+            JingleSession                   session,
+            List<ContentPacketExtension>    contents,
+            boolean[]                       startMuted)
+    {
+        processAllParticipantsSSRCs(contents, session.getAddress());
+
+        return jingleImpl.replaceTransport(
+                useBundle, session, contents, startMuted);
+    }
+
+    /**
+     * We'll attempt to merge any video into the corresponding audio stream
+     * (figured out by stream 'owner'). If given notification contains only
+     * video SSRC we'll look up global conference state held by
+     * {@link JitsiMeetConference} in order to find the matching audio stream.
+     *
+     * After the processing the job is passed to the underlying Jingle operation
+     * set to send the request.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendAddSourceIQ(
+            MediaSSRCMap        ssrcMap,
+            MediaSSRCGroupMap   ssrcGroupMap,
+            JingleSession       session)
+    {
+        String mucJid = session.getAddress();
+        // If this is source add for video only then add audio for merge process
+        for (SourcePacketExtension videoSSRC
+                : ssrcMap.getSSRCsForMedia("video"))
+        {
+            String owner = SSRCSignaling.getSSRCOwner(videoSSRC);
+            SourcePacketExtension audioSSRC
+                = ssrcMap.findSSRCforOwner("audio", owner);
+            if (audioSSRC == null)
+            {
+                // Try finding corresponding audio from the global conference
+                // state for this owner
+                MediaSSRCMap allOwnersSSRCs = getParticipantSSRCMap(owner);
+                List<SourcePacketExtension> audioSSRCs
+                    = allOwnersSSRCs.getSSRCsForMedia("audio");
+                audioSSRC = SSRCSignaling.getFirstWithMSID(audioSSRCs);
+            }
+            if (audioSSRC != null)
+            {
+                ssrcMap.addSSRC("audio", audioSSRC);
+                doMerge(mucJid, owner, ssrcMap);
+                ssrcMap.remove("audio", audioSSRC);
+            }
+            else
+            {
+                logger.warn("No corresponding audio found for: " + owner
+                            + " 'source-add' to: " + mucJid);
+            }
+        }
+        jingleImpl.sendAddSourceIQ(ssrcMap, ssrcGroupMap, session);
+    }
+
+    /**
+     * We don't have to do anything special in 'source-remove' as long as we're
+     * sending "simple" notification which does not include SSRC parameters, but
+     * just the SSRC value. The client should remove all lines corresponding to
+     * the SSRC. Otherwise we would have to keep the track of stuff we send to
+     * each participant, as it will get out of sync with global conference state
+     * held in {@link JitsiMeetConference} after a stream is merged.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendRemoveSourceIQ(
+            MediaSSRCMap        ssrcMap,
+            MediaSSRCGroupMap   ssrcGroupMap,
+            JingleSession       session)
+    {
+        jingleImpl.sendRemoveSourceIQ(ssrcMap, ssrcGroupMap, session);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void terminateSession(JingleSession session, Reason reason)
+    {
+        jingleImpl.terminateSession(session, reason);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void terminateHandlersSessions(JingleRequestHandler requestHandler)
+    {
+        jingleImpl.terminateHandlersSessions(requestHandler);
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -429,6 +429,15 @@ public class Participant
     }
 
     /**
+     * Returns <tt>true</tt> if this participant supports 'lip-sync' or
+     * <tt>false</tt> otherwise.
+     */
+    public boolean hasLipSyncSupport()
+    {
+        return supportedFeatures.contains(DiscoveryUtil.FEATURE_LIPSYNC);
+    }
+
+    /**
      * Returns {@code true} iff this participant supports RTX.
      */
     public boolean hasRtxSupport()

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -291,19 +291,11 @@ public class Participant
     }
 
     /**
-     * Returns the {@link MediaSSRCMap} which contains this peer's media SSRCs.
-     */
-    public MediaSSRCMap getSSRCS()
-    {
-        return ssrcs;
-    }
-
-    /**
-     * Returns shallow copy of this peer's media SSRC map.
+     * Returns deep copy of this peer's media SSRC map.
      */
     public MediaSSRCMap getSSRCsCopy()
     {
-        return ssrcs.copyShallow();
+        return ssrcs.copyDeep();
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -512,6 +512,16 @@ public class Participant
     }
 
     /**
+     * Return a <tt>Boolean</tt> which informs about this participant's video
+     * muted status. The <tt>null</tt> value stands for 'unknown'/not signalled,
+     * <tt>true</tt> for muted and <tt>false</tt> means unmuted.
+     */
+    public Boolean isVideoMuted()
+    {
+        return roomMember.hasVideoMuted();
+    }
+
+    /**
      * Returns the list of SSRC groups of given media type that belong ot this
      * participant.
      * @param media the name of media type("audio","video", ...)

--- a/src/main/java/org/jitsi/jicofo/discovery/DiscoveryUtil.java
+++ b/src/main/java/org/jitsi/jicofo/discovery/DiscoveryUtil.java
@@ -98,6 +98,14 @@ public class DiscoveryUtil
     public final static String FEATURE_HEALTH_CHECK = HealthCheckIQ.NAMESPACE;
 
     /**
+     * A namespace for our custom "lip-sync" feature. Advertised by the clients
+     * that support all of the functionality required for doing the lip-sync
+     * properly.
+     */
+    public final static String FEATURE_LIPSYNC
+        = "http://jitsi.org/meet/lipsync";
+
+    /**
      * Array constant which can be used to check for Version IQ support.
      */
     public final static String[] VERSION_FEATURES = new String[]

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -168,7 +168,7 @@ public abstract class AbstractOperationSetJingle
     }
 
     /**
-     * Determines whether a specific {@limk JingleSession} has been accepted by
+     * Determines whether a specific {@link JingleSession} has been accepted by
      * the client judging by a specific {@code reply} {@link IQ} (received in
      * reply to an invite IQ sent withing the specified {@code JingleSession}).
      *

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -294,7 +294,6 @@ public abstract class AbstractOperationSetJingle
         switch (action)
         {
         case SESSION_ACCEPT:
-            logger.info(session.getAddress() + " real jid: " + iq.getFrom());
             requestHandler.onSessionAccept(session, iq.getContentList());
             break;
         case TRANSPORT_ACCEPT:

--- a/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCMap.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCMap.java
@@ -242,7 +242,8 @@ public class MediaSSRCMap
      */
     public boolean remove(String media, SourcePacketExtension ssrc)
     {
-        return getSSRCsForMedia(media).remove(ssrc);
+        SourcePacketExtension toBeRemoved = findSSRC(media, ssrc.getSSRC());
+        return toBeRemoved != null && getSSRCsForMedia(media).remove(ssrc);
     }
 
     /**

--- a/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCMap.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCMap.java
@@ -123,6 +123,35 @@ public class MediaSSRCMap
     }
 
     /**
+     * Creates a deep copy of this <tt>MediaSSRCMap</tt>.
+     *
+     * @return a new instance of <tt>MediaSSRCMap</tt> which contains copies of
+     *         <tt>SourcePacketExtension</tt> stored in this map.
+     */
+    public MediaSSRCMap copyDeep()
+    {
+        Map<String, List<SourcePacketExtension>> mapCopy = new HashMap<>();
+
+        for (String media : ssrcs.keySet())
+        {
+            List<SourcePacketExtension> mediaSSRCs
+                = ssrcs.get(media);
+
+            List<SourcePacketExtension> SSRCsCopy
+                = new ArrayList<>(mediaSSRCs.size());
+
+            for (SourcePacketExtension ssrc : mediaSSRCs)
+            {
+                SSRCsCopy.add(ssrc.copy());
+            }
+
+            mapCopy.put(media, SSRCsCopy);
+        }
+
+        return new MediaSSRCMap(mapCopy);
+    }
+
+    /**
      * Looks for SSRC in this map.
      *
      * @param media the name of media type of the SSRC we're looking for.
@@ -139,6 +168,27 @@ public class MediaSSRCMap
         for (SourcePacketExtension ssrc : getSSRCsForMedia(media))
         {
             if (ssrcValue == ssrc.getSSRC())
+                return ssrc;
+        }
+        return null;
+    }
+
+    /**
+     * Finds SSRC for given owner.
+     *
+     * @param media the media type of the SSRC we'll be looking for.
+     * @param owner the MUC JID  of the SSRC owner.
+     *
+     * @return <tt>SourcePacketExtension</tt> for given media type and owner or
+     *         <tt>null</tt> if not found.
+     */
+    public SourcePacketExtension findSSRCforOwner(String media, String owner)
+    {
+        List<SourcePacketExtension> mediaSSRCs = getSSRCsForMedia(media);
+        for (SourcePacketExtension ssrc : mediaSSRCs)
+        {
+            String ssrcOwner = SSRCSignaling.getSSRCOwner(ssrc);
+            if (ssrcOwner != null && ssrcOwner.equals(owner))
                 return ssrc;
         }
         return null;
@@ -181,25 +231,18 @@ public class MediaSSRCMap
     }
 
     /**
-     * Returns shallow copy of this map. <tt>SourcePacketExtension</tt>
-     * instances are not copied, but referenced from both copy and this
-     * instance.
+     * Removes given SSRC from this map.
+     *
+     * @param media the media type of the SSRC to be removed.
+     * @param ssrc the <tt>SourcePacketExtension</tt> to be removed from this
+     *        <tt>MediaSSRCMap</tt>.
+     *
+     * @return <tt>true</tt> if the SSRC has been actually removed which means
+     *         that it was in the map before the operation took place.
      */
-    public MediaSSRCMap copyShallow()
+    public boolean remove(String media, SourcePacketExtension ssrc)
     {
-        Map<String, List<SourcePacketExtension>> mapCopy = new HashMap<>();
-
-        for (Map.Entry<String, List<SourcePacketExtension>> e
-                : ssrcs.entrySet())
-        {
-            String media = e.getKey();
-            List<SourcePacketExtension> listCopy
-                = new ArrayList<>(e.getValue());
-
-            mapCopy.put(media, listCopy);
-        }
-
-        return new MediaSSRCMap(mapCopy);
+        return getSSRCsForMedia(media).remove(ssrc);
     }
 
     /**

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCGroup.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCGroup.java
@@ -114,6 +114,15 @@ public class SSRCGroup
     }
 
     /**
+     * Returns the underlying <tt>SourceGroupPacketExtension</tt> wrapped by
+     * this <tt>SSRCGroup</tt> instance.
+     */
+    public SourceGroupPacketExtension getPacketExtension()
+    {
+        return group;
+    }
+
+    /**
      * Returns full copy of this <tt>SSRCGroup</tt>.
      */
     public SSRCGroup copy()

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
@@ -238,6 +238,45 @@ public class SSRCSignaling
         return true;
     }
 
+    /**
+     * Does map the SSRCs found in given Jingle content list on per owner basis.
+     *
+     * @param contents the Jingle contents list that describes media SSRCs.
+     *
+     * @return a <tt>Map<String,MediaSSRCMap></tt> which is the SSRC to owner
+     *         mapping of the SSRCs contained in given Jingle content list.
+     *         An owner comes form the {@link SSRCInfoPacketExtension} included
+     *         as a child of the {@link SourcePacketExtension}.
+     */
+    public static Map<String, MediaSSRCMap> ownerMapping(
+            List<ContentPacketExtension> contents)
+    {
+        Map<String, MediaSSRCMap> ownerMapping = new HashMap<>();
+        for (ContentPacketExtension content : contents)
+        {
+            String media = content.getName();
+            MediaSSRCMap mediaSSRCMap
+                = MediaSSRCMap.getSSRCsFromContent(contents);
+
+            for (SourcePacketExtension ssrc
+                    : mediaSSRCMap.getSSRCsForMedia(media))
+            {
+                String owner = getSSRCOwner(ssrc);
+                MediaSSRCMap ownerMap = ownerMapping.get(owner);
+
+                // Create if not found
+                if (ownerMap == null)
+                {
+                    ownerMap = new MediaSSRCMap();
+                    ownerMapping.put(owner, ownerMap);
+                }
+
+                ownerMap.addSSRC(media, ssrc);
+            }
+        }
+        return ownerMapping;
+    }
+
     public static void setSSRCOwner(SourcePacketExtension ssrcPe, String owner)
     {
         SSRCInfoPacketExtension ssrcInfo

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
@@ -102,9 +102,9 @@ public class SSRCSignaling
     {
         for (SourcePacketExtension ssrc : ssrcs)
         {
-            String videoStreamId = getStreamId(ssrc);
-            if (videoStreamId != null
-                    && !"default".equalsIgnoreCase(videoStreamId))
+            String streamId = getStreamId(ssrc);
+            if (streamId != null
+                    && !"default".equalsIgnoreCase(streamId))
             {
                 return ssrc;
             }
@@ -189,12 +189,15 @@ public class SSRCSignaling
     }
 
     /**
-     * Merges first audio SSRC into the first video stream described by
-     * <tt>MediaSSRCMap</tt>.
+     * Merges the first valid video stream into the first valid audio stream
+     * described in <tt>MediaSSRCMap</tt>. A valid media stream is the one that
+     * has well defined "stream ID" as in the description of
+     * {@link #getFirstWithMSID(List)} method.
      *
      * @param peerSSRCs the map of media SSRC to be modified.
      *
-     * @return <tt>true</tt> if streams were merged.
+     * @return <tt>true</tt> if the streams have been merged or <tt>false</tt>
+     * otherwise.
      */
     public static boolean mergeVideoIntoAudio(MediaSSRCMap peerSSRCs)
     {


### PR DESCRIPTION
Adds a LipSync hack which will selectively merge audio and video streams to enable lipsync in WebRTC stack on the client. Currently this will be enabled for Chrome clients only, given that at the time of SSRC advertisement(joining the conference) remote participant has not his video muted.