### PR TITLE
Temporarily disable SSRC duplicates detection

### DIFF
--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -277,19 +277,20 @@ public class Participant
                     // Continue adding other valid SSRCs...
                     continue;
                 }
+                // FIXME disabled until SSRC groups are not taken into account
                 // Check for duplicated 'msid'
-                else if (streamId != null
-                    && ssrcs.findByStreamId(mediaType, streamId) != null)
-                {
-                    logAddSSRCError(
-                        "Detected duplicated stream id: "
-                            + streamId + "," /* SSRC[mediaType]... */,
-                        true /* log as error */,
-                        ssrcValue, mediaType, getEndpointId());
+                //else if (streamId != null
+                //    && ssrcs.findByStreamId(mediaType, streamId) != null)
+                //{
+                //    logAddSSRCError(
+                //        "Detected duplicated stream id: "
+                //            + streamId + "," /* SSRC[mediaType]... */,
+                //        true /* log as error */,
+                //        ssrcValue, mediaType, getEndpointId());
 
                     // Continue adding other valid SSRCs...
-                    continue;
-                }
+                //    continue;
+                //}
                 // Check for SSRC limit exceeded
                 else if (ssrcs.getSSRCsForMedia(mediaType).size()
                         >= maxSSRCCount)

--- a/src/test/java/org/jitsi/jicofo/ParticipantTest.java
+++ b/src/test/java/org/jitsi/jicofo/ParticipantTest.java
@@ -49,7 +49,8 @@ public class ParticipantTest
      * called either when the answer or the 'source-add' notification is
      * received.
      */
-    @Test
+    // FIXME disabled until SSRC groups are not taken into account
+    //@Test
     public void testAddSSRCFromContent()
     {
         int maxSSRCCount = 2;


### PR DESCRIPTION
SSRC groups used  in simulcast have to be taken into account in the SSRC duplicates detection.