### PR TITLE
ref: Makes some of the JingleOfferFactory methods non-static.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -280,17 +280,20 @@ public class ChannelAllocator implements Runnable
         boolean useRtx
             = config.isRtxEnabled() && newParticipant.hasRtxSupport();
 
+        JingleOfferFactory jingleOfferFactory
+            = FocusBundleActivator.getJingleOfferFactory();
+
         if (newParticipant.hasAudioSupport())
         {
             contents.add(
-                    JingleOfferFactory.createAudioContent(
+                    jingleOfferFactory.createAudioContent(
                             disableIce, useDtls, config.stereoEnabled()));
         }
 
         if (newParticipant.hasVideoSupport())
         {
             contents.add(
-                    JingleOfferFactory.createVideoContent(
+                jingleOfferFactory.createVideoContent(
                             disableIce, useDtls, useRtx,
                             config.getMinBitrate(),
                             config.getStartBitrate()));
@@ -301,7 +304,7 @@ public class ChannelAllocator implements Runnable
         if (openSctp && newParticipant.hasSctpSupport())
         {
             contents.add(
-                    JingleOfferFactory.createDataContent(disableIce, useDtls));
+                    jingleOfferFactory.createDataContent(disableIce, useDtls));
         }
 
         ColibriConferenceIQ peerChannels = allocateChannels(contents);

--- a/src/main/java/org/jitsi/jicofo/FocusBundleActivator.java
+++ b/src/main/java/org/jitsi/jicofo/FocusBundleActivator.java
@@ -52,6 +52,11 @@ public class FocusBundleActivator
     private static OSGIServiceRef<ConfigurationService> configServiceRef;
 
     /**
+     * The Jingle offer factory to use in this bundle.
+     */
+    private static JingleOfferFactory jingleOfferFactory;
+
+    /**
      * {@link EventAdmin} service reference.
      */
     private static OSGIServiceRef<EventAdmin> eventAdminRef;
@@ -94,6 +99,8 @@ public class FocusBundleActivator
 
         configServiceRef
             = new OSGIServiceRef<>(context, ConfigurationService.class);
+
+        jingleOfferFactory = new JingleOfferFactory(configServiceRef.get());
 
         context.registerService(
             ExecutorService.class, sharedThreadPool, null);
@@ -144,6 +151,16 @@ public class FocusBundleActivator
     public static ConfigurationService getConfigService()
     {
         return configServiceRef.get();
+    }
+
+    /**
+     * Gets the Jingle offer factory to use in this bundle.
+     *
+     * @return the Jingle offer factory to use in this bundle
+     */
+    public static JingleOfferFactory getJingleOfferFactory()
+    {
+        return jingleOfferFactory;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -77,42 +77,49 @@ public class JingleOfferFactory
         = "org.jitsi.jicofo.H264_RTX_PT";
 
     /**
-     * The configuration service to be used by this instance.
-     */
-    private static final ConfigurationService cfg
-        = LibJitsiOSGiImpl.getConfigurationService();
-
-    /**
      * The VP8 payload type to include in the Jingle session-invite.
      */
-    private static final int VP8_PT = cfg.getInt(VP8_PT_PNAME, 100);
+    private final int VP8_PT;
 
     /**
      * The VP8 RTX payload type to include in the Jingle session-invite.
      */
-    private static final int VP8_RTX_PT = cfg.getInt(VP8_RTX_PT_PNAME, 96);
+    private final int VP8_RTX_PT;
 
     /**
      * The VP9 payload type to include in the Jingle session-invite.
      */
-    private static final int VP9_PT = cfg.getInt(VP9_PT_PNAME, 101);
+    private final int VP9_PT;
 
     /**
      * The VP9 RTX payload type to include in the Jingle session-invite.
      */
-    private static final int VP9_RTX_PT = cfg.getInt(VP9_RTX_PT_PNAME, 97);
+    private final int VP9_RTX_PT;
 
     /**
      * The H264 payload type to include in the Jingle session-invite.
      */
-    private static final int H264_PT = cfg.getInt(H264_PT_PNAME, 107);
+    private final int H264_PT;
 
     /**
      * The H264 RTX payload type to include in the Jingle session-invite.
      */
-    private static final int H264_RTX_PT = cfg.getInt(H264_RTX_PT_PNAME, 99);
+    private final int H264_RTX_PT;
 
-    private JingleOfferFactory(){ }
+    /**
+     * Ctor.
+     *
+     * @param cfg the {@link ConfigurationService} to pull config options from.
+     */
+    public JingleOfferFactory(ConfigurationService cfg)
+    {
+        VP8_PT = cfg != null ? cfg.getInt(VP8_PT_PNAME, 100) : 100;
+        VP8_RTX_PT = cfg != null ? cfg.getInt(VP8_RTX_PT_PNAME, 96) : 96;
+        VP9_PT = cfg != null ? cfg.getInt(VP9_PT_PNAME, 101) : 101;
+        VP9_RTX_PT = cfg != null ? cfg.getInt(VP9_RTX_PT_PNAME, 97) : 97;
+        H264_PT = cfg != null ? cfg.getInt(H264_PT_PNAME, 107) : 107;
+        H264_RTX_PT = cfg != null ? cfg.getInt(H264_RTX_PT_PNAME, 99) : 99;
+    }
 
     /**
      * Creates a {@link ContentPacketExtension} for the audio media type that
@@ -179,7 +186,7 @@ public class JingleOfferFactory
      * @return <tt>ContentPacketExtension</tt> for given media type that will be
      *         used in initial conference offer.
      */
-    public static ContentPacketExtension createVideoContent(
+    public ContentPacketExtension createVideoContent(
             boolean disableIce, boolean useDtls, boolean useRtx,
             int minBitrate, int startBitrate)
     {
@@ -241,7 +248,7 @@ public class JingleOfferFactory
      * {@link ContentPacketExtension}.
      * @param content the {@link ContentPacketExtension} to add extensions to.
      */
-    private static void addVideoToContent(ContentPacketExtension content,
+    private void addVideoToContent(ContentPacketExtension content,
                                           boolean useRtx,
                                           int minBitrate,
                                           int startBitrate)

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -133,7 +133,7 @@ public class JingleOfferFactory
      * @return <tt>ContentPacketExtension</tt> for given media type that will be
      *         used in initial conference offer.
      */
-    public static ContentPacketExtension createAudioContent(
+    public ContentPacketExtension createAudioContent(
         boolean disableIce, boolean useDtls, boolean stereo)
     {
         ContentPacketExtension content
@@ -157,7 +157,7 @@ public class JingleOfferFactory
      * @return <tt>ContentPacketExtension</tt> for given media type that will be
      *         used in initial conference offer.
      */
-    public static ContentPacketExtension createDataContent(
+    public ContentPacketExtension createDataContent(
         boolean disableIce, boolean useDtls)
     {
         ContentPacketExtension content

--- a/src/test/java/org/jitsi/jicofo/ColibriTest.java
+++ b/src/test/java/org/jitsi/jicofo/ColibriTest.java
@@ -89,12 +89,14 @@ public class ColibriTest
 
         List<ContentPacketExtension> contents = new ArrayList<>();
 
+        JingleOfferFactory jingleOfferFactory
+            = FocusBundleActivator.getJingleOfferFactory();
         ContentPacketExtension audio
-            = JingleOfferFactory.createAudioContent(false, true, false);
+            = jingleOfferFactory.createAudioContent(false, true, false);
         ContentPacketExtension video
-            = JingleOfferFactory.createVideoContent(false, true, false, -1, -1);
+            = jingleOfferFactory.createVideoContent(false, true, false, -1, -1);
         ContentPacketExtension data
-            = JingleOfferFactory.createDataContent(false, true);
+            = jingleOfferFactory.createDataContent(false, true);
 
         contents.add(audio);
         contents.add(video);

--- a/src/test/java/org/jitsi/jicofo/ColibriThreadingTest.java
+++ b/src/test/java/org/jitsi/jicofo/ColibriThreadingTest.java
@@ -315,12 +315,15 @@ public class ColibriThreadingTest
         List<ContentPacketExtension> contents
             = new ArrayList<ContentPacketExtension>();
 
-        contents.add(JingleOfferFactory.createAudioContent(false, true, false));
+        JingleOfferFactory jingleOfferFactory
+            = FocusBundleActivator.getJingleOfferFactory();
+
+        contents.add(jingleOfferFactory.createAudioContent(false, true, false));
 
         contents.add(
-            JingleOfferFactory.createVideoContent(false, true, false, -1, -1));
+            jingleOfferFactory.createVideoContent(false, true, false, -1, -1));
 
-        contents.add(JingleOfferFactory.createDataContent(false, true));
+        contents.add(jingleOfferFactory.createDataContent(false, true));
 
         return contents;
     }

--- a/src/test/java/org/jitsi/jicofo/ParticipantTest.java
+++ b/src/test/java/org/jitsi/jicofo/ParticipantTest.java
@@ -98,11 +98,14 @@ public class ParticipantTest
                 new long[] { 50L, 60L }, cname, msid)
         };
 
+        JingleOfferFactory jingleOfferFactory
+            = FocusBundleActivator.getJingleOfferFactory();
+
         ContentPacketExtension audioContents
-            = JingleOfferFactory.createAudioContent(false, true, true);
+            = jingleOfferFactory.createAudioContent(false, true, true);
 
         ContentPacketExtension videoContents
-            = JingleOfferFactory.createVideoContent(false, true, true, 0, 100);
+            = jingleOfferFactory.createVideoContent(false, true, true, 0, 100);
 
         this.audioRtpDescPe = JingleUtils.getRtpDescription(audioContents);
         this.videoRtpDescPe = JingleUtils.getRtpDescription(videoContents);


### PR DESCRIPTION
Video content creation is parametrizable via some configuration
options, so these methods need access to the ConfigurationService
that is discovered and initialized in the FocusBundleActivator start.

After the ConfigurationService is initialized, we initialize the
JingleOfferFactory and we also make it a static member of the
FocusBundleActivator, just like the ConfigurationService.