### PR TITLE
Fix problems in JibriDetector on XMPP reconnect

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -693,14 +693,24 @@ public class ChatRoomImpl
         XmppConnection connection
                 = provider.getConnectionAdapter();
 
-        IQ reply = (IQ) connection.sendPacketAndGetReply(admin);
-        if (reply == null || reply.getType() != IQ.Type.RESULT)
+        try
         {
-            // FIXME: we should have checked exceptions for all operations in
-            // ChatRoom interface which are expected to fail.
-            // OperationFailedException maybe ?
-            throw new RuntimeException(
+            IQ reply = (IQ) connection.sendPacketAndGetReply(admin);
+            if (reply == null || reply.getType() != IQ.Type.RESULT)
+            {
+                // FIXME: we should have checked exceptions for all operations
+                // in ChatRoom interface which are expected to fail.
+                // OperationFailedException maybe ?
+                throw new RuntimeException(
                     "Failed to grant owner: " + IQUtils.responseToXML(reply));
+            }
+        }
+        catch (OperationFailedException e)
+        {
+            // XXX FIXME unable to throw OperationFailedException, because of
+            // the ChatRoom interface
+            throw new RuntimeException(
+                "Failed to grant owner - XMPP disconnected", e);
         }
     }
 

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -589,24 +589,40 @@ public class XmppProtocolProvider
             this.connection = connection;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public void sendPacket(Packet packet)
         {
+            Objects.requireNonNull(packet, "packet");
+
             if (connection.isConnected())
                 connection.sendPacket(packet);
             else
-                logger.warn(
+                logger.error(
                     "No connection - unable to send packet: " + packet.toXML());
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public Packet sendPacketAndGetReply(Packet packet)
+            throws OperationFailedException
         {
+            Objects.requireNonNull(packet, "packet");
+
             PacketCollector packetCollector
                 = connection.createPacketCollector(
                         new PacketIDFilter(packet.getPacketID()));
 
-            connection.sendPacket(packet);
+            if (connection.isConnected())
+                connection.sendPacket(packet);
+            else
+                throw new OperationFailedException(
+                    "No connection - unable to send packet: " + packet.toXML(),
+                    OperationFailedException.PROVIDER_NOT_REGISTERED);
 
             //FIXME: retry allocation on timeout
             Packet response

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -397,9 +397,13 @@ public class ColibriConferenceImpl
      *
      * @return <tt>Packet</tt> which is JVB response or <tt>null</tt> if
      *         the request timed out.
+     *
+     * @throws OperationFailedException see throws description of
+     * {@link XmppConnection#sendPacketAndGetReply(Packet)}.
      */
     protected Packet sendAllocRequest(String endpointName,
                                       ColibriConferenceIQ request)
+        throws OperationFailedException
     {
         return connection.sendPacketAndGetReply(request);
     }

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -148,8 +148,12 @@ public class ChannelAllocator implements Runnable
 
     /**
      * Method does feature discovery and channel allocation for participant.
+     *
+     * @throws OperationFailedException if the XMPP connection is broken.
+     * The thread should end it's work.
      */
     private void discoverFeaturesAndInvite()
+        throws OperationFailedException
     {
         String address = newParticipant.getMucJid();
 
@@ -219,6 +223,7 @@ public class ChannelAllocator implements Runnable
             JingleSession jingleSession = newParticipant.getJingleSession();
             if (!reInvite || jingleSession == null)
             {
+                // will throw OperationFailedExc if XMPP connection is broken
                 ack = jingle.initiateSession(
                         newParticipant.hasBundleSupport(),
                         address,
@@ -228,6 +233,7 @@ public class ChannelAllocator implements Runnable
             }
             else
             {
+                // will throw OperationFailedExc if XMPP connection is broken
                 ack = jingle.replaceTransport(
                         newParticipant.hasBundleSupport(),
                         jingleSession,

--- a/src/main/java/org/jitsi/jicofo/ChatRoomRoleAndPresence.java
+++ b/src/main/java/org/jitsi/jicofo/ChatRoomRoleAndPresence.java
@@ -245,24 +245,14 @@ public class ChatRoomRoleAndPresence
             else
             {
                 // Elect new owner
-                try
+                if (grantOwner(((XmppChatMember)member).getJabberID()))
                 {
-                    chatRoom.grantOwnership(
-                            ((XmppChatMember)member).getJabberID());
-
                     logger.info(
-                            "Granted owner to " + member.getContactAddress());
+                        "Granted owner to " + member.getContactAddress());
 
                     owner = member;
-                    break;
                 }
-                catch (RuntimeException e)
-                {
-                    logger.error(
-                        "Failed to grant owner status to " + member.getName()
-                            , e);
-                }
-                //break; FIXME: should cancel event if exception occurs ?
+                break;
             }
         }
     }
@@ -336,6 +326,21 @@ public class ChatRoomRoleAndPresence
         }
     }
 
+    private boolean grantOwner(String jid)
+    {
+        try
+        {
+            chatRoom.grantOwnership(jid);
+            return true;
+        }
+        catch(RuntimeException e)
+        {
+            logger.error(
+                "Failed to grant owner status to " + jid , e);
+        }
+        return false;
+    }
+
     private void checkGrantOwnerToAuthUser(ChatRoomMember member)
     {
         XmppChatMember xmppMember = (XmppChatMember) member;
@@ -350,7 +355,7 @@ public class ChatRoomRoleAndPresence
             String authSessionId = authAuthority.getSessionForJid(jabberId);
             if (authSessionId != null)
             {
-                chatRoom.grantOwnership(jabberId);
+                grantOwner(jabberId);
 
                 // Notify that this member has been authenticated using
                 // given session

--- a/src/main/java/org/jitsi/jicofo/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/JvbDoctor.java
@@ -404,7 +404,13 @@ public class JvbDoctor
             return healthIq;
         }
 
+        /**
+         * Performs a health check.
+         * @throws OperationFailedException when XMPP got disconnected -
+         * the task should terminate.
+         */
         private void doHealthCheck()
+            throws OperationFailedException
         {
             // If XMPP is currently not connected skip the health-check
             if (!protocolProvider.isRegistered())

--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -21,6 +21,7 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jitsimeet
           .SSRCInfoPacketExtension;
+import net.java.sip.communicator.service.protocol.*;
 
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.util.*;
@@ -243,6 +244,7 @@ public class LipSyncHack implements OperationSetJingle
             List<ContentPacketExtension>    contents,
             JingleRequestHandler            requestHandler,
             boolean[]                       startMuted)
+        throws OperationFailedException
     {
         processAllParticipantsSSRCs(contents, address);
 
@@ -262,6 +264,7 @@ public class LipSyncHack implements OperationSetJingle
             JingleSession                   session,
             List<ContentPacketExtension>    contents,
             boolean[]                       startMuted)
+        throws OperationFailedException
     {
         processAllParticipantsSSRCs(contents, session.getAddress());
 

--- a/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
+++ b/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
@@ -335,24 +335,33 @@ public class MeetExtensionsHandler
         dialIq.setTo(jigasiJid);
         dialIq.setPacketID(IQ.nextID());
 
-        IQ reply
-            = (IQ) smackXmpp.getXmppConnection().sendPacketAndGetReply(dialIq);
-
-        if (reply != null)
+        try
         {
-            // Send Jigasi response back to the client
-            reply.setFrom(null);
-            reply.setTo(from);
-            reply.setPacketID(originalPacketId);
+            IQ reply
+                = (IQ) smackXmpp
+                    .getXmppConnection()
+                    .sendPacketAndGetReply(dialIq);
+            if (reply != null)
+            {
+                // Send Jigasi response back to the client
+                reply.setFrom(null);
+                reply.setTo(from);
+                reply.setPacketID(originalPacketId);
+            }
+            else
+            {
+                reply
+                    = createErrorResponse(
+                        dialIq,
+                        new XMPPError(
+                                XMPPError.Condition.remote_server_timeout));
+            }
+            smackXmpp.getXmppConnection().sendPacket(reply);
         }
-        else
+        catch (OperationFailedException e)
         {
-            reply = createErrorResponse(
-                    dialIq,
-                    new XMPPError(XMPPError.Condition.remote_server_timeout));
+            logger.error("Failed to send DialIq - XMPP disconnected", e);
         }
-
-        smackXmpp.getXmppConnection().sendPacket(reply);
     }
 
     private boolean acceptMessage(Packet packet)

--- a/src/main/java/org/jitsi/jicofo/discovery/DiscoveryUtil.java
+++ b/src/main/java/org/jitsi/jicofo/discovery/DiscoveryUtil.java
@@ -176,9 +176,21 @@ public class DiscoveryUtil
             versionIq.setType(IQ.Type.GET);
             versionIq.setTo(jid);
 
-            Packet response
-                = xmppOpSet.getXmppConnection()
+            Packet response;
+            try
+            {
+                response
+                    = xmppOpSet
+                        .getXmppConnection()
                         .sendPacketAndGetReply(versionIq);
+            }
+            catch (OperationFailedException e)
+            {
+                logger.error(
+                    "Failed to discover component version - XMPP disconnected",
+                    e);
+                return null;
+            }
 
             if (response instanceof Version)
             {

--- a/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
@@ -19,6 +19,7 @@ package org.jitsi.jicofo.recording;
 
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jirecon.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.ColibriConferenceIQ.Recording.*;
+import net.java.sip.communicator.service.protocol.*;
 
 import org.jitsi.jicofo.*;
 import org.jitsi.protocol.xmpp.*;
@@ -138,8 +139,18 @@ public class JireconRecorder
             recording.setAction(JireconIq.Action.START);
             recording.setOutput(path);
 
-            Packet reply
-                = xmpp.getXmppConnection().sendPacketAndGetReply(recording);
+            Packet reply;
+            try
+            {
+                reply
+                    = xmpp.getXmppConnection().sendPacketAndGetReply(recording);
+            }
+            catch (OperationFailedException e)
+            {
+                logger.error("XMPP disconnected", e);
+                return false;
+            }
+
             if (reply instanceof JireconIq)
             {
                 JireconIq recResponse = (JireconIq) reply;

--- a/src/main/java/org/jitsi/jicofo/recording/JvbRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/JvbRecorder.java
@@ -20,6 +20,7 @@ package org.jitsi.jicofo.recording;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.ColibriConferenceIQ.Recording.*;
 
+import net.java.sip.communicator.service.protocol.*;
 import org.jitsi.jicofo.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.colibri.*;
@@ -117,9 +118,20 @@ public class JvbRecorder
             new ColibriConferenceIQ.Recording(
                 !isRecording ? State.ON : State.OFF, token));
 
-        Packet reply
-            = xmpp.getXmppConnection()
+        Packet reply;
+        try
+        {
+            reply
+                = xmpp
+                    .getXmppConnection()
                     .sendPacketAndGetReply(toggleRecordingIq);
+        }
+        catch (OperationFailedException e)
+        {
+            logger.error("Failed to send recording IQ", e);
+            return false;
+        }
+
         logger.info("REC reply received: " + IQUtils.responseToXML(reply));
         if (reply instanceof ColibriConferenceIQ)
         {

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
@@ -222,14 +222,14 @@ public class JibriDetector
             chatRoom = null;
 
             logger.info("Left JIBRI room: " + jibriBrewery);
+        }
 
-            // Clean up the list of Jibris
-            List<Jibri> jibrisCopy = new ArrayList<>(jibris);
-            jibris.clear();
-            for (Jibri jibri : jibrisCopy)
-            {
-                notifyJibriOffline(jibri.mucJid);
-            }
+        // Clean up the list of Jibris
+        List<Jibri> jibrisCopy = new ArrayList<>(jibris);
+        jibris.clear();
+        for (Jibri jibri : jibrisCopy)
+        {
+            notifyJibriOffline(jibri.mucJid);
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
@@ -222,6 +222,14 @@ public class JibriDetector
             chatRoom = null;
 
             logger.info("Left JIBRI room: " + jibriBrewery);
+
+            // Clean up the list of Jibris
+            List<Jibri> jibrisCopy = new ArrayList<>(jibris);
+            jibris.clear();
+            for (Jibri jibri : jibrisCopy)
+            {
+                notifyJibriOffline(jibri.mucJid);
+            }
         }
     }
 

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -20,6 +20,7 @@ package org.jitsi.protocol.xmpp;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jitsimeet.*;
+import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.util.*;
 
 import org.jitsi.impl.protocol.xmpp.extensions.*;
@@ -92,6 +93,7 @@ public abstract class AbstractOperationSetJingle
      * @param startMuted if the first element is <tt>true</tt> the participant
      * will start audio muted. if the second element is <tt>true</tt> the
      * participant will start video muted.
+     * {@inheritDoc}
      */
     @Override
     public boolean initiateSession(boolean                      useBundle,
@@ -99,6 +101,7 @@ public abstract class AbstractOperationSetJingle
                                    List<ContentPacketExtension> contents,
                                    JingleRequestHandler         requestHandler,
                                    boolean[]                    startMuted)
+        throws OperationFailedException
     {
         logger.info("INVITE PEER: " + address);
 
@@ -229,6 +232,7 @@ public abstract class AbstractOperationSetJingle
                                     JingleSession                   session,
                                     List<ContentPacketExtension>    contents,
                                     boolean[]                       startMuted)
+        throws OperationFailedException
     {
         String address = session.getAddress();
 

--- a/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
@@ -51,13 +51,18 @@ public interface OperationSetJingle
      *
      * @return <tt>true</tt> if have have received RESULT response to
      *         session-initiate IQ.
+     *
+     * @throws OperationFailedException with
+     * {@link OperationFailedException#PROVIDER_NOT_REGISTERED} if the operation
+     * fails, because the XMPP connection is broken.
      */
     boolean initiateSession(
             boolean useBundle,
             String address,
             List<ContentPacketExtension> contents,
             JingleRequestHandler requestHandler,
-            boolean[] startMuted);
+            boolean[] startMuted)
+        throws OperationFailedException;
 
     /**
      * Sends 'transport-replace' IQ to the client.
@@ -71,11 +76,16 @@ public interface OperationSetJingle
      * audio muted" and the seconds one for "start video muted"
      *
      * @return <tt>true</tt> if have have received RESULT response to the IQ.
+     *
+     * @throws OperationFailedException with
+     * {@link OperationFailedException#PROVIDER_NOT_REGISTERED} if the operation
+     * fails, because the XMPP connection is broken.
      */
     boolean replaceTransport(boolean                         useBundle,
                              JingleSession                   session,
                              List<ContentPacketExtension>    contents,
-                             boolean[]                       startMuted);
+                             boolean[]                       startMuted)
+        throws OperationFailedException;
 
     /**
      * Sends 'source-add' proprietary notification.

--- a/src/main/java/org/jitsi/protocol/xmpp/XmppConnection.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/XmppConnection.java
@@ -17,6 +17,8 @@
  */
 package org.jitsi.protocol.xmpp;
 
+import net.java.sip.communicator.service.protocol.*;
+
 import org.jivesoftware.smack.packet.*;
 
 /**
@@ -28,6 +30,10 @@ public interface XmppConnection
 {
     /**
      * Sends given XMPP packet through this connection.
+     * XXX The method will silently fail to send the packet if the XMPP
+     * connection is broken(not connected). Use this method only if such
+     * behaviour is desired, otherwise {@link #sendPacketAndGetReply(Packet)}
+     * should be used instead.
      *
      * @param packet the packet to be sent.
      */
@@ -40,6 +46,11 @@ public interface XmppConnection
      *
      * @return the response packet received within the time limit
      *         or <tt>null</tt> if no response was collected.
+     *
+     * @throws OperationFailedException with
+     * {@link OperationFailedException#PROVIDER_NOT_REGISTERED} error code if
+     * the packet could not be sent, because the XMPP connection is broken.
      */
-    Packet sendPacketAndGetReply(Packet packet);
+    Packet sendPacketAndGetReply(Packet packet)
+        throws OperationFailedException;
 }

--- a/src/test/java/mock/xmpp/colibri/AllocThreadingTestColibriConference.java
+++ b/src/test/java/mock/xmpp/colibri/AllocThreadingTestColibriConference.java
@@ -234,6 +234,7 @@ public class AllocThreadingTestColibriConference
     @Override
     protected Packet sendAllocRequest(String endpointName,
                                       ColibriConferenceIQ request)
+        throws OperationFailedException
     {
         boolean isCreator = confCreator.equals(endpointName);
         synchronized (createConferenceSync)


### PR DESCRIPTION
1. fixes some threads dying while trying to send packets on broken XMPP connection(may lead to weird state left)
2. fixes invalid Jibri addresses kept in the memory after XMPP reconnection