### PR TITLE
Increase default packet timeout to 15 seconds

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
@@ -28,6 +28,8 @@ import net.java.sip.communicator.service.protocol.jabber.*;
 
 import org.jitsi.impl.protocol.xmpp.extensions.*;
 
+import org.jivesoftware.smack.*;
+
 import org.osgi.framework.*;
 
 import java.util.*;
@@ -89,6 +91,8 @@ public class XmppProtocolActivator
         throws Exception
     {
         XmppProtocolActivator.bundleContext = bundleContext;
+
+        SmackConfiguration.setPacketReplyTimeout(15000);
 
         registerXmppExtensions();
 


### PR DESCRIPTION
Seems like the default one equal to 5 seconds will often timeout slower clients on session-invite.