### PR TITLE
Fix not-well-formed error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20160907.181747-20</version>
+      <version>2.9-20161005.180600-21</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/extensions/AbstractIQ.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/extensions/AbstractIQ.java
@@ -124,6 +124,7 @@ public abstract class AbstractIQ
     {
         if (!StringUtils.isNullOrEmpty(value))
         {
+            value = org.jivesoftware.smack.util.StringUtils.escapeForXML(value);
             out.append(name).append("='").append(value).append("' ");
         }
     }


### PR DESCRIPTION
This PR fixes Jicofo breaking it's own XMPP connection when includes unescaped text in XML attributes of some IQs.