### PR TITLE
Measure XMPP packet processing time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,8 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jicoco</artifactId>
-      <version>1.0-20160420.185019-32</version>
+      <!-- FIXME the version to be update through the force push once jicoco PR is merged -->
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jicoco</artifactId>
-      <!-- FIXME the version to be update through the force push once jicoco PR is merged -->
-      <version>1.0-SNAPSHOT</version>
+      <version>1.0-20161103.170039-36</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/jicofo/xmpp/FocusComponent.java
+++ b/src/main/java/org/jitsi/jicofo/xmpp/FocusComponent.java
@@ -198,7 +198,7 @@ public class FocusComponent
     }
 
     @Override
-    protected IQ handleIQGet(IQ iq)
+    protected IQ handleIQGetImpl(IQ iq)
         throws Exception
     {
         try
@@ -237,7 +237,7 @@ public class FocusComponent
             }
             else
             {
-                return super.handleIQGet(iq);
+                return super.handleIQGetImpl(iq);
             }
         }
         catch (Exception e)
@@ -258,10 +258,9 @@ public class FocusComponent
      * <tt>feature-not-implemented</tt>
      * @throws Exception to reply with <tt>internal-server-error</tt> to the
      * specified request
-     * @see AbstractComponent#handleIQSet(IQ)
      */
     @Override
-    public IQ handleIQSet(IQ iq)
+    public IQ handleIQSetImpl(IQ iq)
         throws Exception
     {
         try
@@ -332,7 +331,7 @@ public class FocusComponent
             }
             else
             {
-                return super.handleIQSet(iq);
+                return super.handleIQSetImpl(iq);
             }
         }
         catch (Exception e)

--- a/src/test/java/org/jitsi/jicofo/ShutdownTest.java
+++ b/src/test/java/org/jitsi/jicofo/ShutdownTest.java
@@ -99,7 +99,7 @@ public class ShutdownTest
 
         gracefulShutdownIQ.setFrom("randomJid1234");
 
-        IQ result = focusComponent.handleIQSet(
+        IQ result = focusComponent.handleIQSetImpl(
             IQUtils.convert(gracefulShutdownIQ));
 
         assertEquals(IQ.Type.error, result.getType());
@@ -109,7 +109,7 @@ public class ShutdownTest
         // Now use authorized JID
         gracefulShutdownIQ.setFrom(shutdownJid);
 
-        result = focusComponent.handleIQSet(
+        result = focusComponent.handleIQSetImpl(
             IQUtils.convert(gracefulShutdownIQ));
 
         assertEquals(IQ.Type.result, result.getType());
@@ -118,7 +118,7 @@ public class ShutdownTest
         ConferenceIq newConferenceIQ = new ConferenceIq();
         newConferenceIQ.setRoom("newRoom1");
 
-        result = focusComponent.handleIQSet(
+        result = focusComponent.handleIQSetImpl(
             IQUtils.convert(newConferenceIQ));
 
         assertEquals(IQ.Type.error, result.getType());
@@ -133,7 +133,7 @@ public class ShutdownTest
         ConferenceIq activeConfRequest = new ConferenceIq();
         activeConfRequest.setRoom(roomName);
 
-        result = focusComponent.handleIQSet(
+        result = focusComponent.handleIQSetImpl(
             IQUtils.convert(activeConfRequest));
 
         assertEquals(IQ.Type.result, result.getType());

--- a/src/test/java/org/jitsi/jicofo/XmppTest.java
+++ b/src/test/java/org/jitsi/jicofo/XmppTest.java
@@ -68,7 +68,7 @@ public class XmppTest
         conferenceIq.setRoom(roomName);
 
         IQ result
-            = focusComponent.handleIQSet(
+            = focusComponent.handleIQSetImpl(
                 IQUtils.convert(conferenceIq));
 
         assertNotNull(result);


### PR DESCRIPTION
Updates Jicoco in order to measure packet processing time in the XMPP component.