### PR TITLE
Verify SSRCs and groups

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/DefaultJingleRequestHandler.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/DefaultJingleRequestHandler.java
@@ -20,6 +20,7 @@ package org.jitsi.impl.protocol.xmpp;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import net.java.sip.communicator.util.*;
 import org.jitsi.protocol.xmpp.*;
+import org.jivesoftware.smack.packet.*;
 
 import java.util.*;
 
@@ -39,31 +40,39 @@ public class DefaultJingleRequestHandler
         = Logger.getLogger(DefaultJingleRequestHandler.class);
 
     @Override
-    public void onAddSource(JingleSession jingleSession,
-                            List<ContentPacketExtension> contents)
+    public XMPPError onAddSource(JingleSession jingleSession,
+                                 List<ContentPacketExtension> contents)
     {
         logger.warn("Ignored Jingle 'source-add'");
+
+        return null;
     }
 
     @Override
-    public void onRemoveSource(JingleSession jingleSession,
+    public XMPPError onRemoveSource(JingleSession jingleSession,
                                List<ContentPacketExtension> contents)
     {
         logger.warn("Ignored Jingle 'source-remove'");
+
+        return null;
     }
 
     @Override
-    public void onSessionAccept(JingleSession jingleSession,
+    public XMPPError onSessionAccept(JingleSession jingleSession,
                                 List<ContentPacketExtension> answer)
     {
         logger.warn("Ignored Jingle 'session-accept'");
+
+        return null;
     }
 
     @Override
-    public void onTransportAccept(JingleSession jingleSession,
+    public XMPPError onTransportAccept(JingleSession jingleSession,
                                   List<ContentPacketExtension> contents)
     {
         logger.warn("Ignored Jingle 'transport-accept'");
+
+        return null;
     }
 
     @Override

--- a/src/main/java/org/jitsi/jicofo/InvalidSSRCsException.java
+++ b/src/main/java/org/jitsi/jicofo/InvalidSSRCsException.java
@@ -1,0 +1,37 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo;
+
+/**
+ * This exception is thrown when there is a problem with the SSRCs description
+ * advertised by conference {@link Participant}.
+ *
+ * @author Pawel Domas
+ */
+public class InvalidSSRCsException extends Exception
+{
+    /**
+     * Creates new <tt>InvalidSSRCsException</tt>
+     * @param errorDetails a text that will provide more details for the
+     * exception.
+     */
+    public InvalidSSRCsException(String errorDetails)
+    {
+        super(errorDetails);
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/SSRCValidator.java
+++ b/src/main/java/org/jitsi/jicofo/SSRCValidator.java
@@ -1,0 +1,294 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
+
+import org.jitsi.protocol.xmpp.util.*;
+import org.jitsi.util.*;
+
+import org.jivesoftware.smack.packet.*;
+
+import java.util.*;
+
+/**
+ * Utility class that wraps the process of validating new SSRCs and SSRC groups
+ * that are about to be added to {@link Participant}
+ *
+ * @author Pawel Domas
+ */
+public class SSRCValidator
+{
+    /**
+     * The logger used by this class
+     */
+    private final static Logger classLogger
+        = Logger.getLogger(SSRCValidator.class);
+
+    /**
+     * The logger used by this instance. It uses the log level delegate from
+     * the logger passed to the constructor.
+     */
+    private final Logger logger;
+
+    /**
+     * Participant's endpoint ID used for printing log messages.
+     */
+    private final String endpointId;
+
+    /**
+     * The SSRC map obtained from the participant which reflects current SSRC
+     * status. It's a clone and modifications done here do not affect
+     * the version held by {@link Participant}.
+     */
+    private final MediaSSRCMap ssrcs;
+
+    /**
+     * Same as {@link #ssrcs}, but for SSRC groups.
+     */
+    private final MediaSSRCGroupMap ssrcGroups;
+
+    /**
+     * The limit SSRCs count per media type allowed to be stored by
+     * the {@link Participant} at a time.
+     */
+    private final int maxSSRCCount;
+
+    /**
+     * Creates new <tt>SSRCValidator</tt>
+     * @param endpointId participant's endpoint ID
+     * @param ssrcMap participant's SSRC map
+     * @param ssrcGroups participant's SSRC group map
+     * @param maxSSRCCount the SSRC limit, tells how many SSRC per media type
+     * can be stored at a time.
+     * @param logLevelDelegate a <tt>Logger</tt> which will be used as
+     * the logging level delegate.
+     */
+    public SSRCValidator(String               endpointId,
+                         MediaSSRCMap         ssrcMap,
+                         MediaSSRCGroupMap    ssrcGroups,
+                         int                  maxSSRCCount,
+                         Logger               logLevelDelegate)
+    {
+        this.endpointId = endpointId;
+        this.ssrcs = ssrcMap.copyDeep();
+        this.ssrcGroups = ssrcGroups.copy();
+        this.maxSSRCCount = maxSSRCCount;
+        this.logger = Logger.getLogger(classLogger, logLevelDelegate);
+    }
+
+    /**
+     * Makes an attempt to add given SSRC and SSRC groups to the current state.
+     * It checks some constraints that prevent from injecting invalid
+     * description into the conference:
+     * 1. Allow SSRC value between 1 and 0xFFFFFFFF (note that 0 is a valid
+     *    value, but it breaks WebRTC stack in Chrome, so not allowed here)
+     * 2. Does not allow the same SSRC to appear more than once per media type
+     * 3. Truncates SSRCs above the limit (configured in the constructor)
+     * 4. Filters out SSRC parameters other than 'cname' and 'msid'
+     * 5. Drop empty SSRC groups
+     * 6. Skips duplicated groups (the same semantics and contained SSRCs)
+     * 7. Looks for MSID conflicts between SSRCs which do not belong to the same
+     *    group
+     * 8. Makes sure that SSRCs described by groups exist in media description
+     *
+     * @param newSSRCs the SSRCs to add
+     * @param newGroups the SSRC groups to add
+     *
+     * @return see return value description of
+     * {@link Participant#addSSRCsAndGroupsFromContent(List)}.
+     *
+     * @throws InvalidSSRCsException see throws of
+     * {@link Participant#addSSRCsAndGroupsFromContent(List)}.
+     */
+    public Object[] tryAddSSRCsAndGroups(MediaSSRCMap         newSSRCs,
+                                         MediaSSRCGroupMap    newGroups)
+        throws InvalidSSRCsException
+    {
+        MediaSSRCMap acceptedSSRCs = new MediaSSRCMap();
+        for (String mediaType : newSSRCs.getMediaTypes())
+        {
+            List<SourcePacketExtension> mediaSsrcs
+                = newSSRCs.getSSRCsForMedia(mediaType);
+
+            for (SourcePacketExtension ssrcPe : mediaSsrcs)
+            {
+                long ssrcValue = ssrcPe.getSSRC();
+
+                // NOTE Technically SSRC == 0 is allowed, but it breaks Chrome
+                if (ssrcValue <= 0L || ssrcValue > 0xFFFFFFFFL)
+                {
+                    throw new InvalidSSRCsException(
+                        "Illegal SSRC value: " + ssrcValue);
+                }
+
+                // Check for duplicates
+                String conflictingMediaType
+                    = ssrcs.findSSRCsMediaType(ssrcValue);
+                if (conflictingMediaType != null)
+                {
+                    throw new InvalidSSRCsException(
+                        "SSRC "  + ssrcValue + " is in "
+                            + conflictingMediaType + " already");
+                }
+                // Check for SSRC limit exceeded
+                else if (
+                    ssrcs.getSSRCsForMedia(mediaType).size() >= maxSSRCCount)
+                {
+                    logger.error(
+                        "Too many SSRCs signalled by "
+                            + endpointId + " - dropping: " + ssrcValue);
+                    // Abort - can't add any more SSRCs.
+                    break;
+                }
+
+                SourcePacketExtension copy = ssrcPe.copy();
+
+                filterOutParams(copy);
+
+                acceptedSSRCs.addSSRC(mediaType, copy);
+                this.ssrcs.addSSRC(mediaType, copy);
+            }
+        }
+        // Go over groups
+        MediaSSRCGroupMap acceptedGroups = new MediaSSRCGroupMap();
+
+        // Cross check if any SSRC belongs to any existing group already
+        for (String mediaType : newGroups.getMediaTypes())
+        {
+            for (SSRCGroup groupToAdd
+                : newGroups.getSSRCGroupsForMedia(mediaType))
+            {
+                if (groupToAdd.isEmpty())
+                {
+                    logger.warn("Empty group signalled by: " + endpointId);
+                    continue;
+                }
+
+                if (ssrcGroups.containsGroup(mediaType, groupToAdd))
+                {
+                    logger.warn(
+                        endpointId
+                            + " is trying to add an existing group :"
+                            + groupToAdd);
+                }
+                else
+                {
+                    acceptedGroups.addSSRCGroup(mediaType, groupToAdd);
+                    ssrcGroups.addSSRCGroup(mediaType, groupToAdd);
+                }
+            }
+        }
+
+        this.validateStreams();
+
+        return new Object[] { acceptedSSRCs, acceptedGroups };
+    }
+
+    private void filterOutParams(SourcePacketExtension copy)
+    {
+        Iterator<? extends PacketExtension> params
+            = copy.getChildExtensions().iterator();
+        while (params.hasNext())
+        {
+            PacketExtension ext = params.next();
+            if (ext instanceof ParameterPacketExtension)
+            {
+                ParameterPacketExtension ppe = (ParameterPacketExtension) ext;
+                if (!"cname".equalsIgnoreCase(ppe.getName()) &&
+                    !"msid".equalsIgnoreCase(ppe.getName()))
+                {
+                    params.remove();
+                }
+            }
+        }
+    }
+
+    private void validateStreams()
+        throws InvalidSSRCsException
+    {
+        // Holds SSRCs that belongs to any group
+        MediaSSRCMap groupedSSRCs = new MediaSSRCMap();
+
+        // Go over every group and check if they have corresponding SSRCs
+        for (String mediaType : ssrcGroups.getMediaTypes())
+        {
+            List<SSRCGroup> mediaGroups
+                = ssrcGroups.getSSRCGroupsForMedia(mediaType);
+            for (SSRCGroup group : mediaGroups)
+            {
+                List<SourcePacketExtension> groupSSRCs = group.getSources();
+                // NOTE that empty groups are not allowed at this point and
+                // should have been filtered out earlier
+
+                for (SourcePacketExtension ssrc : groupSSRCs)
+                {
+                    long ssrcValue = ssrc.getSSRC();
+                    // Is there a corresponding SSRC that sit's in the SSRCs map ?
+                    SourcePacketExtension ssrcInMedia
+                        = this.ssrcs.findSSRC(mediaType, ssrcValue);
+                    if (ssrcInMedia == null)
+                    {
+                        String errorMsg
+                            = "SSRC " + ssrcValue + " not found in "
+                                + mediaType + " for group: " + group;
+                        throw new InvalidSSRCsException(errorMsg);
+                    }
+                    groupedSSRCs.addSSRC(mediaType, ssrc);
+                }
+            }
+        }
+
+        MediaSSRCMap notGroupedSSRCs = this.ssrcs.copyDeep();
+        notGroupedSSRCs.remove(groupedSSRCs);
+
+        // Check for duplicated 'MSID's across each media type in
+        // non grouped-ssrcs
+        for (String mediaType : notGroupedSSRCs.getMediaTypes())
+        {
+            Map<String, SourcePacketExtension> streamMap
+                = new HashMap<>();
+
+            List<SourcePacketExtension> mediaSSRCs
+                = notGroupedSSRCs.getSSRCsForMedia(mediaType);
+            for (SourcePacketExtension ssrc : mediaSSRCs)
+            {
+                String streamId = SSRCSignaling.getStreamId(ssrc);
+                if (streamId != null)
+                {
+                    SourcePacketExtension conflictingSSRC
+                        = streamMap.get(streamId);
+                    if (conflictingSSRC != null)
+                    {
+                        throw new InvalidSSRCsException(
+                            "Not grouped SSRC " + ssrc.getSSRC()
+                                + " has conflicting MSID '" + streamId
+                                + "' with " + conflictingSSRC.getSSRC());
+                    }
+                    else
+                    {
+                        streamMap.put(streamId, ssrc);
+                    }
+                }
+                // else
+                // That could be recv-only SSRC (no MSID)
+            }
+        }
+    }
+}

--- a/src/main/java/org/jitsi/protocol/xmpp/JingleRequestHandler.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/JingleRequestHandler.java
@@ -19,6 +19,8 @@ package org.jitsi.protocol.xmpp;
 
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 
+import org.jivesoftware.smack.packet.*;
+
 import java.util.*;
 
 /**
@@ -38,8 +40,11 @@ public interface JingleRequestHandler
      *                 .jabber.extensions.colibri.SourcePacketExtension} inside
      *                 of <tt>RtpDescriptionPacketExtension</tt> or in the
      *                 <tt>ContentPacketExtension</tt> directly.
+     *
+     * @return <tt>XMPPError</tt> if an error should be returned as response to
+     * the original request or <tt>null</tt> if the processing was successful.
      */
-    void onAddSource(JingleSession jingleSession,
+    XMPPError onAddSource(JingleSession jingleSession,
                      List<ContentPacketExtension> contents);
 
     /**
@@ -52,17 +57,23 @@ public interface JingleRequestHandler
      *                 .jabber.extensions.colibri.SourcePacketExtension} inside
      *                 of <tt>RtpDescriptionPacketExtension</tt> or in the
      *                 <tt>ContentPacketExtension</tt> directly.
+     *
+     * @return <tt>XMPPError</tt> if an error should be returned as response to
+     * the original request or <tt>null</tt> if the processing was successful.
      */
-    void onRemoveSource(JingleSession jingleSession,
-                        List<ContentPacketExtension> contents);
+    XMPPError onRemoveSource(JingleSession jingleSession,
+                             List<ContentPacketExtension> contents);
 
     /**
      * Callback fired when 'session-accept' is received from the client.
      *
      * @param jingleSession the session that has received the notification.
      * @param answer content list that describe peer media offer.
+     *
+     * @return <tt>XMPPError</tt> if an error should be returned as response to
+     * the original request or <tt>null</tt> if the processing was successful.
      */
-    void onSessionAccept(JingleSession jingleSession,
+    XMPPError onSessionAccept(JingleSession jingleSession,
                          List<ContentPacketExtension> answer);
 
     /**
@@ -79,8 +90,11 @@ public interface JingleRequestHandler
      *
      * @param jingleSession the session that has received the notification
      * @param contents content list that contains media transport description
+     *
+     * @return <tt>XMPPError</tt> if an error should be returned as response to
+     * the original request or <tt>null</tt> if the processing was successful.
      */
-    void onTransportAccept(JingleSession jingleSession,
+    XMPPError onTransportAccept(JingleSession jingleSession,
                            List<ContentPacketExtension> contents);
 
     /**

--- a/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCGroupMap.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCGroupMap.java
@@ -128,26 +128,56 @@ public class MediaSSRCGroupMap
      * map instance.
      * @param ssrcGroups the <tt>MediaSSRCGroupMap</tt> that will be added to
      *                   this map instance.
-     * @return returns that map that contains only those groups that were
-     *         actually added.
      */
-    public MediaSSRCGroupMap add(MediaSSRCGroupMap ssrcGroups)
+    public void add(MediaSSRCGroupMap ssrcGroups)
     {
-        MediaSSRCGroupMap addedGroups = new MediaSSRCGroupMap();
         for (String media : ssrcGroups.getMediaTypes())
         {
             List<SSRCGroup> groups = ssrcGroups.getSSRCGroupsForMedia(media);
             for (SSRCGroup group : groups)
             {
-                if (!group.isEmpty())
-                {
-                    addSSRCGroup(media, group);
-
-                    addedGroups.addSSRCGroup(media, group);
-                }
+                addSSRCGroup(media, group);
             }
         }
-        return addedGroups;
+    }
+
+    /**
+     * Checks whether or not this map contains given <tt>{@link SSRCGroup}</tt>.
+     * @param mediaType the type of the media fo the group to be found.
+     * @param toFind the <tt>SSRCGroup</tt> to be found.
+     * @return <tt>true</tt> if the given <tt>SSRCGroup</tt> exists in the map
+     * already or <tt>false</tt> otherwise. A group is considered equal when it
+     * has the same semantics and SSRCs stored. The order of SSRCs appearing in
+     * the group is important as well.
+     */
+    public boolean containsGroup(String mediaType, SSRCGroup toFind)
+    {
+        List<SourcePacketExtension> comparedSSRCs = toFind.getSources();
+
+        List<SSRCGroup> groups = this.getSSRCGroupsForMedia(mediaType);
+        for (SSRCGroup group : groups)
+        {
+            if (!toFind.getSemantics().equals(toFind.getSemantics()))
+                continue;
+
+            List<SourcePacketExtension> groupSSRCs = group.getSources();
+            if (groupSSRCs.size() != comparedSSRCs.size())
+                continue;
+
+            boolean theSame = true;
+            for (int i=0; i<comparedSSRCs.size(); i++)
+            {
+                if (groupSSRCs.get(i).getSSRC()
+                    != comparedSSRCs.get(i).getSSRC())
+                {
+                    theSame = false;
+                    break;
+                }
+            }
+            if (theSame)
+                return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCMap.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/MediaSSRCMap.java
@@ -177,6 +177,24 @@ public class MediaSSRCMap
     }
 
     /**
+     * Looks for given SSRC number and returns type of the media for the first
+     * match found.
+     * @param ssrcValue the SSRC number to be found
+     * @return type of the media of the SSRC identified by the given number or
+     * <tt>null</tt> if not found.
+     */
+    public String findSSRCsMediaType(long ssrcValue)
+    {
+        Set<String> mediaTypes = getMediaTypes();
+        for (String mediaType : mediaTypes)
+        {
+            if (findSSRC(mediaType, ssrcValue) != null)
+                return mediaType;
+        }
+        return null;
+    }
+
+    /**
      * Finds SSRC for given owner.
      *
      * @param media the media type of the SSRC we'll be looking for.

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCGroup.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCGroup.java
@@ -103,6 +103,15 @@ public class SSRCGroup
     }
 
     /**
+     * Returns the SSRC contained in this group.
+     * @return the internal list that stores <tt>SourcePacketExtension</tt>
+     */
+    public List<SourcePacketExtension> getSources()
+    {
+        return group.getSources();
+    }
+
+    /**
      * Returns deep copy of underlying <tt>SourceGroupPacketExtension</tt>.
      */
     public SourceGroupPacketExtension getExtensionCopy()
@@ -175,5 +184,23 @@ public class SSRCGroup
     public boolean isEmpty()
     {
         return this.group.getSources().isEmpty();
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder ssrcs = new StringBuilder();
+        for (SourcePacketExtension ssrc : this.group.getSources())
+        {
+            // FIXME do not print for the last element
+            ssrcs.append(ssrc.getSSRC()).append(", ");
+        }
+        return "SSRCGroup[" + this.group.getSemantics() + ", " + ssrcs
+            + "]@" + Integer.toHexString(hashCode());
+    }
+
+    public String getSemantics()
+    {
+        return group.getSemantics();
     }
 }

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
@@ -175,7 +175,7 @@ public class SSRCSignaling
      *             which we want to obtain WebRTC stream ID.
      * @return WebRTC stream ID that is the first part of "msid" SSRC parameter.
      */
-    private static String getStreamId(SourcePacketExtension ssrc)
+    public static String getStreamId(SourcePacketExtension ssrc)
     {
         ParameterPacketExtension msid = getParam(ssrc, "msid");
 

--- a/src/test/java/org/jitsi/jicofo/ParticipantTest.java
+++ b/src/test/java/org/jitsi/jicofo/ParticipantTest.java
@@ -32,9 +32,7 @@ import org.junit.runners.*;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link Participant}.
@@ -44,88 +42,409 @@ import static org.junit.Assert.assertNull;
 @RunWith(JUnit4.class)
 public class ParticipantTest
 {
-    /**
-     * Tests the {@link Participant#addSSRCsFromContent(List)} which is normally
-     * called either when the answer or the 'source-add' notification is
-     * received.
-     */
-    // FIXME disabled until SSRC groups are not taken into account
-    //@Test
-    public void testAddSSRCFromContent()
+    private MockJitsiMeetConference mockConference;
+    private MockRoomMember roomMember;
+    private Participant participant;
+
+    private ArrayList<ContentPacketExtension> answerContents;
+    private RtpDescriptionPacketExtension audioRtpDescPe;
+    private RtpDescriptionPacketExtension videoRtpDescPe;
+
+    private SourcePacketExtension[] audioSSRCs;
+
+    private SourcePacketExtension[] videoSSRCs;
+    private SourceGroupPacketExtension[] videoGroups;
+
+    @Before
+    public void setUpContents()
     {
-        int maxSSRCCount = 2;
+        this.mockConference = new MockJitsiMeetConference();
+        MockMultiUserChat mockMultiUserChat = new MockMultiUserChat(null, null);
+        this.roomMember = mockMultiUserChat.createMockRoomMember("testMember");
+        this.participant
+            = new Participant(mockConference, roomMember, 20);
 
-        MockJitsiMeetConference mockConference = new MockJitsiMeetConference();
+        SourcePacketExtension ssrc1 = createSSRC(1L);
+        SourcePacketExtension ssrc2 = createSSRC(2L);
+        SourcePacketExtension ssrc4 = createSSRC(4L);
 
-        MockMultiUserChat mockMultiUserChat
-            = new MockMultiUserChat(null, null);
+        this.audioSSRCs = new SourcePacketExtension[] { ssrc1, ssrc2, ssrc4};
 
-        MockRoomMember roomMember
-            = mockMultiUserChat.createMockRoomMember("testMember");
+        String cname = "videocname";
+        String msid = "vstream vtrack";
 
-        Participant participant
-            = new Participant(mockConference, roomMember, maxSSRCCount);
+        this.videoSSRCs = new SourcePacketExtension[] {
+            createGroupSSRC(10L, cname, msid),
+            createGroupSSRC(20L, cname, msid),
+            createGroupSSRC(30L, cname, msid),
+            createGroupSSRC(40L, cname, msid),
+            createGroupSSRC(50L, cname, msid),
+            createGroupSSRC(60L, cname, msid)
+        };
 
-        SourcePacketExtension[] audioSSRCs
-            = new SourcePacketExtension[] {
-            SSRCUtil.createSSRC(1L, new String[][]{
-                {"cname", "cname1"},
-                {"msid", "stream1 track1"}
-            }),
-            SSRCUtil.createSSRC(2L, new String[][]{
-                {"cname", "cname2"},
-                {"msid", "stream2 track2"}
-            }),
-            // Duplicated SSRC
-            SSRCUtil.createSSRC(1L, new String[][]{
-                {"cname", "cname3"},
-                {"msid", "stream3 track3"}
-            }),
-            // Duplicated media stream id
-            SSRCUtil.createSSRC(3L, new String[][]{
-                {"cname", "cname2"},
-                {"msid", "stream2 track2"}
-            }),
-            SSRCUtil.createSSRC(4L, new String[][]{
-                {"cname", "cname4"},
-                {"msid", "stream4 track4"}
-            })};
+        this.videoGroups = new SourceGroupPacketExtension[] {
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_SIMULCAST,
+                new long[] { 10L, 30L, 50L },
+                cname, msid),
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_FID,
+                new long[] { 10L, 20L }, cname, msid),
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_FID,
+                new long[] { 30L, 40L }, cname, msid),
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_FID,
+                new long[] { 50L, 60L }, cname, msid)
+        };
 
         ContentPacketExtension audioContents
             = JingleOfferFactory.createAudioContent(false, true, true);
 
-        RtpDescriptionPacketExtension audioRtpDescPe
-            = JingleUtils.getRtpDescription(audioContents);
+        ContentPacketExtension videoContents
+            = JingleOfferFactory.createVideoContent(false, true, true, 0, 100);
 
+        this.audioRtpDescPe = JingleUtils.getRtpDescription(audioContents);
+        this.videoRtpDescPe = JingleUtils.getRtpDescription(videoContents);
+
+        this.answerContents = new ArrayList<>();
+
+        answerContents.add(audioContents);
+        answerContents.add(videoContents);
+    }
+
+    private void addDefaultAudioSSRCs()
+    {
         for (SourcePacketExtension ssrc : audioSSRCs)
         {
             audioRtpDescPe.addChildExtension(ssrc);
         }
+    }
 
-        List<ContentPacketExtension> answerContents = new ArrayList<>();
+    private void addDefaultVideoSSRCs()
+    {
+        for (SourcePacketExtension ssrc : videoSSRCs)
+            videoRtpDescPe.addChildExtension(ssrc);
+    }
 
-        answerContents.add(audioContents);
+    private void addDefaultVideoGroups()
+    {
+        for (SourceGroupPacketExtension group : videoGroups)
+            videoRtpDescPe.addChildExtension(group);
+    }
 
-        MediaSSRCMap addedSSRCs
-            = participant.addSSRCsFromContent(answerContents);
+    @Test
+    public void testNegative()
+    {
+        audioRtpDescPe.addChildExtension(createSSRC(-1));
+
+        this.addDefaultAudioSSRCs();
+
+        try
+        {
+            participant.addSSRCsAndGroupsFromContent(answerContents);
+            fail("Did not detect SSRC -1 as invalid");
+        }
+        catch (InvalidSSRCsException exc)
+        {
+            assertEquals("Illegal SSRC value: -1", exc.getMessage());
+        }
+    }
+
+    @Test
+    public void testZero()
+    {
+        audioRtpDescPe.addChildExtension(createSSRC(0));
+
+        this.addDefaultAudioSSRCs();
+
+        try
+        {
+            participant.addSSRCsAndGroupsFromContent(answerContents);
+            fail("Did not detect SSRC 0 as invalid");
+        }
+        catch (InvalidSSRCsException exc)
+        {
+            assertEquals("Illegal SSRC value: 0", exc.getMessage());
+        }
+    }
+
+    //@Test
+    public void testInvalidNumber()
+    {
+        // FIXME SSRC implementation will always trim the value to 32bit
+        //SourcePacketExtension ssrcInvalid = createSSRC(0xFFFFFFFFFL);
+
+        //this.addDefaultAudioSSRCs();
+
+        // bla bla bla
+    }
+
+    @Test
+    public void testDuplicate()
+    {
+        // Duplicated SSRC with 1
+        SourcePacketExtension ssrc1Duplicate
+            = SSRCUtil.createSSRC(1L, new String[][]{
+                    {"cname", "cname3"},
+                    {"msid", "stream3 track3"},
+                    {"mslabel", "stream3"},
+                    {"label", "track3"}
+                });
+
+        audioRtpDescPe.addChildExtension(ssrc1Duplicate);
+
+        this.addDefaultAudioSSRCs();
+
+        try
+        {
+            participant.addSSRCsAndGroupsFromContent(answerContents);
+            fail("Did not detect SSRC 1 duplicate");
+        }
+        catch (InvalidSSRCsException exc)
+        {
+            assertEquals("SSRC 1 is in audio already", exc.getMessage());
+        }
+    }
+
+    @Test
+    public void testDuplicateDifferentMediaType()
+    {
+        // Duplicated video SSRC will conflict with SSRC 1 in audio
+        SourcePacketExtension ssrc1Duplicate
+            = SSRCUtil.createSSRC(1L, new String[][]{
+            {"cname", "cname3"},
+            {"msid", "stream3 track3"},
+            {"mslabel", "stream3"},
+            {"label", "track3"}
+        });
+
+        videoRtpDescPe.addChildExtension(ssrc1Duplicate);
+
+        this.addDefaultAudioSSRCs();
+        this.addDefaultVideoSSRCs();
+        this.addDefaultVideoGroups();
+
+        try
+        {
+            participant.addSSRCsAndGroupsFromContent(answerContents);
+            fail("Did not detect SSRC 1 duplicate");
+        }
+        catch (InvalidSSRCsException exc)
+        {
+            assertEquals("SSRC 1 is in audio already", exc.getMessage());
+        }
+    }
+
+    @Test
+    public void testMSIDDuplicate()
+    {
+        // Duplicated media stream id with SSRC2
+        SourcePacketExtension ssrc3
+            = SSRCUtil.createSSRC(3L, new String[][]{
+            {"cname", "cname2"},
+            {"msid", "stream2 track2"},
+            {"mslabel", "stream2"},
+            {"label", "track2"}
+        });
+
+        this.addDefaultAudioSSRCs();
+
+        audioRtpDescPe.addChildExtension(ssrc3);
+
+        try
+        {
+            participant.addSSRCsAndGroupsFromContent(answerContents);
+            fail("Did not detect MSID duplicate");
+        }
+        catch (InvalidSSRCsException exc)
+        {
+            assertEquals(
+                "Not grouped SSRC 3 has conflicting MSID 'stream2' with 2",
+                exc.getMessage());
+        }
+    }
+
+    /**
+     * Tests the max SSRC count limit.
+     */
+    @Test
+    public void testSSRCLimit()
+        throws InvalidSSRCsException
+    {
+        int maxSsrcCount = 4;
+        this.participant
+            = new Participant(mockConference, roomMember, maxSsrcCount);
+
+        this.addDefaultAudioSSRCs();
+        audioRtpDescPe.addChildExtension(createSSRC(5L));
+        audioRtpDescPe.addChildExtension(createSSRC(6L));
+
+        Object[] ssrcsAndGroups
+            = participant.addSSRCsAndGroupsFromContent(answerContents);
+        MediaSSRCMap addedSSRCs = (MediaSSRCMap) ssrcsAndGroups[0];
 
         List<SourcePacketExtension> addedAudioSSRCs
             = addedSSRCs.getSSRCsForMedia("audio");
 
-        assertEquals(2, addedAudioSSRCs.size());
+        assertEquals(4, addedAudioSSRCs.size());
 
-        SourcePacketExtension ssrc1 = addedSSRCs.findSSRC("audio", 1L);
-        assertNotNull(ssrc1);
-        assertEquals("cname1", ssrc1.getParameter("cname"));
-        assertEquals("stream1 track1", ssrc1.getParameter("msid"));
+        verifySSRC(
+            "cname5", "stream5 track5", addedSSRCs.findSSRC("audio", 5L));
 
-        SourcePacketExtension ssrc2 = addedSSRCs.findSSRC("audio", 2L);
-        assertNotNull(ssrc2);
+        /* overflows the max SSRC count */
+        assertNull(addedSSRCs.findSSRC("audio", 6L));
+    }
 
-        SourcePacketExtension ssrc3 = addedSSRCs.findSSRC("audio", 3L);
-        assertNull(ssrc3); /* conflicting */
+    @Test
+    public void testParamFilter()
+        throws InvalidSSRCsException
+    {
+        this.addDefaultAudioSSRCs();
 
-        SourcePacketExtension ssrc4 = addedSSRCs.findSSRC("audio", 4L);
-        assertNull(ssrc4); /* overflows the max SSRC count */
+        Object[] ssrcsAndGroups
+            = participant.addSSRCsAndGroupsFromContent(answerContents);
+        MediaSSRCMap addedSSRCs = (MediaSSRCMap) ssrcsAndGroups[0];
+
+        List<SourcePacketExtension> addedAudioSSRCs
+            = addedSSRCs.getSSRCsForMedia("audio");
+
+        assertEquals(3, addedAudioSSRCs.size());
+
+        verifySSRC(
+            "cname1", "stream1 track1", addedSSRCs.findSSRC("audio", 1L));
+
+        verifySSRC(
+            "cname2", "stream2 track2", addedSSRCs.findSSRC("audio", 2L));
+
+        verifySSRC(
+            "cname4", "stream4 track4", addedSSRCs.findSSRC("audio", 4L));
+    }
+
+    @Test
+    public void testEmptyGroup()
+        throws InvalidSSRCsException
+    {
+        this.addDefaultVideoSSRCs();
+        this.addDefaultVideoGroups();
+
+        SourceGroupPacketExtension group = new SourceGroupPacketExtension();
+        group.setSemantics(SourceGroupPacketExtension.SEMANTICS_FID);
+        videoRtpDescPe.addChildExtension(group);
+
+        SourceGroupPacketExtension group2 = new SourceGroupPacketExtension();
+        group2.setSemantics(SourceGroupPacketExtension.SEMANTICS_FID);
+        videoRtpDescPe.addChildExtension(group2);
+
+        MediaSSRCGroupMap addedGroups
+            = (MediaSSRCGroupMap) participant
+                .addSSRCsAndGroupsFromContent(answerContents)[1];
+
+        assertEquals(
+            this.videoGroups.length,
+            addedGroups.getSSRCGroupsForMedia("video").size());
+    }
+
+    @Test
+    public void testGroupedSSRCNotFound()
+    {
+        SourcePacketExtension ssrc1 = createGroupSSRC(1L, "cname1", "s t1");
+
+        SourceGroupPacketExtension group1
+            = createGroup(
+                SourceGroupPacketExtension.SEMANTICS_FID,
+                new long[] { 1L, 2L}, "cname1", "s t1");
+
+        videoRtpDescPe.addChildExtension(ssrc1);
+        videoRtpDescPe.addChildExtension(group1);
+
+        try
+        {
+            participant.addSSRCsAndGroupsFromContent(answerContents);
+            fail("Failed to detect that SSRC 2 is not in video SDP");
+        }
+        catch (InvalidSSRCsException e)
+        {
+            assertTrue(e.getMessage().startsWith(
+                "SSRC 2 not found in video for group: SSRCGroup[FID, 1, 2, ]"));
+        }
+    }
+
+    @Test
+    public void testDuplicatedGroups()
+        throws InvalidSSRCsException
+    {
+        SourcePacketExtension ssrc1 = createGroupSSRC(1L, "cname1", "s t1");
+        SourcePacketExtension ssrc2 = createGroupSSRC(2L, "cname1", "s t1");
+
+        SourceGroupPacketExtension group1
+            = createGroup(
+                    SourceGroupPacketExtension.SEMANTICS_FID,
+                    new long[] { 1L, 2L}, "cname1", "s t1");
+
+        videoRtpDescPe.addChildExtension(ssrc1);
+        videoRtpDescPe.addChildExtension(ssrc2);
+        videoRtpDescPe.addChildExtension(group1);
+
+        videoRtpDescPe.addChildExtension(
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_FID,
+                new long[] { 1L, 2L}, "cname1", "s t1"));
+
+        Object[] ssrcsAndGroups
+            = participant.addSSRCsAndGroupsFromContent(answerContents);
+
+        MediaSSRCMap ssrcs = (MediaSSRCMap) ssrcsAndGroups[0];
+        assertEquals(2, ssrcs.getSSRCsForMedia("video").size());
+
+        MediaSSRCGroupMap groups = (MediaSSRCGroupMap) ssrcsAndGroups[1];
+        assertEquals(1, groups.getSSRCGroupsForMedia("video").size());
+    }
+
+    private void verifySSRC(
+        String cname, String msid, SourcePacketExtension ssrc)
+    {
+        assertNotNull(ssrc);
+        assertEquals(cname, ssrc.getParameter("cname"));
+        assertEquals(msid, ssrc.getParameter("msid"));
+        assertNull(ssrc.getParameter("mslabel"));
+        assertNull(ssrc.getParameter("label"));
+    }
+
+    private SourcePacketExtension createSSRC(long ssrcNum)
+    {
+        return SSRCUtil.createSSRC(ssrcNum, new String[][]{
+            {"cname", "cname" + ssrcNum},
+            {"msid", "stream" + ssrcNum + " track" + ssrcNum},
+            {"mslabel", "stream" + ssrcNum},
+            {"label", "track" + ssrcNum}
+        });
+    }
+
+    private SourcePacketExtension createGroupSSRC(long ssrcNum, String cname, String msid)
+    {
+        return SSRCUtil.createSSRC(ssrcNum, new String[][]{
+            {"cname", cname},
+            {"msid", msid}
+        });
+    }
+
+    private SourceGroupPacketExtension createGroup(String semantics,
+                                                   long[] ssrcs,
+                                                   String cname,
+                                                   String msid)
+    {
+        SourceGroupPacketExtension groupPe = new SourceGroupPacketExtension();
+
+        groupPe.setSemantics(semantics);
+
+        List<SourcePacketExtension> ssrcList = new ArrayList<>(ssrcs.length);
+        for (long ssrc : ssrcs)
+        {
+            ssrcList.add(createGroupSSRC(ssrc, cname, msid));
+        }
+        groupPe.addSources(ssrcList);
+
+        return groupPe;
     }
 }


### PR DESCRIPTION
Checks the following, before accepting SSRCs to the conference description:
1. Allow SSRC value between 1 and 0xFFFFFFFF
2. Do not allow the same SSRC to appear more than once per media type
3. Skip SSRCs if the SSRC count limit is exceeded
4. Filter out SSRC parameters other than 'cname' and 'msid'
5. Drop empty SSRC groups
6. Skip duplicated groups (the same semantics and SSRCs)
7. Look for MSID conflicts between SSRCs which do not belong to the same
    group
8. Make sure that SSRCs described by groups exist in media description

Some of the above were checked even before the PR changes.