### PR TITLE
Less verbose log

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -532,6 +532,12 @@ public class ChatRoomImpl
     }
 
     @Override
+    public String getLocalMucJid()
+    {
+        return myMucAddress;
+    }
+
+    @Override
     public int getMembersCount()
     {
         return muc.getOccupantsCount();

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -32,9 +32,9 @@ import org.jitsi.jicofo.reservation.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.protocol.xmpp.util.*;
-import org.jitsi.util.*;
 import org.jitsi.eventadmin.*;
 
+import org.jitsi.util.*;
 import org.osgi.framework.*;
 
 import java.text.*;
@@ -620,6 +620,21 @@ public class JitsiMeetConference
     boolean isFocusMember(ChatRoomMember member)
     {
         return member.getName().equals(focusUserName);
+    }
+
+    /**
+     * Checks if given MUC jid belongs to the focus user.
+     *
+     * @param mucJid the full MUC address to check.
+     *
+     * @return <tt>true</tt> if given <tt>mucJid</tt> belongs to the focus
+     *         participant or <tt>false</tt> otherwise.
+     */
+    boolean isFocusMember(String mucJid)
+    {
+        ChatRoom2 chatRoom = this.chatRoom;
+        return !StringUtils.isNullOrEmpty(mucJid)
+                && chatRoom != null && mucJid.equals(chatRoom.getLocalMucJid());
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
+++ b/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
@@ -466,15 +466,20 @@ public class MeetExtensionsHandler
             return;
         }
 
+        if (conference.isFocusMember(from))
+            return; // Not interested in local presence
+
         ChatRoomMemberRole role = conference.getRoleForMucJid(from);
         if (role == null)
         {
-            logger.warn("Failed to get user's role for: " + from
-                      + " - Jicofo is no longer in the MUC ?");
-            return;
+            // FIXME this is printed every time new user joins the room, because
+            // PacketListener is fired before MUC knows the user is in the room.
+            // This might be a problem if it would be the only presence ever
+            // received from such participant although very unlikely with
+            // the current client code.
+            logger.warn("Failed to get user's role for: " + from);
         }
-
-        if (role.compareTo(ChatRoomMemberRole.MODERATOR) < 0)
+        else if (role.compareTo(ChatRoomMemberRole.MODERATOR) < 0)
         {
             StartMutedPacketExtension ext
                 = (StartMutedPacketExtension)

--- a/src/main/java/org/jitsi/protocol/xmpp/ChatRoom2.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/ChatRoom2.java
@@ -37,4 +37,10 @@ public interface ChatRoom2
      *         <tt>null</tt> if not found.
      */
     XmppChatMember findChatMember(String mucJid);
+
+    /**
+     * Returns the MUC address of our chat member.
+     * @return our full MUC JID for example: room@conference.server.net/nickname
+     */
+    String getLocalMucJid();
 }

--- a/src/test/java/mock/muc/MockMultiUserChat.java
+++ b/src/test/java/mock/muc/MockMultiUserChat.java
@@ -73,6 +73,12 @@ public class MockMultiUserChat
     }
 
     @Override
+    public String getLocalMucJid()
+    {
+        return me != null ? me.getContactAddress() : null;
+    }
+
+    @Override
     public String getName()
     {
         return roomName;


### PR DESCRIPTION
A continuation of https://github.com/jitsi/jicofo/pull/116
It turns out that the warning added in the previous PR is now logged too often, because it also includes the presence packets of Jicofo itself. This PR will ignore these packets as we're not interested in processing them in the MeetExtensionsHandler.