### PR TITLE
Fix NPE in XmppProtocolProvider when fails to login

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -240,7 +240,15 @@ public class XmppProtocolProvider
         }
         catch (XMPPException e)
         {
-            logger.error("Failed to connect: " + e.getMessage(), e);
+            logger.error("Failed to connect/login: " + e.getMessage(), e);
+            // If the connect part succeeded, but login failed we don't want to
+            // rely on Smack's built-in retries, as it will be handled by
+            // the RetryStrategy
+            connection.removeConnectionListener(connListener);
+            if (connection.isConnected())
+            {
+                connection.disconnect();
+            }
             return true;
         }
     }


### PR DESCRIPTION
Fixes:
Jicofo 2016-11-17 20:39:04.842 SEVERE: [15] org.jitsi.jicofo.ProtocolProviderHandler.registrationStateChanged().142 null
java.lang.NullPointerException
	at org.jitsi.impl.protocol.xmpp.XmppProtocolProvider.discoverItems(XmppProtocolProvider.java:488)
	at org.jitsi.impl.protocol.xmpp.OpSetSimpleCapsImpl.getItems(OpSetSimpleCapsImpl.java:53)
	at org.jitsi.jicofo.ComponentsDiscovery.discoverServices(ComponentsDiscovery.java:236)
	at org.jitsi.jicofo.ComponentsDiscovery.firstTimeDiscovery(ComponentsDiscovery.java:306)
	at org.jitsi.jicofo.ComponentsDiscovery.registrationStateChanged(ComponentsDiscovery.java:341)
	at org.jitsi.jicofo.ProtocolProviderHandler.registrationStateChanged(ProtocolProviderHandler.java:138)
	at net.java.sip.communicator.service.protocol.AbstractProtocolProviderService.fireRegistrationStateChanged(AbstractProtocolProviderService.java:187)
	at net.java.sip.communicator.service.protocol.AbstractProtocolProviderService.fireRegistrationStateChanged(AbstractProtocolProviderService.java:141)
	at org.jitsi.impl.protocol.xmpp.XmppProtocolProvider.notifyConnected(XmppProtocolProvider.java:255)
	at org.jitsi.impl.protocol.xmpp.XmppProtocolProvider.access$300(XmppProtocolProvider.java:46)
	at org.jitsi.impl.protocol.xmpp.XmppProtocolProvider$XmppConnectionListener.reconnectionSuccessful(XmppProtocolProvider.java:569)
	at org.jivesoftware.smack.PacketReader.notifyReconnection(PacketReader.java:193)
	at org.jivesoftware.smack.XMPPConnection.initConnection(XMPPConnection.java:589)
	at org.jivesoftware.smack.XMPPConnection.connectUsingConfiguration(XMPPConnection.java:532)
	at org.jivesoftware.smack.XMPPConnection.connect(XMPPConnection.java:968)
	at org.jitsi.impl.protocol.xmpp.XmppProtocolProvider.doConnect(XmppProtocolProvider.java:210)
	at org.jitsi.impl.protocol.xmpp.XmppProtocolProvider.access$000(XmppProtocolProvider.java:46)
	at org.jitsi.impl.protocol.xmpp.XmppProtocolProvider$1.call(XmppProtocolProvider.java:191)
	at org.jitsi.impl.protocol.xmpp.XmppProtocolProvider$1.call(XmppProtocolProvider.java:186)
	at org.jitsi.retry.RetryStrategy$TaskRunner.run(RetryStrategy.java:193)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)