### PR TITLE
Configure colibri channels according to rtpLevelRelayType property

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -200,7 +200,27 @@ public class ColibriConferenceImpl
             colibriBuilder.setAdaptiveSimulcast(
                 config.isAdaptiveSimulcastEnabled());
             colibriBuilder.setSimulcastMode(config.getSimulcastMode());
+
             colibriBuilder.setAudioPacketDelay(config.getAudioPacketDelay());
+            // rtp level relay type used with the colibri channels allocated
+            // for this conference
+            RTPLevelRelayType rtpRelayType = RTPLevelRelayType.TRANSLATOR;
+            try
+            {
+                if (!StringUtils.isNullOrEmpty(config.getRtpLevelRelayType()))
+                    rtpRelayType = RTPLevelRelayType.parseRTPLevelRelayType
+                            (config.getRtpLevelRelayType());
+            }
+            catch (IllegalArgumentException e)
+            {
+                logger.error(
+                        "Failed to parse rtpLevelRelayType JitsiMeet config," +
+                                " use rtp-level-relay-type translator for " +
+                                getName());
+            }
+            colibriBuilder.setRTPLevelRelayType(rtpRelayType);
+            logger.info
+                    ("setConfig: rtpRelayType = " + rtpRelayType.toString());
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -313,6 +313,27 @@ public class FocusManager
 
         JitsiMeetConference conference = conferences.get(room);
 
+        //properties could be updated
+        if (conference.getColibriConference() != null)
+        {
+            JitsiMeetConfig config = new JitsiMeetConfig(properties);
+            conference.getColibriConference().setConfig(config);
+
+            StringBuilder options = new StringBuilder();
+            for (Map.Entry<String, String> option : properties.entrySet())
+            {
+                options.append("\n    ")
+                       .append(option.getKey())
+                       .append(": ")
+                       .append(option.getValue());
+
+            }
+
+            logger.info("The updated options for room " + room + "@" + focusUserDomain
+                    + " conferences count: " + conferences.size()
+                    + " options:" + options.toString());
+        }
+
         return conference.isInTheRoom();
     }
 

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConfig.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConfig.java
@@ -135,6 +135,11 @@ public class JitsiMeetConfig
      */
     public static final String USE_ROOM_AS_SHARED_DOC_NAME
             = "useRoomAsSharedDocumentName";
+    /**
+     * The name of the rtp level relay type property.
+     */
+    public static final String RTP_LEVEL_RELAY_TYPE_PNAME = "rtpLevelRelayType";
+
 
     /**
      * The default value of the "startBitrate" property.
@@ -341,5 +346,14 @@ public class JitsiMeetConfig
     {
         Boolean useRoom = getBoolean(USE_ROOM_AS_SHARED_DOC_NAME);
         return (useRoom != null) && useRoom;
+    }
+
+    /**
+     * Returns the value of the rtp level relay type property.
+     * @return the value of the rtp level relay type property.
+     */
+    public String getRtpLevelRelayType()
+    {
+        return properties.get(RTP_LEVEL_RELAY_TYPE_PNAME);
     }
 }


### PR DESCRIPTION
When colibri channels are created, use the rtpLevelRelayType config property to configure rtp-level-relay-type channel element.

(PR recreated after rebase).