### PR TITLE
Update protocol-jabber to fix capabilities related memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20160708.122741-18</version>
+      <version>2.9-20160907.181747-20</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
EntityCapsManager class was ignoring Presence packets without the 'c'
extension and not cleaning up map entries. The issue occurs when used
with Prosody nightly 683 and later. We don't know the exact version when
the problem started, but 652 was fine.