### PR TITLE
SSRCValidator will require one MSID across the SSRC group

### DIFF
--- a/src/test/java/org/jitsi/jicofo/ParticipantTest.java
+++ b/src/test/java/org/jitsi/jicofo/ParticipantTest.java
@@ -265,6 +265,32 @@ public class ParticipantTest
         }
     }
 
+    @Test
+    public void testMSIDMismatchInTheSameGroup()
+    {
+        // Overwrite SSRC 20 with something wrong
+        this.videoSSRCs[1]
+            = createGroupSSRC(20L, "blabla", "wrongStream wrongTrack");
+
+        this.addDefaultVideoSSRCs();
+        this.addDefaultVideoGroups();
+
+        try
+        {
+            participant.addSSRCsAndGroupsFromContent(answerContents);
+            fail("Did not detect MSID mismatch in 10+20 FID group");
+        }
+        catch (InvalidSSRCsException exc)
+        {
+            String errorMsg = exc.getMessage();
+            assertTrue(
+                "Invalid message (constant needs update ?): " + errorMsg,
+                errorMsg.startsWith(
+                    "MSID mismatch detected "
+                        + "in group SSRCGroup[FID, 10, 20, ]"));
+        }
+    }
+
     /**
      * Tests the max SSRC count limit.
      */


### PR DESCRIPTION
SSRCValidator will make sure that any grouped SSRC has an MSID and that it's the same across the group.