### PR TITLE
feat: Allows updating the COLIBRI channel media direction.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20161005.180600-21</version>
+      <version>2.9-20170322.204148-23</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -832,7 +832,8 @@ public class ColibriConferenceImpl
             MediaSSRCMap                                   ssrcs,
             MediaSSRCGroupMap                              ssrcGroups,
             IceUdpTransportPacketExtension                 bundleTransport,
-            Map<String, IceUdpTransportPacketExtension>    transportMap)
+            Map<String, IceUdpTransportPacketExtension>    transportMap,
+            Map<String, MediaDirection>                    directionMap)
     {
         ColibriConferenceIQ iq;
 
@@ -877,6 +878,14 @@ public class ColibriConferenceImpl
             else if (transportMap != null
                     && colibriBuilder.addTransportUpdateReq(
                             transportMap, localChannelsInfo))
+            {
+                send = true;
+            }
+
+            // Media direction.
+            if (directionMap != null
+                    && colibriBuilder.addDirectionUpdateReq(
+                            directionMap, localChannelsInfo))
             {
                 send = true;
             }

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -258,7 +258,8 @@ public class ChannelAllocator implements Runnable
                     newParticipant.getRtpDescriptionMap(),
                     newParticipant.getSSRCsCopy(),
                     newParticipant.getSSRCGroupsCopy(),
-                    null, null, null);
+                    null, null,
+                    newParticipant.getDirectionMap());
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -258,7 +258,7 @@ public class ChannelAllocator implements Runnable
                     newParticipant.getRtpDescriptionMap(),
                     newParticipant.getSSRCsCopy(),
                     newParticipant.getSSRCGroupsCopy(),
-                    null, null);
+                    null, null, null);
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -972,6 +972,7 @@ public class JitsiMeetConferenceImpl
         participant.setJingleSession(peerJingleSession);
 
         // Extract and store various session information in the Participant
+        participant.setDirection(answer);
         participant.setRTPDescription(answer);
         participant.addTransportFromJingle(answer);
 
@@ -1006,7 +1007,8 @@ public class JitsiMeetConferenceImpl
                     peerSSRCs,
                     peerGroupsMap,
                     participant.getBundleTransport(),
-                    participant.getTransportMap());
+                    participant.getTransportMap(),
+                    participant.getDirectionMap());
         }
 
         // Loop over current participant and send 'source-add' notification

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -24,6 +24,7 @@ import net.java.sip.communicator.service.protocol.*;
 import org.jitsi.jicofo.discovery.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.util.*;
+import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 
 import java.util.*;
@@ -70,6 +71,13 @@ public class Participant
      * content.
      */
     private Map<String, RtpDescriptionPacketExtension> rtpDescriptionMap;
+
+    /**
+     * The map of the most recently received media direction for each Colibri
+     * content.
+     */
+    private Map<String, MediaDirection> directionMap;
+
 
     /**
      * Peer's media SSRCs.
@@ -200,6 +208,63 @@ public class Participant
     public XmppChatMember getChatMember()
     {
         return roomMember;
+    }
+
+    /**
+     * Returns the currently stored map of media direction to Colibri content
+     * name.
+     *
+     * @return a <tt>Map<String,MediaDirection></tt> which maps the media
+     * direction to the corresponding Colibri content names.
+     */
+    public Map<String, MediaDirection> getDirectionMap()
+    {
+        return directionMap;
+    }
+
+    /**
+     * Extracts and stores media directionfor each content type from given
+     * Jingle contents.
+     * @param jingleContents the list of Jingle content packet extension from
+     *        <tt>Participant</tt>'s answer.
+     */
+    public void setDirection(List<ContentPacketExtension> jingleContents)
+    {
+        Map<String, MediaDirection> directionsMap = new HashMap<>();
+
+        for (ContentPacketExtension content : jingleContents)
+        {
+            ContentPacketExtension.SendersEnum sendersEnum = content.getSenders();
+
+            if (sendersEnum != null)
+            {
+                switch (sendersEnum)
+                {
+                case both:
+                    directionsMap.put(
+                        content.getName(), MediaDirection.SENDRECV);
+                    break;
+                case initiator:
+                    // initiator maps to sendonly, so the COLIBRI channel needs
+                    // to be recvonly.
+                    directionsMap.put(
+                        content.getName(), MediaDirection.RECVONLY);
+                    break;
+                case none:
+                    directionsMap.put(
+                        content.getName(), MediaDirection.INACTIVE);
+                    break;
+                case responder:
+                    // responder maps to recvonly, so the COLIBRI channel needs
+                    // to be sendonly.
+                    directionsMap.put(
+                        content.getName(), MediaDirection.SENDONLY);
+                    break;
+                }
+            }
+        }
+
+        this.directionMap = directionsMap;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -78,7 +78,6 @@ public class Participant
      */
     private Map<String, MediaDirection> directionMap;
 
-
     /**
      * Peer's media SSRCs.
      */

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -23,6 +23,7 @@ import net.java.sip.communicator.service.protocol.*;
 
 import org.jitsi.jicofo.*;
 import org.jitsi.protocol.xmpp.util.*;
+import org.jitsi.service.neomedia.*;
 
 import java.util.*;
 
@@ -144,7 +145,8 @@ public interface ColibriConference
             MediaSSRCMap                                   ssrcs,
             MediaSSRCGroupMap                              ssrcGroups,
             IceUdpTransportPacketExtension                 bundleTransport,
-            Map<String, IceUdpTransportPacketExtension>    transportMap);
+            Map<String, IceUdpTransportPacketExtension>    transportMap,
+            Map<String, MediaDirection>                    directionMap);
 
     /**
      * Updates the RTP description for active channels (existing on the bridge).


### PR DESCRIPTION
This SHOULD NOT be merged. If a participant joins video muted, then the m-line direction is set to recvonly and the colibri channel in the bridge gets configured as sendonly and it's not getting updated. 