### PR TITLE
Jibri busy and error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20160505.143533-15</version>
+      <version>2.9-20160513.193145-16</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20160513.193145-16</version>
+      <version>2.9-20160519.122058-17</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetGlobalConfig.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetGlobalConfig.java
@@ -56,13 +56,13 @@ public class JitsiMeetGlobalConfig
      * The name of the config property which specifies how long we're going to
      * wait for Jibri to start recording from the time it accepted START request
      */
-    private static final String PENDING_TIMEOUT_PROP_NAME
+    private static final String JIBRI_PENDING_TIMEOUT_PROP_NAME
         = "org.jitsi.jicofo.jibri.PENDING_TIMEOUT";
 
     /**
-     * The default value for {@link #PENDING_TIMEOUT_PROP_NAME}.
+     * The default value for {@link #JIBRI_PENDING_TIMEOUT_PROP_NAME}.
      */
-    private static final int DEFAULT_PENDING_TIMEOUT = 90;
+    private static final int JIBRI_DEFAULT_PENDING_TIMEOUT = 90;
 
     /**
      * If set to <tt>true</tt> enables {@link LipSyncHack}.
@@ -143,7 +143,8 @@ public class JitsiMeetGlobalConfig
 
         jibriPendingTimeout
             = configService.getInt(
-                    PENDING_TIMEOUT_PROP_NAME, DEFAULT_PENDING_TIMEOUT);
+                    JIBRI_PENDING_TIMEOUT_PROP_NAME,
+                    JIBRI_DEFAULT_PENDING_TIMEOUT);
 
         if (jibriPendingTimeout > 0)
         {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetGlobalConfig.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetGlobalConfig.java
@@ -62,7 +62,7 @@ public class JitsiMeetGlobalConfig
     /**
      * The default value for {@link #PENDING_TIMEOUT_PROP_NAME}.
      */
-    private static final int DEFAULT_PENDING_TIMEOUT = 30;
+    private static final int DEFAULT_PENDING_TIMEOUT = 90;
 
     /**
      * If set to <tt>true</tt> enables {@link LipSyncHack}.

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
@@ -129,6 +129,16 @@ public class JibriDetector
     }
 
     /**
+     * Checks whether or not there are any Jibri instances connected.
+     * @return <tt>true</tt> if there are any Jibri instances currently
+     * connected to the brewery room or <tt>false</tt> otherwise.
+     */
+    public boolean isAnyJibriConnected()
+    {
+        return jibris.size() > 0;
+    }
+
+    /**
      * Initializes this instance.
      */
     public void init()

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -131,9 +131,7 @@ public class JibriRecorder
 
         jibriDetector.addJibriListener(this);
 
-        setJibriStatus(
-                jibriDetector.selectJibri() != null ?
-                    JibriIq.Status.OFF : JibriIq.Status.UNDEFINED);
+        updateJibriAvailability();
     }
 
     /**
@@ -538,9 +536,18 @@ public class JibriRecorder
      */
     private void updateJibriAvailability()
     {
-        setJibriStatus(
-            jibriDetector.selectJibri() != null
-                ? JibriIq.Status.OFF : JibriIq.Status.UNDEFINED);
+        if (jibriDetector.selectJibri() != null)
+        {
+            setJibriStatus(JibriIq.Status.OFF);
+        }
+        else if (jibriDetector.isAnyJibriConnected())
+        {
+            setJibriStatus(JibriIq.Status.BUSY);
+        }
+        else
+        {
+            setJibriStatus(JibriIq.Status.UNDEFINED);
+        }
     }
 
     @Override

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -428,15 +428,15 @@ public class JibriRecorder
             logger.info("Updating status from Jibri: " + iq.toXML()
                 + " for " + roomName);
 
-            // We stop either on "off" or on "error"
+            // We stop either on "off" or on "failed"
             if ((JibriIq.Status.OFF.equals(status) ||
-                JibriIq.Status.ERROR.equals(status))
+                JibriIq.Status.FAILED.equals(status))
                 && recorderComponentJid != null/* This means we're recording */)
             {
                 logger.info("Recording stopped for: " + roomName);
                 // Make sure that there is XMPPError for ERROR status
                 XMPPError error = iq.getError();
-                if (JibriIq.Status.ERROR.equals(status) && error == null)
+                if (JibriIq.Status.FAILED.equals(status) && error == null)
                 {
                     error = new XMPPError(
                             XMPPError.Condition.interna_server_error,
@@ -543,7 +543,7 @@ public class JibriRecorder
      *
      * @param error if the recording stopped because of an error it should be
      * passed as an argument here which will result in stopping with
-     * the {@link JibriIq.Status#ERROR} status passed to the application.
+     * the {@link JibriIq.Status#FAILED} status passed to the application.
      */
     private void recordingStopped(XMPPError error)
     {
@@ -551,7 +551,7 @@ public class JibriRecorder
         // First we'll send an error and then follow with availability status
         if (error != null)
         {
-            setJibriStatus(JibriIq.Status.ERROR, error);
+            setJibriStatus(JibriIq.Status.FAILED, error);
         }
         // Update based on availability
         updateJibriAvailability();

--- a/src/test/java/org/jitsi/jicofo/FocusTestSuite.java
+++ b/src/test/java/org/jitsi/jicofo/FocusTestSuite.java
@@ -35,6 +35,7 @@ import org.junit.runners.*;
         AuthEventsTest.class,
         ConferenceJsonTest.class,
         ConferenceIqProviderTest.class,
+        JibriIqProviderTest.class,
         JireconIqProviderTest.class,
         JvbDoctorTest.class,
         MuteIqProviderTest.class,

--- a/src/test/java/org/jitsi/jicofo/xmpp/JibriIqProviderTest.java
+++ b/src/test/java/org/jitsi/jicofo/xmpp/JibriIqProviderTest.java
@@ -72,7 +72,7 @@ public class JibriIqProviderTest
         String iqXml =
             "<iq to='t' from='f'>" +
                 "<jibri xmlns='http://jitsi.org/protocol/jibri'" +
-                "       status='error'>" +
+                "       status='failed'>" +
                 "<error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas' " +
                 "       type='wait' code='504'>" +
                 "<remote-server-timeout" +
@@ -86,7 +86,7 @@ public class JibriIqProviderTest
 
         assertNotNull(jibriIq);
 
-        assertEquals(JibriIq.Status.ERROR, jibriIq.getStatus());
+        assertEquals(JibriIq.Status.FAILED, jibriIq.getStatus());
 
         XMPPError error = jibriIq.getError();
         assertNotNull(error);

--- a/src/test/java/org/jitsi/jicofo/xmpp/JibriIqProviderTest.java
+++ b/src/test/java/org/jitsi/jicofo/xmpp/JibriIqProviderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.xmpp;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jibri.*;
+
+import org.jitsi.xmpp.util.*;
+
+import org.jivesoftware.smack.packet.*;
+
+import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Few basic tests for parsing JibriIQ
+ *
+ * @author Pawel Domas
+ */
+@RunWith(JUnit4.class)
+public class JibriIqProviderTest
+{
+    @Test
+    public void testParseIQ()
+        throws Exception
+    {
+        JibriIqProvider provider = new JibriIqProvider();
+
+        // JibriIq
+        String iqXml =
+            "<iq to='t' from='f'>" +
+                "<jibri xmlns='http://jitsi.org/protocol/jibri'" +
+                "       status='busy' action='stop'/>" +
+                "</iq>";
+
+        JibriIq jibriIq = (JibriIq) IQUtils.parse(iqXml, provider);
+
+        assertNotNull(jibriIq);
+
+        assertEquals(JibriIq.Status.BUSY, jibriIq.getStatus());
+        assertEquals(JibriIq.Action.STOP, jibriIq.getAction());
+
+        assertNull(jibriIq.getError());
+    }
+
+    @Test
+    public void testParseError()
+        throws Exception
+    {
+        JibriIqProvider provider = new JibriIqProvider();
+
+        // JibriIq
+        String iqXml =
+            "<iq to='t' from='f'>" +
+                "<jibri xmlns='http://jitsi.org/protocol/jibri'" +
+                "       status='error'>" +
+                "<error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas' " +
+                "       type='wait' code='504'>" +
+                "<remote-server-timeout" +
+                "       xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>" +
+                "<text>Youtube request timeout</text>" +
+                "</error>" +
+                "<jibri/>" +
+                "</iq>";
+
+        JibriIq jibriIq = (JibriIq) IQUtils.parse(iqXml, provider);
+
+        assertNotNull(jibriIq);
+
+        assertEquals(JibriIq.Status.ERROR, jibriIq.getStatus());
+
+        XMPPError error = jibriIq.getError();
+        assertNotNull(error);
+
+        assertEquals(XMPPError.Type.WAIT, error.getType());
+
+        assertEquals(504, error.getCode());
+
+        assertEquals("Youtube request timeout", error.getMessage());
+
+        String condition = error.getCondition();
+
+        assertNotNull(condition);
+
+        assertEquals(
+                XMPPError.Condition.remote_server_timeout.toString(),
+                condition);
+    }
+}


### PR DESCRIPTION
Implements new Jibri states:
- "failed": when Jibri recorder fail with an erron it will send it to Jicofo which will then forward it to the client in the "failed" state
- "busy": when there are Jibris connected to the system, but all are currently in "busy" state then Jicofo will broadcast "busy" state instead of "undefined"