### PR TITLE
fix(MeetExtensionsHandler): fix NPE on get user role

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -846,6 +846,9 @@ public class JitsiMeetConference
 
     public ChatRoomMemberRole getRoleForMucJid(String mucJid)
     {
+        if (chatRoom == null)
+            return null;
+
         for (ChatRoomMember member : chatRoom.getMembers())
         {
             if (member.getContactAddress().equals(mucJid))

--- a/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
+++ b/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
@@ -467,8 +467,14 @@ public class MeetExtensionsHandler
         }
 
         ChatRoomMemberRole role = conference.getRoleForMucJid(from);
+        if (role == null)
+        {
+            logger.warn("Failed to get user's role for: " + from
+                      + " - Jicofo is no longer in the MUC ?");
+            return;
+        }
 
-        if (role != null && role.compareTo(ChatRoomMemberRole.MODERATOR) < 0)
+        if (role.compareTo(ChatRoomMemberRole.MODERATOR) < 0)
         {
             StartMutedPacketExtension ext
                 = (StartMutedPacketExtension)


### PR DESCRIPTION
The conference might have stopped, before PacketListener is executed
and user's MUC role is no longer available. It's fine to just abort the
operation.

Trying to fix:
Jicofo 2016-08-29 20:10:43.041 SEVERE: [36] org.jivesoftware.smack.Connection.notifyListener() null
java.lang.NullPointerException
at org.jitsi.jicofo.JitsiMeetConference.getRoleForMucJid(JitsiMeetConference.java:849)
at org.jitsi.jicofo.MeetExtensionsHandler.handlePresence(MeetExtensionsHandler.java:469)
at org.jitsi.jicofo.MeetExtensionsHandler.processPacket(MeetExtensionsHandler.java:154)
at org.jivesoftware.smack.Connection$ListenerWrapper.notifyListener(Connection.java:867)
at org.jivesoftware.smack.PacketReader$ListenerNotification.run(PacketReader.java:457)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)