### PR TITLE
Quick fix for conference burst

### DIFF
--- a/src/main/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeSelector.java
@@ -750,22 +750,29 @@ public class BridgeSelector
             {
                 logger.info(
                     "Video stream count for: " + jid + ": " + streamCount);
+            }
 
-                int estimatedBefore = getEstimatedVideoStreamCount();
+            int estimatedBefore = getEstimatedVideoStreamCount();
 
-                this.videoStreamCount = streamCount;
+            this.videoStreamCount = streamCount;
 
-                if (videoStreamCountDiff != 0)
-                {
-                    videoStreamCountDiff = 0;
-                    logger.info(
-                        "Reset video stream diff on " + this.jid
-                            + " video channels: " + this.videoChannelCount
-                            + " video streams: " + this.videoStreamCount
-                            + " (estimation error: "
-                            + (estimatedBefore - getEstimatedVideoStreamCount())
-                            + ")");
-                }
+            // The event for video streams count diff are processed on
+            // a single threaded queue and those will pile up during conference
+            // burst. Because of that "videoStreamCountDiff" must be cleared
+            // even if the was no change to the actual value.
+            // FIXME eventually add a timestamp and reject old events
+            if (videoStreamCountDiff != 0)
+            {
+                videoStreamCountDiff = 0;
+                logger.info(
+                    "Reset video stream diff on " + this.jid
+                        + " video channels: " + this.videoChannelCount
+                        + " video streams: " + this.videoStreamCount
+                        + " (estimation error: "
+                        // FIXME estimation error is often invalid wrong,
+                        // but not enough time to look into it now
+                        + (estimatedBefore - getEstimatedVideoStreamCount())
+                        + ")");
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue where during conference burst many "video stream count added/removed" events would be queued onto the single threaded queue and then those are processed, after let's say 0 is received through PubSub. So even though those events were generated before the PubSub they will be effective, but they should not. This change will make the incoming PubSub stats overwrite outdated values (before the change they would overwrite it only if the stream count has changed).