### PR TITLE
No healthcheck logs

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -675,7 +675,7 @@ public class ChatRoomImpl
     @Override
     public void grantOwnership(String address)
     {
-        logger.info("Grant owner to " + address);
+        logger.debug("Grant owner to " + address);
 
         // Have to construct the IQ manually as Smack version used here seems
         // to be using wrong namespace(muc#owner instead of muc#admin)

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -661,7 +661,7 @@ public class ChannelAllocator implements Runnable
                         // Mark 'jvb' as SSRC owner
                         SSRCInfoPacketExtension ssrcInfo
                             = new SSRCInfoPacketExtension();
-                        ssrcInfo.setOwner("jvb");
+                        ssrcInfo.setOwner(SSRCSignaling.SSRC_OWNER_JVB);
                         ssrcCopy.addChildExtension(ssrcInfo);
 
                         rtpDescPe.addChildExtension(ssrcCopy);

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -49,10 +49,18 @@ public class ChannelAllocator implements Runnable
     final static int BRIDGE_FAILURE_ERR_CODE = 20;
 
     /**
-     * The logger instance used in this class.
+     * The class logger which can be used to override logging level inherited
+     * from {@link JitsiMeetConference}.
      */
-    private final static Logger logger
+    private final static Logger classLogger
         = Logger.getLogger(ChannelAllocator.class);
+
+    /**
+     * The logger for this instance. Uses the logging level either of the
+     * {@link #classLogger} or {@link JitsiMeetConference#getLogger()}
+     * whichever is higher.
+     */
+    private final Logger logger;
 
     /**
      * Parent {@link JitsiMeetConference}.
@@ -113,6 +121,7 @@ public class ChannelAllocator implements Runnable
         this.newParticipant = newParticipant;
         this.startMuted = startMuted;
         this.reInvite = reInvite;
+        this.logger = Logger.getLogger(classLogger, meetConference.getLogger());
     }
 
     private OperationSetJitsiMeetTools getMeetTools()

--- a/src/main/java/org/jitsi/jicofo/ChatRoomRoleAndPresence.java
+++ b/src/main/java/org/jitsi/jicofo/ChatRoomRoleAndPresence.java
@@ -20,12 +20,13 @@ package org.jitsi.jicofo;
 import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import net.java.sip.communicator.util.*;
-import net.java.sip.communicator.util.Logger;
+
 import org.jitsi.assertions.*;
 import org.jitsi.jicofo.auth.*;
 import org.jitsi.jicofo.log.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.util.*;
+import org.jitsi.util.Logger;
 import org.jitsi.eventadmin.*;
 
 /**
@@ -43,9 +44,10 @@ public class ChatRoomRoleAndPresence
                AuthenticationListener
 {
     /**
-     * The logger
+     * The class logger which can be used to override logging level inherited
+     * from {@link JitsiMeetConference}.
      */
-    private static final Logger logger
+    private static final Logger classLogger
         = Logger.getLogger(ChatRoomRoleAndPresence.class);
 
     /**
@@ -77,6 +79,13 @@ public class ChatRoomRoleAndPresence
     private boolean autoOwner;
 
     /**
+     * The logger for this instance. Uses the logging level either of the
+     * {@link #classLogger} or {@link JitsiMeetConference#getLogger()}
+     * whichever is higher.
+     */
+    private final Logger logger;
+
+    /**
      * Current owner(other than the focus itself) of Jitsi Meet conference.
      */
     private ChatRoomMember owner;
@@ -89,6 +98,7 @@ public class ChatRoomRoleAndPresence
 
         this.conference = conference;
         this.chatRoom = chatRoom;
+        this.logger = Logger.getLogger(classLogger, conference.getLogger());
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -22,7 +22,6 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import net.java.sip.communicator.util.*;
-import net.java.sip.communicator.util.Logger;
 
 import org.jitsi.assertions.*;
 import org.jitsi.impl.protocol.xmpp.extensions.*;
@@ -35,11 +34,13 @@ import org.jitsi.protocol.xmpp.util.*;
 import org.jitsi.eventadmin.*;
 
 import org.jitsi.util.*;
+import org.jitsi.util.Logger;
 import org.osgi.framework.*;
 
 import java.text.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.logging.*;
 
 /**
  * Class represents the focus of Jitsi Meet conference. Responsibilities:
@@ -58,9 +59,9 @@ public class JitsiMeetConference
                EventHandler
 {
     /**
-     * The logger instance used by this class.
+     * The classLogger instance used by this class.
      */
-    private final static Logger logger
+    private final static Logger classLogger
         = Logger.getLogger(JitsiMeetConference.class);
 
     /**
@@ -90,6 +91,13 @@ public class JitsiMeetConference
      * {@link ConferenceListener} that will be notified about conference events.
      */
     private final ConferenceListener listener;
+
+    /**
+     * The logger for this instance. Uses the logging level either the one of
+     * {@link #classLogger} or the one passed to the constructor, whichever
+     * is higher.
+     */
+    private final Logger logger = Logger.getLogger(classLogger, null);
 
     /**
      * The instance of conference configuration.
@@ -234,13 +242,16 @@ public class JitsiMeetConference
      *        events.
      * @param config the conference configuration instance.
      * @param globalConfig an instance of the global config service.
+     * @param logLevel (optional) the logging level to be used by this instance.
+     *        See {@link #logger} for more details.
      */
     public JitsiMeetConference(String                   roomName,
                                String                   focusUserName,
                                ProtocolProviderHandler  protocolProviderHandler,
                                ConferenceListener       listener,
                                JitsiMeetConfig          config,
-                               JitsiMeetGlobalConfig    globalConfig)
+                               JitsiMeetGlobalConfig    globalConfig,
+                               Level                    logLevel)
     {
         Assert.notNull(protocolProviderHandler, "protocolProviderHandler");
         Assert.notNull(config, "config");
@@ -253,6 +264,9 @@ public class JitsiMeetConference
         this.config = config;
         this.globalConfig = globalConfig;
         this.etherpadName = createSharedDocumentName();
+
+        if (logLevel != null)
+            logger.setLevel(logLevel);
     }
 
     /**
@@ -546,6 +560,7 @@ public class JitsiMeetConference
 
         newParticipant
             = new Participant(
+                    this,
                     (XmppChatMember) chatRoomMember,
                     globalConfig.getMaxSSRCsPerUser());
 
@@ -1639,6 +1654,14 @@ public class JitsiMeetConference
     public JitsiMeetConfig getConfig()
     {
         return config;
+    }
+
+    /**
+     * Returns the <tt>Logger</tt> used by this instance.
+     */
+    public Logger getLogger()
+    {
+        return logger;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
@@ -37,9 +37,10 @@ import org.jivesoftware.smack.packet.*;
 public class JitsiMeetRecording
 {
     /**
-     * The logger used by MeetRecording class.
+     * The class logger which can be used to override logging level inherited
+     * from {@link JitsiMeetConference}.
      */
-    private final static Logger logger
+    private final static Logger classLogger
         = Logger.getLogger(JitsiMeetRecording.class);
 
     /**
@@ -71,6 +72,12 @@ public class JitsiMeetRecording
      */
     private final OperationSetDirectSmackXmpp xmppOpSet;
 
+    /**
+     * The logger for this instance. Uses the logging level either of the
+     * {@link #classLogger} or {@link JitsiMeetConference#getLogger()}
+     * whichever is higher.
+     */
+    private final Logger logger;
 
     /**
      * Creates new instance of <tt>JitsiMeetRecording</tt>.
@@ -87,6 +94,8 @@ public class JitsiMeetRecording
         this.xmppOpSet
             = meetConference.getXmppProvider().getOperationSet(
                     OperationSetDirectSmackXmpp.class);
+
+        logger = Logger.getLogger(classLogger, meetConference.getLogger());
     }
 
     /**
@@ -141,13 +150,13 @@ public class JitsiMeetRecording
         {
             recorder
                 = new JireconRecorder(
-                        meetConference.getFocusJid(),
+                        meetConference,
                         services.getJireconRecorder(), xmppOpSet);
             return recorder;
         }
         else
         {
-            logger.warn("No recorder service discovered - using JVB");
+            logger.info("No recorder service discovered - using JVB");
 
             ColibriConference colibriConference
                 = meetConference.getColibriConference();
@@ -165,10 +174,7 @@ public class JitsiMeetRecording
 
             recorder
                 = new JvbRecorder(
-                        colibriConference.getConferenceId(),
-                        videobridge,
-                        colibriConference.getName(),
-                        xmppOpSet);
+                            meetConference, videobridge, xmppOpSet);
             return recorder;
         }
     }

--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -174,8 +174,9 @@ public class LipSyncHack implements OperationSetJingle
             = (merged ? "Merging" : "Not merging")
                     + " A/V streams from " + owner +" to " + participant;
 
-        // The stream is merged most of the time and it's not that interesting
-        if (merged)
+        // The stream is merged most of the time and it's not that interesting.
+        // FIXME JVBs SSRCs are not merged currently, but maybe should be ?
+        if (merged || SSRCSignaling.SSRC_OWNER_JVB.equals(owner))
             logger.debug(logMsg);
         else
             logger.info(logMsg);

--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -145,12 +145,18 @@ public class LipSyncHack implements OperationSetJingle
             = conference.findParticipantForRoomJid(ownerJid);
         if (streamsOwner == null)
         {
-            logger.error(
-                    "Stream owner not a participant or not found for jid: "
-                        + ownerJid);
+            // Do not log that error for the JVB
+            if (!SSRCSignaling.SSRC_OWNER_JVB.equals(ownerJid))
+                logger.error(
+                        "Stream owner not a participant or not found for jid: "
+                            + ownerJid);
             return false;
         }
 
+        // FIXME: we do not know if the JVBs to which the SSRCs belong should
+        // be merged, as the 'streamsOwner' will always be null. This could be
+        // detected based on JVB version if we need to merge them at any point
+        // in the future.
         boolean supportsLipSync = participant.hasLipSyncSupport();
 
         logger.debug(String.format(

--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -153,8 +153,7 @@ public class LipSyncHack implements OperationSetJingle
 
         boolean supportsLipSync = participant.hasLipSyncSupport();
 
-        // FIXME switch to debug level after some more testing
-        logger.info(String.format(
+        logger.debug(String.format(
                 "Lips-sync From %s to %s, lip-sync: %s",
                 ownerJid, participantJid, supportsLipSync));
 
@@ -170,10 +169,16 @@ public class LipSyncHack implements OperationSetJingle
         {
             merged = SSRCSignaling.mergeVideoIntoAudio(ssrcs);
         }
-        // FIXME switch to debug level after some more testing
-        logger.info(
-               (merged ? "Merging" : "Not merging")
-                    + " A/V streams from " + owner +" to " + participant);
+
+        String logMsg
+            = (merged ? "Merging" : "Not merging")
+                    + " A/V streams from " + owner +" to " + participant;
+
+        // The stream is merged most of the time and it's not that interesting
+        if (merged)
+            logger.debug(logMsg);
+        else
+            logger.info(logMsg);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -21,7 +21,6 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jitsimeet
           .SSRCInfoPacketExtension;
-import net.java.sip.communicator.util.Logger;
 
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.util.*;
@@ -65,9 +64,11 @@ import java.util.*;
 public class LipSyncHack implements OperationSetJingle
 {
     /**
-     * The logger used in <tt>LipSyncHack</tt>.
+     * The class logger which can be used to override logging level inherited
+     * from {@link JitsiMeetConference}.
      */
-    static private final Logger logger = Logger.getLogger(LipSyncHack.class);
+    static private final Logger classLogger
+        = Logger.getLogger(LipSyncHack.class);
 
     /**
      * Parent conference for which this instance is doing stream merging.
@@ -80,6 +81,13 @@ public class LipSyncHack implements OperationSetJingle
     private final OperationSetJingle jingleImpl;
 
     /**
+     * The logger for this instance. Uses the logging level either of the
+     * {@link #classLogger} or {@link JitsiMeetConference#getLogger()}
+     * whichever is higher.
+     */
+    private final Logger logger;
+
+    /**
      * Creates new instance of <tt>LipSyncHack</tt> for given conference.
      *
      * @param conference parent <tt>JitsiMeetConference</tt> for which this
@@ -90,8 +98,12 @@ public class LipSyncHack implements OperationSetJingle
     public LipSyncHack(JitsiMeetConference    conference,
                        OperationSetJingle     jingleImpl)
     {
+        Objects.requireNonNull(conference, "conference");
+        Objects.requireNonNull(jingleImpl, "jingleImpl");
+
         this.conference = conference;
         this.jingleImpl = jingleImpl;
+        this.logger = Logger.getLogger(classLogger, conference.getLogger());
     }
 
     private MediaSSRCMap getParticipantSSRCMap(String mucJid)

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -20,12 +20,12 @@ package org.jitsi.jicofo;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import net.java.sip.communicator.service.protocol.*;
-import net.java.sip.communicator.util.*;
 
 import org.jitsi.assertions.*;
 import org.jitsi.jicofo.discovery.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.util.*;
+import org.jitsi.util.*;
 
 import java.util.*;
 
@@ -38,9 +38,11 @@ import java.util.*;
 public class Participant
 {
     /**
-     * The logger
+     * The class logger which can be used to override logging level inherited
+     * from {@link JitsiMeetConference}.
      */
-    private final static Logger logger = Logger.getLogger(Participant.class);
+    private final static Logger classLogger
+        = Logger.getLogger(Participant.class);
 
     /**
      * MUC chat member of this participant.
@@ -56,6 +58,13 @@ public class Participant
      * Information about Colibri channels allocated for this peer(if any).
      */
     private ColibriConferenceIQ colibriChannelsInfo;
+
+    /**
+     * The logger for this instance. Uses the logging level either of the
+     * {@link #classLogger} or {@link JitsiMeetConference#getLogger()}
+     * whichever is higher.
+     */
+    private final Logger logger;
 
     /**
      * The map of the most recently received RTP description for each Colibri
@@ -156,12 +165,16 @@ public class Participant
      * @param maxSSRCCount how many unique SSRCs per media this participant
      *                     instance will be allowed to advertise.
      */
-    public Participant(XmppChatMember roomMember, int maxSSRCCount)
+    public Participant(JitsiMeetConference    conference,
+                       XmppChatMember         roomMember,
+                       int                    maxSSRCCount)
     {
+        Assert.notNull(conference, "conference");
         Assert.notNull(roomMember, "roomMember");
 
         this.roomMember = roomMember;
         this.maxSSRCCount = maxSSRCCount;
+        this.logger = Logger.getLogger(classLogger, conference.getLogger());
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/ProtocolProviderHandler.java
+++ b/src/main/java/org/jitsi/jicofo/ProtocolProviderHandler.java
@@ -160,9 +160,8 @@ public class ProtocolProviderHandler
      */
     public void removeRegistrationListener(RegistrationStateChangeListener l)
     {
-        //FIXME: remove when leak is fixed
         boolean ok = regListeners.remove(l);
-        logger.info("Listener removed ? " + ok + ", " + l);
+        logger.debug("Listener removed ? " + ok + ", " + l);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
@@ -27,6 +27,8 @@ import org.jitsi.xmpp.util.*;
 
 import org.jivesoftware.smack.packet.*;
 
+import java.util.*;
+
 /**
  * Class implements {@link Recorder} using Jirecon recorder container.
  *
@@ -36,9 +38,10 @@ public class JireconRecorder
     extends Recorder
 {
     /**
-     * The logger.
+     * The class logger which can be used to override logging level inherited
+     * from {@link JitsiMeetConference}.
      */
-    private final static Logger logger
+    private final static Logger classLogger
         = Logger.getLogger(JireconRecorder.class);
 
     /**
@@ -47,6 +50,13 @@ public class JireconRecorder
      */
     static final String MEDIA_RECORDING_TOKEN_PNAME
         = "org.jitsi.videobridge.MEDIA_RECORDING_TOKEN";
+
+    /**
+     * The logger for this instance. Uses the logging level either of the
+     * {@link #classLogger} or {@link JitsiMeetConference#getLogger()}
+     * whichever is higher.
+     */
+    private final Logger logger;
 
     /**
      * FIXME: not sure about that
@@ -71,21 +81,25 @@ public class JireconRecorder
 
     /**
      * Creates new instance of <tt>JireconRecorder</tt>.
-     * @param mucRoomJid focus room jid in form of
-     *                   "room_name@muc_component/focus_nickname".
+     * @param conference the parent conference for which this instance will be
+     * handling the recording.
      * @param recorderComponentJid recorder component address.
      * @param xmpp {@link OperationSetDirectSmackXmpp} instance for current
      *             XMPP connection.
      */
-    public JireconRecorder(String mucRoomJid, String recorderComponentJid,
+    public JireconRecorder(JitsiMeetConference conference,
+                           String recorderComponentJid,
                            OperationSetDirectSmackXmpp xmpp)
     {
         super(recorderComponentJid, xmpp);
 
-        this.mucRoomJid = mucRoomJid;
+        Objects.requireNonNull(conference, "conference");
+
+        this.mucRoomJid = conference.getFocusJid();
         this.token
             = FocusBundleActivator.getConfigService()
                     .getString(MEDIA_RECORDING_TOKEN_PNAME);
+        this.logger = Logger.getLogger(classLogger, conference.getLogger());
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/recording/JvbRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/JvbRecorder.java
@@ -19,12 +19,16 @@ package org.jitsi.jicofo.recording;
 
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.ColibriConferenceIQ.Recording.*;
-import net.java.sip.communicator.util.*;
 
+import org.jitsi.jicofo.*;
 import org.jitsi.protocol.xmpp.*;
+import org.jitsi.protocol.xmpp.colibri.*;
+import org.jitsi.util.*;
 import org.jitsi.xmpp.util.*;
 
 import org.jivesoftware.smack.packet.*;
+
+import java.util.*;
 
 /**
  * Implements {@link Recorder} using direct Colibri queries sent to
@@ -36,9 +40,11 @@ public class JvbRecorder
     extends Recorder
 {
     /**
-     * The logger instance used by this class.
+     * The class logger which can be used to override logging level inherited
+     * from {@link JitsiMeetConference}.
      */
-    private final static Logger logger = Logger.getLogger(JvbRecorder.class);
+    private final static Logger classLogger
+        = Logger.getLogger(JvbRecorder.class);
 
     /**
      * Colibri conference identifier
@@ -50,26 +56,38 @@ public class JvbRecorder
      */
     boolean isRecording;
 
+    /**
+     * The logger for this instance. Uses the logging level either of the
+     * {@link #classLogger} or {@link JitsiMeetConference#getLogger()}
+     * whichever is higher.
+     */
+    private final Logger logger;
+
     private final String roomName;
 
     /**
      * Creates new instance of <tt>JvbRecorder</tt>.
-     * @param conferenceId colibri conference ID obtained when allocated
-     *                     on the bridge
+     * @param conference parent {@link JitsiMeetConference} to be recorded
+     *        by this instance.
      * @param videoBridgeComponentJid videobridge component address.
-     * @param roomName the room name.
      * @param xmpp {@link OperationSetDirectSmackXmpp}
      *              for current XMPP connection.
      */
-    public JvbRecorder(String conferenceId,
+    public JvbRecorder(JitsiMeetConference conference,
                        String videoBridgeComponentJid,
-                       String roomName,
                        OperationSetDirectSmackXmpp xmpp)
     {
         super(videoBridgeComponentJid, xmpp);
 
-        this.conferenceId = conferenceId;
-        this.roomName = roomName;
+        Objects.requireNonNull(conference, "conference");
+
+        ColibriConference colibriConference = conference.getColibriConference();
+
+        Objects.requireNonNull(colibriConference, "colibriConference");
+
+        this.conferenceId = colibriConference.getConferenceId();
+        this.roomName = colibriConference.getName();
+        this.logger = Logger.getLogger(classLogger, conference.getLogger());
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -20,7 +20,6 @@ package org.jitsi.jicofo.recording.jibri;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jibri.*;
 import net.java.sip.communicator.service.protocol.*;
-import net.java.sip.communicator.util.Logger;
 
 import org.jitsi.assertions.*;
 import org.jitsi.jicofo.*;
@@ -49,9 +48,11 @@ public class JibriRecorder
     implements JibriListener
 {
     /**
-     * The logger.
+     * The class logger which can be used to override logging level inherited
+     * from {@link JitsiMeetConference}.
      */
-    static private final Logger logger = Logger.getLogger(JibriRecorder.class);
+    static private final Logger classLogger
+        = Logger.getLogger(JibriRecorder.class);
 
     /**
      * The number of times to retry connecting to a Jibri.
@@ -87,6 +88,13 @@ public class JibriRecorder
      * The global config used by this instance.
      */
     private final JitsiMeetGlobalConfig globalConfig;
+
+    /**
+     * The logger for this instance. Uses the logging level either of the
+     * {@link #classLogger} or {@link JitsiMeetConference#getLogger()}
+     * whichever is higher.
+     */
+    private final Logger logger;
 
     /**
      * Meet tools instance used to inject packet extensions to Jicofo's MUC
@@ -164,6 +172,8 @@ public class JibriRecorder
             = protocolService.getOperationSet(OperationSetJitsiMeetTools.class);
 
         jibriDetector = conference.getServices().getJibriDetector();
+
+        logger = Logger.getLogger(classLogger, conference.getLogger());
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/rest/Health.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Health.java
@@ -19,6 +19,7 @@ package org.jitsi.jicofo.rest;
 
 import java.io.*;
 import java.util.*;
+import java.util.logging.*;
 import javax.servlet.*;
 import javax.servlet.http.*;
 
@@ -27,6 +28,7 @@ import org.eclipse.jetty.server.*;
 import org.jitsi.assertions.*;
 import org.jitsi.jicofo.*;
 import org.jitsi.util.*;
+import org.jitsi.util.Logger;
 import org.json.simple.*;
 
 /**
@@ -99,7 +101,10 @@ public class Health
         while (focusManager.getConference(roomName) != null);
 
         // Create a conference with the generated room name.
-        if (!focusManager.conferenceRequest(roomName, JITSI_MEET_CONFIG))
+        if (!focusManager.conferenceRequest(
+                    roomName,
+                    JITSI_MEET_CONFIG,
+                    Level.WARNING /* conference logging level */))
         {
             throw new RuntimeException(
                     "Failed to create conference with room name " + roomName);

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
@@ -36,6 +36,12 @@ import java.util.*;
 public class SSRCSignaling
 {
     /**
+     * The constant value used as owner attribute value of
+     * {@link SSRCInfoPacketExtension} for the SSRC which belongs to the JVB.
+     */
+    public static final String SSRC_OWNER_JVB = "jvb";
+
+    /**
      * Copies value of "<parameter>" SSRC child element. The parameter to be
      * copied must exist in both source and destination SSRCs.
      * @param dst target <tt>SourcePacketExtension</tt> to which we want copy


### PR DESCRIPTION
This PR silences out the logs produced during Jicofo health checks. Also gets rid of some not very useful logs left for debugging purpose of the issues which are no longer present.