### PR TITLE
fix(ChannelAllocator): reInvite = JingleSession != null

### DIFF
--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -99,20 +99,17 @@ public class ChannelAllocator implements Runnable
      * @param startMuted an array which must have the size of 2 where the first
      * value stands for "start audio muted" and the second one for "video
      * muted". This is to be included in client's offer.
-     * @param reInvite <tt>true</tt> if the offer will be a 're-invite' one or
-     * <tt>false</tt> otherwise.
      */
     public ChannelAllocator(JitsiMeetConference    meetConference,
                             ColibriConference      colibriConference,
                             Participant            newParticipant,
-                            boolean[]              startMuted,
-                            boolean                reInvite)
+                            boolean[]              startMuted)
     {
         this.meetConference = meetConference;
         this.colibriConference = colibriConference;
         this.newParticipant = newParticipant;
         this.startMuted = startMuted;
-        this.reInvite = reInvite;
+        this.reInvite = newParticipant.getJingleSession() != null;
     }
 
     private OperationSetJitsiMeetTools getMeetTools()
@@ -207,8 +204,7 @@ public class ChannelAllocator implements Runnable
         {
             OperationSetJingle jingle = meetConference.getJingle();
             boolean ack;
-            JingleSession jingleSession = newParticipant.getJingleSession();
-            if (!reInvite || jingleSession == null)
+            if (!reInvite)
             {
                 ack = jingle.initiateSession(
                         newParticipant.hasBundleSupport(),
@@ -221,7 +217,7 @@ public class ChannelAllocator implements Runnable
             {
                 ack = jingle.replaceTransport(
                         newParticipant.hasBundleSupport(),
-                        jingleSession,
+                        newParticipant.getJingleSession(),
                         offer,
                         startMuted);
             }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -527,8 +527,7 @@ public class JitsiMeetConference
         // this on separate thread.
         FocusBundleActivator.getSharedThreadPool().submit(
                 new ChannelAllocator(
-                        this, colibriConference, newParticipant,
-                        startMuted, false /* re-invite */));
+                        this, colibriConference, newParticipant, startMuted));
     }
 
     /**
@@ -1530,8 +1529,7 @@ public class JitsiMeetConference
             // this on separate thread.
             FocusBundleActivator.getSharedThreadPool().submit(
                     new ChannelAllocator(
-                            this, colibriConference,
-                            p, startMuted, true /* re-invite */));
+                            this, colibriConference, p, startMuted));
         }
     }
 


### PR DESCRIPTION
If the Participant has JingleSession instance set it means that the
'session-accept' was received and processed already. Initialize
'reInvite' field early to avoid inconsistencies and confusing log
messages about the 'transport-replace' when it is really
the 'session-accept' being sent.
