### PR TITLE
feat: Adds transport-cc to the offer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20170313.220152-258</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <!-- TODO it should not be here, but for some reason ice4j version 1.0 is loaded without explicit declaration -->  
     <dependency>

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -193,6 +193,13 @@ public class JingleOfferFactory
         absSendTime.setURI(URI.create(RTPExtension.ABS_SEND_TIME_URN));
         rtpDesc.addExtmap(absSendTime);
 
+        // a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+        RTPHdrExtPacketExtension tcc
+            = new RTPHdrExtPacketExtension();
+        tcc.setID("5");
+        tcc.setURI(URI.create(RTPExtension.TRANSPORT_CC_URN));
+        rtpDesc.addExtmap(tcc);
+
         // a=rtpmap:100 VP8/90000
         int vp8pt = 100;
         PayloadTypePacketExtension vp8
@@ -209,6 +216,9 @@ public class JingleOfferFactory
 
         // a=rtcp-fb:100 goog-remb
         vp8.addRtcpFeedbackType(createRtcpFbPacketExtension("goog-remb", null));
+
+        // a=rtcp-fb:100 transport-cc
+        vp8.addRtcpFeedbackType(createRtcpFbPacketExtension("transport-cc", null));
 
         if (minBitrate != -1)
         {
@@ -428,6 +438,9 @@ public class JingleOfferFactory
 
         // fmtp:111 useinbandfec=1
         addParameterExtension(opus, "useinbandfec", "1");
+
+        // a=rtcp-fb:111 transport-cc
+        opus.addRtcpFeedbackType(createRtcpFbPacketExtension("transport-cc", null));
 
         // a=rtpmap:103 ISAC/16000
         addPayloadTypeExtension(rtpDesc, 103, "ISAC", 16000);


### PR DESCRIPTION
DO NOT MERGE

This is only to make the transport-cc tests more thorough. It should be merge only after we implement the rest of the transport-cc-based bandwidth estimation.