### PR TITLE
Component disconnected

### DIFF
--- a/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
+++ b/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
@@ -631,6 +631,19 @@ public class ComponentsDiscovery
         {
             synchronized (this)
             {
+                // JVB unavailable ?
+                if ("service-unavailable".equals(payload.getElementName()))
+                {
+                    logger.info(
+                            "Service unavailable through PubSub for " + itemId);
+
+                    if (bridgesMap.remove(itemId) != null)
+                    {
+                        bridgeWentOffline(itemId);
+                    }
+                    return;
+                }
+
                 // Potential bridge JID may be carried in item ID
                 verifyJvbJid(itemId);
 

--- a/src/main/java/org/jitsi/jicofo/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/JvbDoctor.java
@@ -376,22 +376,23 @@ public class JvbDoctor
             {
                 // Check if that bridge comes with health check support
                 List<String> jvbFeatures = capsOpSet.getFeatures(bridgeJid);
-                if (jvbFeatures == null)
+                if (jvbFeatures != null)
+                {
+                    hasHealthCheckSupport
+                        = DiscoveryUtil.checkFeatureSupport(
+                                HEALTH_CHECK_FEATURES, jvbFeatures);
+                    if (!hasHealthCheckSupport)
+                    {
+                        logger.warn(
+                                bridgeJid + " does not support health checks!");
+                    }
+                }
+                else
                 {
                     logger.warn(
-                        "Failed to check for health check support on "
-                            + bridgeJid);
-                    return;
+                           "Failed to check for health check support on "
+                               + bridgeJid);
                 }
-                if (!DiscoveryUtil.checkFeatureSupport(
-                    HEALTH_CHECK_FEATURES,
-                    jvbFeatures))
-                {
-                    logger.warn(bridgeJid + " does not support health checks!");
-                    hasHealthCheckSupport = false;
-                }
-                // This JVB supports health checks
-                hasHealthCheckSupport = true;
             }
         }
 


### PR DESCRIPTION
Handles PubSub notification containing <service-unavailable/> element inserted by the Prosody plugin when it detects that the component has been disconnected to react to bridge shutdown/restart faster.