### PR TITLE
Timeout lonely participant's media session who remain in the MUC

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -335,7 +335,7 @@ public class JitsiMeetConference
         }
         catch(Exception e)
         {
-            this.stop();
+            stop();
 
             throw e;
         }
@@ -598,7 +598,7 @@ public class JitsiMeetConference
 
         if(!startMuted[0])
         {
-            Integer startAudioMuted = this.config.getAudioMuted();
+            Integer startAudioMuted = config.getAudioMuted();
             if(startAudioMuted != null)
             {
                 startMuted[0] = (participantNumber > startAudioMuted);
@@ -607,7 +607,7 @@ public class JitsiMeetConference
 
         if(!startMuted[1])
         {
-            Integer startVideoMuted = this.config.getVideoMuted();
+            Integer startVideoMuted = config.getVideoMuted();
             if(startVideoMuted != null)
             {
                 startMuted[1] = (participantNumber > startVideoMuted);
@@ -1712,9 +1712,9 @@ public class JitsiMeetConference
     private String createSharedDocumentName()
     {
         String sharedDocumentName;
-        if (this.config.useRoomAsSharedDocName())
+        if (config.useRoomAsSharedDocName())
             sharedDocumentName
-                = MucUtil.extractName(this.roomName.toLowerCase());
+                = MucUtil.extractName(roomName.toLowerCase());
         else
            sharedDocumentName
                    = UUID.randomUUID().toString().replaceAll("-", "");
@@ -1727,14 +1727,14 @@ public class JitsiMeetConference
      */
     private void rescheduleSinglePeerTimeout()
     {
-        if (this.executor != null)
+        if (executor != null)
         {
             cancelSinglePeerTimeout();
 
             long timeout = globalConfig.getSingleParticipantTimeout();
 
-            this.singleParticipantTout
-                = this.executor.schedule(
+            singleParticipantTout
+                = executor.schedule(
                         new SinglePersonTimeout(),
                         timeout, TimeUnit.MILLISECONDS);
 

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -748,7 +748,7 @@ public class JitsiMeetConference
             {
                 logger.info("Hanging up member " + contactAddress);
 
-                jingle.terminateSession(peerJingleSession, Reason.GONE);
+                jingle.terminateSession(peerJingleSession, Reason.GONE, null);
 
                 removeSSRCs(
                         peerJingleSession,

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -1731,7 +1731,7 @@ public class JitsiMeetConference
         {
             cancelSinglePeerTimeout();
 
-            long timeout = 5000;
+            long timeout = globalConfig.getSingleParticipantTimeout();
 
             this.singleParticipantTout
                 = this.executor.schedule(

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetGlobalConfig.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetGlobalConfig.java
@@ -48,9 +48,21 @@ public class JitsiMeetGlobalConfig
         = "org.jitsi.jicofo.MAX_SSRC_PER_USER";
 
     /**
+     * The name of configuration property that sets
+     * {@link #singleParticipantTimeout}.
+     */
+    private final static String SINGLE_PARTICIPANT_TIMEOUT_CONFIG_PNAME
+        = "org.jitsi.jicofo.SINGLE_PARTICIPANT_TIMEOUT";
+
+    /**
      * The default value for {@link #maxSSRCsPerUser}.
      */
     private final static int DEFAULT_MAX_SSRC_PER_USER = 20;
+
+    /**
+     * The default value for {@link #singleParticipantTimeout}.
+     */
+    private final static long DEFAULT_SINGLE_PARTICIPANT_TIMEOUT = 20000;
 
     /**
      * The name of the config property which specifies how long we're going to
@@ -83,6 +95,16 @@ public class JitsiMeetGlobalConfig
      * conference participant.
      */
     private int maxSSRCsPerUser;
+
+    /**
+     * Tells how long participant's media session will be kept alive once it
+     * remains the only person in the room - which means that nobody is
+     * receiving his/her media. This participant could be timed out immediately
+     * as well, but we don't want to reallocate channels when the other peer is
+     * only reloading his/her page. The value is amount of time measured in
+     * milliseconds.
+     */
+    private long singleParticipantTimeout;
 
     /**
      * OSGi service registration instance.
@@ -166,6 +188,15 @@ public class JitsiMeetGlobalConfig
         {
             logger.warn("Jibri PENDING timeouts are disabled");
         }
+
+        singleParticipantTimeout
+            = configService.getLong(
+                    SINGLE_PARTICIPANT_TIMEOUT_CONFIG_PNAME,
+                    DEFAULT_SINGLE_PARTICIPANT_TIMEOUT);
+
+        logger.info(
+                "Lonely participants will be \"terminated\" after "
+                    + singleParticipantTimeout +" milliseconds");
     }
 
     /**
@@ -189,6 +220,16 @@ public class JitsiMeetGlobalConfig
     public int getMaxSSRCsPerUser()
     {
         return maxSSRCsPerUser;
+    }
+
+    /**
+     * Gets the value for "single participant timeout".
+     * @return the value in milliseconds.
+     * @see #singleParticipantTimeout
+     */
+    public long getSingleParticipantTimeout()
+    {
+        return singleParticipantTimeout;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -317,9 +317,11 @@ public class LipSyncHack implements OperationSetJingle
      * {@inheritDoc}
      */
     @Override
-    public void terminateSession(JingleSession session, Reason reason)
+    public void terminateSession(JingleSession    session,
+                                 Reason           reason,
+                                 String           msg)
     {
-        jingleImpl.terminateSession(session, reason);
+        jingleImpl.terminateSession(session, reason, msg);
     }
 
     /**

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -545,7 +545,7 @@ public abstract class AbstractOperationSetJingle
         {
             if (session.getRequestHandler() == requestHandler)
             {
-                terminateSession(session, Reason.GONE);
+                terminateSession(session, Reason.GONE, null);
             }
         }
     }
@@ -557,9 +557,12 @@ public abstract class AbstractOperationSetJingle
      * @param session the <tt>JingleSession</tt> to terminate.
      * @param reason one of {@link Reason} enum that indicates why the session
      *               is being ended or <tt>null</tt> to omit.
+     * {@inheritDoc}
      */
     @Override
-    public void terminateSession(JingleSession session, Reason reason)
+    public void terminateSession(JingleSession    session,
+                                 Reason           reason,
+                                 String           message)
     {
         logger.info("Terminate session: " + session.getAddress());
 
@@ -571,7 +574,8 @@ public abstract class AbstractOperationSetJingle
                     getOurJID(),
                     session.getAddress(),
                     session.getSessionID(),
-                    reason, null);
+                    reason,
+                    message);
 
         getConnection().sendPacket(terminate);
 

--- a/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
@@ -111,8 +111,10 @@ public interface OperationSetJingle
      * @param session the <tt>JingleSession</tt> to be terminated.
      * @param reason optional <tt>Reason</tt> specifying the reason of session
      *               termination.
+     * @param message optional text message providing more details about
+     *                the reason for terminating the session.
      */
-    void terminateSession(JingleSession session, Reason reason);
+    void terminateSession(JingleSession session, Reason reason, String message);
 
     /**
      * Terminates all active Jingle Sessions associated with given


### PR DESCRIPTION
After the call ends the person who remains alone in the room will have it's media session expired after 20 seconds to prevent from wasting the bandwidth/resources.