### PR TITLE
fix(AbstractOperationSetJingle): NegativeArraySizeException

### DIFF
--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -28,6 +28,7 @@ import org.jitsi.protocol.xmpp.util.*;
 import org.jivesoftware.smack.packet.*;
 
 import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Class provides template implementation of {@link OperationSetJingle}.
@@ -47,7 +48,8 @@ public abstract class AbstractOperationSetJingle
     /**
      * The list of active Jingle sessions.
      */
-    protected final Map<String, JingleSession> sessions = new HashMap<>();
+    protected final Map<String, JingleSession> sessions
+        = new ConcurrentHashMap<>();
 
     /**
      * Implementing classes should return our JID here.


### PR DESCRIPTION
When two threads remove Jingle sessions at the same that strange things may happen. Trying to fix:
Jicofo 2016-08-30 07:05:25.911 WARNING: [13] org.jitsi.jicofo.FocusManager.expireLoop().661 Error while checking for timeouted conference
java.lang.NegativeArraySizeException
at java.util.AbstractCollection.toArray(AbstractCollection.java:136)
at java.util.ArrayList.<init>(ArrayList.java:177)
at org.jitsi.protocol.xmpp.AbstractOperationSetJingle.terminateHandlersSessions(AbstractOperationSetJingle.java:540)
at org.jitsi.jicofo.JitsiMeetConference.stop(JitsiMeetConference.java:350)
at org.jitsi.jicofo.FocusManager$FocusExpireThread.expireLoop(FocusManager.java:655)
at org.jitsi.jicofo.FocusManager$FocusExpireThread.access$000(FocusManager.java:543)
at org.jitsi.jicofo.FocusManager$FocusExpireThread$1.run(FocusManager.java:573)
at java.lang.Thread.run(Thread.java:745)