### PR TITLE
fix: Remove abs-send-time from audio.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -411,11 +411,6 @@ public class JingleOfferFactory
         ssrcAudioLevel.setID("1");
         ssrcAudioLevel.setURI(URI.create(RTPExtension.SSRC_AUDIO_LEVEL_URN));
         rtpDesc.addExtmap(ssrcAudioLevel);
-        RTPHdrExtPacketExtension absSendTime
-                = new RTPHdrExtPacketExtension();
-        absSendTime.setID("3");
-        absSendTime.setURI(URI.create(RTPExtension.ABS_SEND_TIME_URN));
-        rtpDesc.addExtmap(absSendTime);
 
         // a=rtpmap:111 opus/48000/2
         PayloadTypePacketExtension opus


### PR DESCRIPTION
Chrome is rejecting the abs-send-time for audio (not sure when that
started, but it's expected since they're moving away from receiver side
bandwidth estimations), but since it's singnaled through COLIBRI to the
bridge, the bridge adds it to outgoing RTP audio packets, which causing
the client to flood the verbose console logs with:

[32136:46627:0314/121945.923995:WARNING:rtp_utility.cc(342)] Failed to
find extension id: 3