### PR TITLE
Enable the LS hack when video muted.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -139,20 +139,14 @@ public class LipSyncHack implements OperationSetJingle
             return false;
         }
 
-        Boolean isVideoMuted = streamsOwner.isVideoMuted();
-        if (isVideoMuted == null)
-        {
-            logger.warn("No 'videomuted' presence extension for " + ownerJid);
-        }
-
         boolean supportsLipSync = participant.hasLipSyncSupport();
 
         // FIXME switch to debug level after some more testing
         logger.info(String.format(
-                "Lips-sync From %s to %s, lip-sync: %s, video muted: %s",
-                ownerJid, participantJid, supportsLipSync, isVideoMuted));
+                "Lips-sync From %s to %s, lip-sync: %s",
+                ownerJid, participantJid, supportsLipSync));
 
-        return supportsLipSync && Boolean.FALSE.equals(isVideoMuted);
+        return supportsLipSync;
     }
 
     private void doMerge(String          participant,


### PR DESCRIPTION
A complementary hack has been implemented in the JVB which allows to merge the streams, even if the video is muted.

UPDATE: The complementary hack is here https://github.com/jitsi/jitsi-videobridge/pull/277. Please do not merge this until the JVB hack has been merged.