### PR TITLE
Catches all errors in Runnables passed to ScheduledExecutorService.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -134,7 +134,7 @@ public class ChannelAllocator implements Runnable
         {
             discoverFeaturesAndInvite();
         }
-        catch (Exception e)
+        catch (Throwable e)
         {
             logger.error("Exception on participant invite", e);
         }

--- a/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
+++ b/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
@@ -478,7 +478,7 @@ public class ComponentsDiscovery
                         {
                             validateBridges();
                         }
-                        catch (Exception e)
+                        catch (Throwable e)
                         {
                             logger.error(e, e);
                         }

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -357,11 +357,13 @@ public class JibriRecorder
                     }
                     //else the response will be handled in processPacket()
                 }
-                catch (OperationFailedException e)
+                catch (Throwable t)
                 {
                     logger.error(
-                            "Failed to start recording in " + roomName
-                                + " - XMPP connection is broken");
+                        "Failed to start recording in " + roomName
+                            + (t instanceof OperationFailedException ?
+                                " - XMPP connection is broken"
+                                : ""), t);
                     recordingStopped(
                             null, false /* do not send status updates */);
                 }


### PR DESCRIPTION
ScheduledExecutorService has the functionality to catch any Error coming out of the Runnable run method and swallow it without printing anything.
