### PR TITLE
mvn: Changes the scope of the ice4j dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
       <artifactId>libjitsi</artifactId>
       <version>1.0-20161020.193142-197</version>
     </dependency>
+    <!-- TODO it should not be here, but for some reason ice4j version 1.0 is loaded without explicit declaration -->  
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>ice4j</artifactId>
+      <version>1.1-20161005.095034-20</version>
+    </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
@@ -147,13 +153,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-    </dependency>
-    <!-- TODO it should not be here, but for some reason ice4j version 1.0 is loaded without explicit declaration -->  
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>ice4j</artifactId>
-      <version>1.1-20161005.095034-20</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
With a "test" scope the ice4j jar is not included in the package,
resulting in (probably harmless) class not found errors:
java.lang.NoClassDefFoundError: org/ice4j/stack/PacketLogger
    at
net.java.sip.communicator.impl.netaddr.NetaddrActivator.start(NetaddrActivator.java:85)
    at
org.jitsi.impl.osgi.framework.BundleImpl.start(BundleImpl.java:293)
    at
org.jitsi.impl.osgi.framework.launch.FrameworkImpl.startLevelChanged(FrameworkImpl.java:460)
    at
org.jitsi.impl.osgi.framework.startlevel.FrameworkStartLevelImpl$Command.run(FrameworkStartLevelImpl.java:126)
    at
org.jitsi.impl.osgi.framework.AsyncExecutor.runInThread(AsyncExecutor.java:111)
    at
org.jitsi.impl.osgi.framework.AsyncExecutor.access$000(AsyncExecutor.java:17)
    at
org.jitsi.impl.osgi.framework.AsyncExecutor$1.run(AsyncExecutor.java:220)