### PR TITLE
Stream duplicates

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/OpSetSubscriptionImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/OpSetSubscriptionImpl.java
@@ -19,7 +19,6 @@ package org.jitsi.impl.protocol.xmpp;
 
 import net.java.sip.communicator.util.*;
 
-import org.jitsi.assertions.*;
 import org.jitsi.jicofo.*;
 import org.jitsi.protocol.xmpp.*;
 

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -63,9 +63,9 @@ public class ChannelAllocator implements Runnable
     private final Logger logger;
 
     /**
-     * Parent {@link JitsiMeetConference}.
+     * Parent {@link JitsiMeetConferenceImpl}.
      */
-    private final JitsiMeetConference meetConference;
+    private final JitsiMeetConferenceImpl meetConference;
 
     /**
      * <tt>ColibriConference</tt> instance used by this thread to allocate
@@ -110,11 +110,11 @@ public class ChannelAllocator implements Runnable
      * @param reInvite <tt>true</tt> if the offer will be a 're-invite' one or
      * <tt>false</tt> otherwise.
      */
-    public ChannelAllocator(JitsiMeetConference    meetConference,
-                            ColibriConference      colibriConference,
-                            Participant            newParticipant,
-                            boolean[]              startMuted,
-                            boolean                reInvite)
+    public ChannelAllocator(JitsiMeetConferenceImpl    meetConference,
+                            ColibriConference          colibriConference,
+                            Participant                newParticipant,
+                            boolean[]                  startMuted,
+                            boolean                    reInvite)
     {
         this.meetConference = meetConference;
         this.colibriConference = colibriConference;
@@ -122,12 +122,6 @@ public class ChannelAllocator implements Runnable
         this.startMuted = startMuted;
         this.reInvite = reInvite;
         this.logger = Logger.getLogger(classLogger, meetConference.getLogger());
-    }
-
-    private OperationSetJitsiMeetTools getMeetTools()
-    {
-        return meetConference.getXmppProvider().getOperationSet(
-                OperationSetJitsiMeetTools.class);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/ChatRoomRoleAndPresence.java
+++ b/src/main/java/org/jitsi/jicofo/ChatRoomRoleAndPresence.java
@@ -21,7 +21,6 @@ import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import net.java.sip.communicator.util.*;
 
-import org.jitsi.assertions.*;
 import org.jitsi.jicofo.auth.*;
 import org.jitsi.jicofo.event.*;
 import org.jitsi.protocol.xmpp.*;

--- a/src/main/java/org/jitsi/jicofo/ChatRoomRoleAndPresence.java
+++ b/src/main/java/org/jitsi/jicofo/ChatRoomRoleAndPresence.java
@@ -52,10 +52,10 @@ public class ChatRoomRoleAndPresence
         = Logger.getLogger(ChatRoomRoleAndPresence.class);
 
     /**
-     * The {@link JitsiMeetConference} for which this instance is handling MUC
-     * related stuff.
+     * The {@link JitsiMeetConferenceImpl} for which this instance is handling
+     * MUC related stuff.
      */
-    private final JitsiMeetConference conference;
+    private final JitsiMeetConferenceImpl conference;
 
     /**
      * The {@link ChatRoom} that is hosting Jitsi Meet conference.
@@ -91,7 +91,7 @@ public class ChatRoomRoleAndPresence
      */
     private ChatRoomMember owner;
 
-    public ChatRoomRoleAndPresence(JitsiMeetConference conference,
+    public ChatRoomRoleAndPresence(JitsiMeetConferenceImpl conference,
                                    ChatRoom chatRoom)
     {
         this.conference = Objects.requireNonNull(conference, "conference");

--- a/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
+++ b/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
@@ -21,7 +21,6 @@ import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import net.java.sip.communicator.util.Logger;
 
-import org.jitsi.assertions.*;
 import org.jitsi.eventadmin.*;
 import org.jitsi.jicofo.discovery.*;
 import org.jitsi.jicofo.discovery.Version;

--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -41,7 +41,7 @@ import java.util.logging.*;
  * @author Pawel Domas
  */
 public class FocusManager
-    implements JitsiMeetConference.ConferenceListener,
+    implements JitsiMeetConferenceImpl.ConferenceListener,
                RegistrationStateChangeListener
 {
     /**
@@ -130,7 +130,7 @@ public class FocusManager
      * solution of synchronizing on {@code #this} in
      * {@link #getConferenceCount()} is safe.
      */
-    private final Map<String, JitsiMeetConference> conferences
+    private final Map<String, JitsiMeetConferenceImpl> conferences
         = new ConcurrentHashMap<>();
 
     // Convert to list when needed
@@ -302,7 +302,7 @@ public class FocusManager
             createConference(room, properties, loggingLevel);
         }
 
-        JitsiMeetConference conference = conferences.get(room);
+        JitsiMeetConferenceImpl conference = conferences.get(room);
 
         return conference.isInTheRoom();
     }
@@ -325,8 +325,8 @@ public class FocusManager
             = JitsiMeetGlobalConfig.getGlobalConfig(
                 FocusBundleActivator.bundleContext);
 
-        JitsiMeetConference conference
-            = new JitsiMeetConference(
+        JitsiMeetConferenceImpl conference
+            = new JitsiMeetConferenceImpl(
                     room, focusUserName, protocolProviderHandler,
                     this, config, globalConfig, logLevel);
 
@@ -389,7 +389,8 @@ public class FocusManager
     {
         roomName = roomName.toLowerCase();
 
-        JitsiMeetConference conference = getConference(roomName);
+        JitsiMeetConferenceImpl conference
+            = (JitsiMeetConferenceImpl) getConference(roomName);
         if (conference == null)
         {
             logger.error(
@@ -404,7 +405,7 @@ public class FocusManager
      * {@inheritDoc}
      */
     @Override
-    public synchronized void conferenceEnded(JitsiMeetConference conference)
+    public synchronized void conferenceEnded(JitsiMeetConferenceImpl conference)
     {
         String roomName = conference.getRoomName();
 
@@ -662,14 +663,14 @@ public class FocusManager
 
                 try
                 {
-                    ArrayList<JitsiMeetConference> conferenceCopy;
+                    ArrayList<JitsiMeetConferenceImpl> conferenceCopy;
                     synchronized (FocusManager.this)
                     {
                         conferenceCopy = new ArrayList<>(conferences.values());
                     }
 
                     // Loop over conferences
-                    for (JitsiMeetConference conference : conferenceCopy)
+                    for (JitsiMeetConferenceImpl conference : conferenceCopy)
                     {
                         long idleStamp = conference.getIdleTimestamp();
                         // Is active ?

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -23,7 +23,6 @@ import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import net.java.sip.communicator.util.*;
 
-import org.jitsi.assertions.*;
 import org.jitsi.impl.protocol.xmpp.extensions.*;
 import org.jitsi.jicofo.event.*;
 import org.jitsi.jicofo.reservation.*;

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -1,0 +1,63 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2016 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo;
+
+import org.jitsi.protocol.xmpp.colibri.*;
+import org.jitsi.util.*;
+
+/**
+ * The conference interface extracted from {@link JitsiMeetConferenceImpl} for
+ * the unit tests purpose. There are many method that would be a good candidate
+ * for ending up in this interface, but until the only reason for this interface
+ * are tests, only methods actually used there are listed here.
+ *
+ * @author Pawel Domas
+ */
+public interface JitsiMeetConference
+{
+    /**
+     * @return the <tt>Logger</tt> instance which might be used to inherit
+     * the logging level assigned on the per conference basis.
+     */
+    Logger getLogger();
+
+    /**
+     * Checks how many {@link Participant}s are in the conference.
+     * @return an integer greater than 0.
+     */
+    int getParticipantCount();
+
+    /**
+     * Find {@link Participant} for given MUC JID.
+     *
+     * @param mucJid participant's MUC jid (ex. "room@muc.server.com/nickname").
+     *
+     * @return {@link Participant} instance or <tt>null</tt> if not found.
+     */
+    Participant findParticipantForRoomJid(String mucJid);
+
+    /**
+     * The {@link ColibriConference} for this instance.
+     *
+     * @return {@link ColibriConference} currently allocated on the JVB for the
+     * conference handled by this {@link JitsiMeetConference} instance or
+     * <tt>null</tt> if there isn't any for some reason (not started, broken or
+     * ended).
+     */
+    ColibriConference getColibriConference();
+}

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -52,7 +52,8 @@ import java.util.logging.*;
  * @author Pawel Domas
  */
 public class JitsiMeetConferenceImpl
-    implements RegistrationStateChangeListener,
+    implements JitsiMeetConference,
+               RegistrationStateChangeListener,
                JingleRequestHandler,
                EventHandler
 {
@@ -86,9 +87,10 @@ public class JitsiMeetConferenceImpl
     private final String roomName;
 
     /**
-     * {@link ConferenceListener} that will be notified about conference events.
+     * {@link ConferenceListener} that will be notified
+     * about conference events.
      */
-    private final ConferenceListener listener;
+    private final JitsiMeetConferenceImpl.ConferenceListener listener;
 
     /**
      * The logger for this instance. Uses the logging level either the one of
@@ -899,7 +901,7 @@ public class JitsiMeetConferenceImpl
         return null;
     }
 
-    Participant findParticipantForRoomJid(String roomJid)
+    public Participant findParticipantForRoomJid(String roomJid)
     {
         for (Participant participant : participants)
         {
@@ -1714,13 +1716,13 @@ public class JitsiMeetConferenceImpl
     /**
      * The interface used to listen for conference events.
      */
-    public interface ConferenceListener
+    interface ConferenceListener
     {
         /**
          * Event fired when conference has ended.
          * @param conference the conference instance that has ended.
          */
-        void conferenceEnded(JitsiMeetConference conference);
+        void conferenceEnded(JitsiMeetConferenceImpl conference);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -51,7 +51,7 @@ import java.util.logging.*;
  *
  * @author Pawel Domas
  */
-public class JitsiMeetConference
+public class JitsiMeetConferenceImpl
     implements RegistrationStateChangeListener,
                JingleRequestHandler,
                EventHandler
@@ -60,7 +60,7 @@ public class JitsiMeetConference
      * The classLogger instance used by this class.
      */
     private final static Logger classLogger
-        = Logger.getLogger(JitsiMeetConference.class);
+        = Logger.getLogger(JitsiMeetConferenceImpl.class);
 
     /**
      * Format used to print the date into the focus identifier string.
@@ -232,7 +232,7 @@ public class JitsiMeetConference
     private ScheduledExecutorService executor;
 
     /**
-     * Creates new instance of {@link JitsiMeetConference}.
+     * Creates new instance of {@link JitsiMeetConferenceImpl}.
      *
      * @param roomName name of MUC room that is hosting the conference.
      * @param focusUserName focus user login.
@@ -243,13 +243,13 @@ public class JitsiMeetConference
      * @param logLevel (optional) the logging level to be used by this instance.
      *        See {@link #logger} for more details.
      */
-    public JitsiMeetConference(String                   roomName,
-                               String                   focusUserName,
-                               ProtocolProviderHandler  protocolProviderHandler,
-                               ConferenceListener       listener,
-                               JitsiMeetConfig          config,
-                               JitsiMeetGlobalConfig    globalConfig,
-                               Level                    logLevel)
+    public JitsiMeetConferenceImpl(String                   roomName,
+                                   String                   focusUserName,
+                                   ProtocolProviderHandler  protocolProviderHandler,
+                                   ConferenceListener       listener,
+                                   JitsiMeetConfig          config,
+                                   JitsiMeetGlobalConfig    globalConfig,
+                                   Level                    logLevel)
     {
         this.protocolProviderHandler
             = Objects.requireNonNull(

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
@@ -51,10 +51,10 @@ public class JitsiMeetRecording
     private RecordingState earlyRecordingState = null;
 
     /**
-     * The <tt>JitsiMeetConference</tt> for which this instance is dealing with
-     * all the recording related stuff.
+     * The <tt>JitsiMeetConferenceImpl</tt> for which this instance is dealing
+     * with all the recording related stuff.
      */
-    private final JitsiMeetConference meetConference;
+    private final JitsiMeetConferenceImpl meetConference;
 
     /**
      * Recording functionality implementation backend.
@@ -81,12 +81,12 @@ public class JitsiMeetRecording
 
     /**
      * Creates new instance of <tt>JitsiMeetRecording</tt>.
-     * @param meetConference parent <tt>JitsiMeetConference</tt> for which this
-     *        instance will be taking care of the recording.
+     * @param meetConference parent <tt>JitsiMeetConferenceImpl</tt> for which
+     *        this instance will be taking care of the recording.
      * @param meetServices <tt>JitsiMeetServices</tt> instance which provides
      *        the info about recorder components availability.
      */
-    public JitsiMeetRecording(JitsiMeetConference meetConference,
+    public JitsiMeetRecording(JitsiMeetConferenceImpl meetConference,
                               JitsiMeetServices meetServices)
     {
         this.meetConference = meetConference;

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetServices.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetServices.java
@@ -22,7 +22,6 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jirecon.*;
 import net.java.sip.communicator.util.Logger;
 
-import org.jitsi.assertions.*;
 import org.jitsi.eventadmin.*;
 import org.jitsi.jicofo.discovery.*;
 import org.jitsi.jicofo.discovery.Version;

--- a/src/main/java/org/jitsi/jicofo/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/JvbDoctor.java
@@ -21,7 +21,6 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.health.*;
 import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.util.*;
 
-import org.jitsi.assertions.*;
 import org.jitsi.eventadmin.*;
 import org.jitsi.jicofo.discovery.*;
 import org.jitsi.jicofo.event.*;

--- a/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
+++ b/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
@@ -164,7 +164,7 @@ public class MeetExtensionsHandler
     {
         ColibriConferenceIQ.Recording recording = colibriIQ.getRecording();
         String from = colibriIQ.getFrom();
-        JitsiMeetConference conference
+        JitsiMeetConferenceImpl conference
             = getConferenceForMucJid(colibriIQ.getFrom());
         if (conference == null)
         {
@@ -214,14 +214,14 @@ public class MeetExtensionsHandler
         return packet instanceof MuteIq;
     }
 
-    private JitsiMeetConference getConferenceForMucJid(String mucJid)
+    private JitsiMeetConferenceImpl getConferenceForMucJid(String mucJid)
     {
         String roomName = MucUtil.extractRoomNameFromMucJid(mucJid);
         if (roomName == null)
         {
             return null;
         }
-        return focusManager.getConference(roomName);
+        return (JitsiMeetConferenceImpl) focusManager.getConference(roomName);
     }
 
     private void handleMuteIq(MuteIq muteIq)
@@ -233,7 +233,7 @@ public class MeetExtensionsHandler
             return;
 
         String from = muteIq.getFrom();
-        JitsiMeetConference conference = getConferenceForMucJid(from);
+        JitsiMeetConferenceImpl conference = getConferenceForMucJid(from);
         if (conference == null)
         {
             logger.debug("Mute error: room not found for JID: " + from);
@@ -276,7 +276,7 @@ public class MeetExtensionsHandler
     {
         String from = dialIq.getFrom();
 
-        JitsiMeetConference conference = getConferenceForMucJid(from);
+        JitsiMeetConferenceImpl conference = getConferenceForMucJid(from);
 
         if (conference == null)
         {
@@ -376,7 +376,7 @@ public class MeetExtensionsHandler
         }
 
         String from = presence.getFrom();
-        JitsiMeetConference conference = getConferenceForMucJid(from);
+        JitsiMeetConferenceImpl conference = getConferenceForMucJid(from);
 
         if (conference == null)
         {

--- a/src/main/java/org/jitsi/jicofo/VersionBroadcaster.java
+++ b/src/main/java/org/jitsi/jicofo/VersionBroadcaster.java
@@ -132,7 +132,8 @@ public class VersionBroadcaster
 
         String roomJid = (String) event.getProperty(EventFactory.ROOM_JID_KEY);
 
-        JitsiMeetConference conference = focusManager.getConference(roomJid);
+        JitsiMeetConferenceImpl conference
+            = (JitsiMeetConferenceImpl) focusManager.getConference(roomJid);
         if (conference == null)
         {
             logger.error("Conference is null");

--- a/src/main/java/org/jitsi/jicofo/VersionBroadcaster.java
+++ b/src/main/java/org/jitsi/jicofo/VersionBroadcaster.java
@@ -21,7 +21,6 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.jitsimeet.*;
 import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.util.*;
 
-import org.jitsi.assertions.*;
 import org.jitsi.eventadmin.*;
 import org.jitsi.jicofo.discovery.Version;
 import org.jitsi.jicofo.event.*;

--- a/src/main/java/org/jitsi/jicofo/auth/AuthenticationSession.java
+++ b/src/main/java/org/jitsi/jicofo/auth/AuthenticationSession.java
@@ -17,8 +17,6 @@
  */
 package org.jitsi.jicofo.auth;
 
-import org.jitsi.assertions.*;
-
 import java.util.*;
 
 /**

--- a/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
@@ -88,7 +88,7 @@ public class JireconRecorder
      * @param xmpp {@link OperationSetDirectSmackXmpp} instance for current
      *             XMPP connection.
      */
-    public JireconRecorder(JitsiMeetConference conference,
+    public JireconRecorder(JitsiMeetConferenceImpl conference,
                            String recorderComponentJid,
                            OperationSetDirectSmackXmpp xmpp)
     {

--- a/src/main/java/org/jitsi/jicofo/recording/Recorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/Recorder.java
@@ -17,7 +17,6 @@
  */
 package org.jitsi.jicofo.recording;
 
-import org.jitsi.assertions.*;
 import org.jitsi.protocol.xmpp.*;
 
 import org.jivesoftware.smack.*;

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -81,9 +81,9 @@ public class JibriRecorder
     }
 
     /**
-     * Recorded <tt>JitsiMeetConference</tt>.
+     * Recorded <tt>JitsiMeetConferenceImpl</tt>.
      */
-    private final JitsiMeetConference conference;
+    private final JitsiMeetConferenceImpl conference;
 
     /**
      * The global config used by this instance.
@@ -158,10 +158,10 @@ public class JibriRecorder
      * @param globalConfig the global config that provides some values required
      *                     by <tt>JibriRecorder</tt> to work.
      */
-    public JibriRecorder(JitsiMeetConference         conference,
-                         OperationSetDirectSmackXmpp xmpp,
-                         ScheduledExecutorService    scheduledExecutor,
-                         JitsiMeetGlobalConfig       globalConfig)
+    public JibriRecorder(JitsiMeetConferenceImpl         conference,
+                         OperationSetDirectSmackXmpp     xmpp,
+                         ScheduledExecutorService        scheduledExecutor,
+                         JitsiMeetGlobalConfig           globalConfig)
     {
         super(null, xmpp);
 

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -21,7 +21,6 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jibri.*;
 import net.java.sip.communicator.service.protocol.*;
 
-import org.jitsi.assertions.*;
 import org.jitsi.eventadmin.*;
 import org.jitsi.jicofo.*;
 import org.jitsi.jicofo.recording.*;

--- a/src/main/java/org/jitsi/jicofo/rest/Health.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Health.java
@@ -25,7 +25,6 @@ import javax.servlet.http.*;
 
 import org.eclipse.jetty.server.*;
 
-import org.jitsi.assertions.*;
 import org.jitsi.jicofo.*;
 import org.jitsi.util.*;
 import org.jitsi.util.Logger;

--- a/src/main/java/org/jitsi/protocol/xmpp/JingleSession.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/JingleSession.java
@@ -17,8 +17,6 @@
  */
 package org.jitsi.protocol.xmpp;
 
-import org.jitsi.assertions.*;
-
 import java.util.*;
 
 /**

--- a/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCMap.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCMap.java
@@ -155,6 +155,21 @@ public class MediaSSRCMap
     }
 
     /**
+     * Looks for SSRC with given stream ID("msid") and media type.
+     *
+     * @param media the name of the SSRC media type
+     * @param streamId the stream ID("msid") for which SSRC is to be found.
+     *
+     * @return <tt>SourcePacketExtension</tt> of given media type and stream id
+     * or <tt>null</tt> if not such SSRC exists in this <tt>MediaSSRCMap</tt>.
+     */
+    public SourcePacketExtension findByStreamId(String media, String streamId)
+    {
+        return SSRCSignaling.findFirstWithMSID(
+            getSSRCsForMedia(media), streamId /* msid */);
+    }
+
+    /**
      * Looks for SSRC in this map.
      *
      * @param media the name of media type of the SSRC we're looking for.

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCGroup.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCGroup.java
@@ -21,7 +21,6 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import net.java.sip.communicator.impl.protocol.jabber.jinglesdp.*;
 
-import org.jitsi.assertions.*;
 import org.jitsi.util.*;
 
 import java.util.*;

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
@@ -31,6 +31,9 @@ import java.util.*;
 /**
  * Class gathers utility method related to SSRC signaling.
  *
+ * TODO it feels like this utility thing is a candidate for SSRC class wrapping
+ * <tt>SourcePacketExtension</tt>
+ *
  * @author Pawel Domas
  */
 public class SSRCSignaling
@@ -115,6 +118,32 @@ public class SSRCSignaling
                 return ssrc;
             }
         }
+        return null;
+    }
+
+    /**
+     * Searches the list of SSRCs for a one that matches given "msid".
+     *
+     * @param ssrcs the list of <tt>SourcePacketExtension</tt> to be searched.
+     * @param msid the stream ID("msid") of the SSRC to be found.
+     *
+     * @return <tt>SourcePacketExtension</tt> or <tt>null</tt> if not found.
+     */
+    public static SourcePacketExtension findFirstWithMSID(
+            List<SourcePacketExtension>    ssrcs,
+            String                         msid)
+    {
+        // Avoid NPE
+        if (msid == null)
+            return null;
+
+        for (SourcePacketExtension ssrc : ssrcs)
+        {
+            if (msid.equalsIgnoreCase(getStreamId(ssrc)))
+                return ssrc;
+        }
+
+        // Not found
         return null;
     }
 

--- a/src/test/java/org/jitsi/jicofo/MockJitsiMeetConference.java
+++ b/src/test/java/org/jitsi/jicofo/MockJitsiMeetConference.java
@@ -1,0 +1,67 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2016 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo;
+
+import org.jitsi.protocol.xmpp.colibri.*;
+import org.jitsi.util.*;
+
+/**
+ * Mock {@link JitsiMeetConference} implementation.
+ *
+ * @author Pawel Domas
+ */
+public class MockJitsiMeetConference
+    implements JitsiMeetConference
+{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Logger getLogger()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Participant findParticipantForRoomJid(String jid)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ColibriConference getColibriConference()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getParticipantCount()
+    {
+        return 0;
+    }
+
+}

--- a/src/test/java/org/jitsi/jicofo/ParticipantTest.java
+++ b/src/test/java/org/jitsi/jicofo/ParticipantTest.java
@@ -1,0 +1,130 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2016 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo;
+
+import mock.muc.*;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
+import net.java.sip.communicator.impl.protocol.jabber.jinglesdp.*;
+
+import org.jitsi.jicofo.util.*;
+import org.jitsi.protocol.xmpp.util.*;
+
+import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link Participant}.
+ *
+ * @author Pawel Domas
+ */
+@RunWith(JUnit4.class)
+public class ParticipantTest
+{
+    /**
+     * Tests the {@link Participant#addSSRCsFromContent(List)} which is normally
+     * called either when the answer or the 'source-add' notification is
+     * received.
+     */
+    @Test
+    public void testAddSSRCFromContent()
+    {
+        int maxSSRCCount = 2;
+
+        MockJitsiMeetConference mockConference = new MockJitsiMeetConference();
+
+        MockMultiUserChat mockMultiUserChat
+            = new MockMultiUserChat(null, null);
+
+        MockRoomMember roomMember
+            = mockMultiUserChat.createMockRoomMember("testMember");
+
+        Participant participant
+            = new Participant(mockConference, roomMember, maxSSRCCount);
+
+        SourcePacketExtension[] audioSSRCs
+            = new SourcePacketExtension[] {
+            SSRCUtil.createSSRC(1L, new String[][]{
+                {"cname", "cname1"},
+                {"msid", "stream1 track1"}
+            }),
+            SSRCUtil.createSSRC(2L, new String[][]{
+                {"cname", "cname2"},
+                {"msid", "stream2 track2"}
+            }),
+            // Duplicated SSRC
+            SSRCUtil.createSSRC(1L, new String[][]{
+                {"cname", "cname3"},
+                {"msid", "stream3 track3"}
+            }),
+            // Duplicated media stream id
+            SSRCUtil.createSSRC(3L, new String[][]{
+                {"cname", "cname2"},
+                {"msid", "stream2 track2"}
+            }),
+            SSRCUtil.createSSRC(4L, new String[][]{
+                {"cname", "cname4"},
+                {"msid", "stream4 track4"}
+            })};
+
+        ContentPacketExtension audioContents
+            = JingleOfferFactory.createAudioContent(false, true, true);
+
+        RtpDescriptionPacketExtension audioRtpDescPe
+            = JingleUtils.getRtpDescription(audioContents);
+
+        for (SourcePacketExtension ssrc : audioSSRCs)
+        {
+            audioRtpDescPe.addChildExtension(ssrc);
+        }
+
+        List<ContentPacketExtension> answerContents = new ArrayList<>();
+
+        answerContents.add(audioContents);
+
+        MediaSSRCMap addedSSRCs
+            = participant.addSSRCsFromContent(answerContents);
+
+        List<SourcePacketExtension> addedAudioSSRCs
+            = addedSSRCs.getSSRCsForMedia("audio");
+
+        assertEquals(2, addedAudioSSRCs.size());
+
+        SourcePacketExtension ssrc1 = addedSSRCs.findSSRC("audio", 1L);
+        assertNotNull(ssrc1);
+        assertEquals("cname1", ssrc1.getParameter("cname"));
+        assertEquals("stream1 track1", ssrc1.getParameter("msid"));
+
+        SourcePacketExtension ssrc2 = addedSSRCs.findSSRC("audio", 2L);
+        assertNotNull(ssrc2);
+
+        SourcePacketExtension ssrc3 = addedSSRCs.findSSRC("audio", 3L);
+        assertNull(ssrc3); /* conflicting */
+
+        SourcePacketExtension ssrc4 = addedSSRCs.findSSRC("audio", 4L);
+        assertNull(ssrc4); /* overflows the max SSRC count */
+    }
+}


### PR DESCRIPTION
Prevents from allowing to inject multiple SSRCs for the same media stream id. Logs an error when such case is detected.