### PR TITLE
Fix NPE in reservation system when there's no authAuthority

### DIFF
--- a/src/main/java/org/jitsi/impl/reservation/rest/RESTReservations.java
+++ b/src/main/java/org/jitsi/impl/reservation/rest/RESTReservations.java
@@ -201,7 +201,7 @@ public class RESTReservations
         if (creator == null)
         {
             logger.warn(
-                "Room " + mucRoomName + " was created without a creator"
+                "Room " + mucRoomName + " was created without a creator");
             return new Result(RESULT_OK);
         }
 

--- a/src/main/java/org/jitsi/impl/reservation/rest/RESTReservations.java
+++ b/src/main/java/org/jitsi/impl/reservation/rest/RESTReservations.java
@@ -149,11 +149,11 @@ public class RESTReservations
 
                     // Conference already exists(check if we have it locally)
                     conference = findConferenceForId(conflictId);
-                    
+
                     logger.info(
                         "Conference '" + mucRoomName + "' already "
                             + "allocated, id: " + conflictId);
-                    
+
                     // do GET conflict conference
                     if (conference == null)
                     {
@@ -197,6 +197,14 @@ public class RESTReservations
             }
         }
 
+        // If there is no authAuthority, creator is null
+        if (creator == null)
+        {
+            logger.warn(
+                "Room " + mucRoomName + " was created without a creator"
+            return new Result(RESULT_OK);
+        }
+
         // Verify owner == creator
         if (creator.equals(conference.getOwner()))
         {
@@ -207,7 +215,6 @@ public class RESTReservations
             logger.error(
                 "Room " + mucRoomName + ", conflict : "
                         + creator + " != " + conference.getOwner());
-            
             return new Result(RESULT_CONFLICT);
         }
     }


### PR DESCRIPTION
I am using Jicofo's reservation system to generate a PIN to each conference to integrate with Jigasi.

However, I get a NPE in [this line](https://github.com/jitsi/jicofo/blob/8f165d52b2cf4d34925de09e120fb13632ebcd18/src/main/java/org/jitsi/impl/reservation/rest/RESTReservations.java#L201) for every new conference. 

Looking at the code, I found out that the reason for getting a NPE is that identity/creator variable is set to null by default in [this line](https://github.com/jitsi/jicofo/blob/master/src/main/java/org/jitsi/jicofo/xmpp/FocusComponent.java#L361) and it does not change its value if there is no authentication system, which is my case.  

This PR allows the conference to be created when there isn't an authentication system. 
Tell me if this is not a desirable behavior, so I can work on a fix.