### PR TITLE
Deprecate Recorder

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -25,6 +25,7 @@ import net.java.sip.communicator.util.*;
 
 import org.jitsi.impl.protocol.xmpp.extensions.*;
 import org.jitsi.jicofo.event.*;
+import org.jitsi.jicofo.recording.jibri.*;
 import org.jitsi.jicofo.reservation.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.colibri.*;
@@ -181,6 +182,12 @@ public class JitsiMeetConferenceImpl
      * Takes care of conference recording.
      */
     private JitsiMeetRecording recording;
+
+    /**
+     * The {@link JibriRecorder} instance used to provide live streaming through
+     * Jibri.
+     */
+    private JibriRecorder jibriRecorder;
 
     /**
      * Information about Jitsi Meet conference services like videobridge,
@@ -348,6 +355,16 @@ public class JitsiMeetConferenceImpl
                             BridgeEvent.BRIDGE_DOWN
                         },
                         this);
+
+            JibriDetector jibriDetector = services.getJibriDetector();
+            if (jibriDetector != null)
+            {
+                jibriRecorder
+                    = new JibriRecorder(
+                            this, getXmppConnection(), executor, globalConfig);
+
+                jibriRecorder.init();
+            }
         }
         catch(Exception e)
         {
@@ -367,6 +384,12 @@ public class JitsiMeetConferenceImpl
             return;
 
         started = false;
+
+        if (jibriRecorder != null)
+        {
+            jibriRecorder.dispose();
+            jibriRecorder = null;
+        }
 
         if (eventHandlerRegistration != null)
         {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
@@ -21,7 +21,6 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.service.protocol.*;
 
 import org.jitsi.jicofo.recording.*;
-import org.jitsi.jicofo.recording.jibri.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.util.*;
@@ -133,15 +132,6 @@ public class JitsiMeetRecording
     {
         if (recorder != null)
             return recorder;
-
-        if (services.getJibriDetector() != null)
-        {
-            recorder = new JibriRecorder(
-                    meetConference, connection,
-                    FocusBundleActivator.getSharedThreadPool(),
-                    meetConference.getGlobalConfig());
-            return recorder;
-        }
 
         String recorderService = services.getJireconRecorder();
         if (!StringUtils.isNullOrEmpty(recorderService))

--- a/src/main/java/org/jitsi/jicofo/recording/Recorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/Recorder.java
@@ -34,6 +34,8 @@ import java.util.*;
  * controlling recording functionality.
  *
  * @author Pawel Domas
+ * @deprecated this class is going away soon together with {@link JvbRecorder}
+ * and {@link JireconRecorder}.
  */
 public abstract class Recorder
     implements PacketListener,


### PR DESCRIPTION
JibriRecorder will no longer extend deprecated Recorder. Also JibriRecorder instance lifetime will no longer be tied to the lifetime of a Colibri conference on the JVB. That's because it needs
to report Jibri availability even if the conference has expired. For example when there's just one participant left and the JVB conference is being expired.