### PR TITLE
Refactors JitsiMeetConferenceImpl

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
@@ -48,6 +48,12 @@ public class ChatMemberImpl
     private final String nickname;
 
     /**
+     * The region (e.g. "us-east") of this {@link ChatMemberImpl}, advertised
+     * by the remote peer in presence.
+     */
+    private String region;
+
+    /**
      * The chat room of the member.
      */
     private final ChatRoomImpl chatRoom;
@@ -262,6 +268,25 @@ public class ChatMemberImpl
                 this.robot = newStatus;
             }
         }
+
+        RegionPacketExtension regionPE
+            = (RegionPacketExtension)
+                presence.getExtension(
+                        RegionPacketExtension.ELEMENT_NAME,
+                        RegionPacketExtension.NAMESPACE);
+        if (regionPE != null)
+        {
+            region = regionPE.getRegionId();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRegion()
+    {
+        return region;
     }
 
     /**

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
@@ -78,6 +78,11 @@ public class XmppProtocolActivator
                 VideoMutedExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<>(
                         VideoMutedExtension.class));
+        smackInterOp.addExtensionProvider(
+                RegionPacketExtension.ELEMENT_NAME,
+                RegionPacketExtension.NAMESPACE,
+                new DefaultPacketExtensionProvider<>(
+                        RegionPacketExtension.class));
 
         // Override original Smack Version IQ class
         AbstractSmackInteroperabilityLayer.getInstance()

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -199,7 +199,7 @@ public class XmppProtocolProvider
      * <tt>false</tt> in case we have failed want to retry connection attempt.
      * <tt>true</tt> is returned when we either connect successfully or when we
      * detect that there is no chance to get connected any any future retries
-     * should be cancelled.
+     * should be canceled.
      */
     synchronized private boolean doConnect()
     {

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/extensions/RegionPacketExtension.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/extensions/RegionPacketExtension.java
@@ -1,0 +1,55 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.protocol.xmpp.extensions;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.*;
+
+/**
+ * A packet extension which contains an id of a region.
+ *
+ * @author Boris Grozev
+ */
+public class RegionPacketExtension
+    extends AbstractPacketExtension
+{
+    /**
+     * XML element name of this packet extension.
+     */
+    public static final String ELEMENT_NAME = "region";
+
+    /**
+     * XML namespace of this packet extension.
+     */
+    public static final String NAMESPACE = "http://jitsi.org/jitsi-meet";
+
+    /**
+     * Creates new instance of <tt>EtherpadPacketExt</tt>.
+     */
+    public RegionPacketExtension()
+    {
+        super(NAMESPACE, ELEMENT_NAME);
+    }
+
+    /**
+     * @return the value of the "id" attribute.
+     */
+    public String getRegionId()
+    {
+        return getAttributeAsString("id");
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeSelector.java
@@ -459,6 +459,14 @@ public class BridgeSelector
                     bridgeState.setVideoStreamCount(videoStreamCount);
                 }
             }
+            else if ("relay_id".equals(stat.getName()))
+            {
+                Object relayId = stat.getValue();
+                if (relayId != null)
+                {
+                    bridgeState.setRelayId(relayId.toString());
+                }
+            }
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeSelector.java
@@ -457,6 +457,14 @@ public class BridgeSelector
                     bridgeState.setRelayId(relayId.toString());
                 }
             }
+            else if ("region".equals(stat.getName()))
+            {
+                Object region = stat.getValue();
+                if (region != null)
+                {
+                    bridgeState.setRegion(region.toString());
+                }
+            }
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeSelector.java
@@ -729,7 +729,19 @@ public class BridgeSelector
                                   JitsiMeetConference conference,
                                   Participant participant)
         {
-            // TODO: take the region into account
+            // Prefer a bridge in the participant's region.
+            String participantRegion = participant.getChatMember().getRegion();
+            if (participantRegion != null)
+            {
+                for (BridgeState bridge : bridges)
+                {
+                    if (bridge.isOperational()
+                        && participantRegion.equals(bridge.getRegion()))
+                    {
+                        return bridge;
+                    }
+                }
+            }
 
             for (BridgeState bridge : bridges)
             {

--- a/src/main/java/org/jitsi/jicofo/BridgeState.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeState.java
@@ -69,6 +69,12 @@ class BridgeState
     private String relayId = null;
 
     /**
+     * The region advertised by the bridge, or {@code null} if none was
+     * advertised.
+     */
+    private String region = null;
+
+    /**
      * Accumulates video stream count changes coming from
      * {@link BridgeEvent#VIDEOSTREAMS_CHANGED} in order to estimate video
      * stream count on the bridge. The value is included in the result
@@ -301,4 +307,22 @@ class BridgeState
     {
         return version;
     }
+
+    /**
+     * @return the region of this {@link BridgeState}.
+     */
+    public String getRegion()
+    {
+        return region;
+    }
+
+    /**
+     * Sets the region (e.g. "us-east") of this {@link BridgeState}.
+     * @param region the value to set.
+     */
+    public void setRegion(String region)
+    {
+        this.region = region;
+    }
+
 }

--- a/src/main/java/org/jitsi/jicofo/BridgeState.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeState.java
@@ -100,12 +100,13 @@ class BridgeState
      * working bridges go down and might eventually get elevated back to
      * {@code true}.
      */
-    private boolean isOperational = true /* we assume it is operational */;
+    private volatile boolean isOperational
+        = true /* we assume it is operational */;
 
     /**
      * The time when this instance has failed.
      */
-    private long failureTimestamp;
+    private volatile long failureTimestamp;
 
     BridgeState(BridgeSelector bridgeSelector, String bridgeJid,
                 Version version)

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -151,6 +151,8 @@ public class ChannelAllocator implements Runnable
         {
             logger.error("Exception on participant invite", e);
         }
+
+        participant.channelAllocatorCompleted(this);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -102,7 +102,7 @@ public class ChannelAllocator implements Runnable
     private final boolean reInvite;
 
     /**
-     * A flag which indicates whether channel allocation is cancelled. Raising
+     * A flag which indicates whether channel allocation is canceled. Raising
      * this makes the allocation thread discontinue the allocation process and
      * return.
      */
@@ -186,7 +186,7 @@ public class ChannelAllocator implements Runnable
             offer = createOffer();
             if (offer == null)
             {
-                logger.info("Channel allocation cancelled for " + address);
+                logger.info("Channel allocation canceled for " + address);
                 return;
             }
         }
@@ -407,7 +407,7 @@ public class ChannelAllocator implements Runnable
                             participant.getEndpointId(),
                             true /* initiator */, contents);
 
-                // null means cancelled, because colibriConference has been
+                // null means canceled, because colibriConference has been
                 // disposed by another thread
                 if (peerChannels == null)
                 {

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -438,7 +438,7 @@ public class ChannelAllocator implements Runnable
                         != exc.getErrorCode())
                 {
                     bridgeSelector.updateBridgeOperationalStatus(jvb, false);
-                    bridgeDesc.bridgeHasFailed = true;
+                    bridgeDesc.hasFailed = true;
                 }
 
                 // Check if the conference is in progress

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -169,19 +169,19 @@ public class ChannelAllocator implements Runnable
         List<String> features = DiscoveryUtil.discoverParticipantFeatures(
                     meetConference.getXmppProvider(), address);
 
-        participant.setSupportedFeatures(features);
-
-        logger.info(
-            address + " has bundle ? " + participant.hasBundleSupport());
-
-        List<ContentPacketExtension> offer;
-
         if (canceled)
         {
             // Another thread intentionally called cancel() and it is its
             // responsibility to retry if necessary.
             return;
         }
+
+        participant.setSupportedFeatures(features);
+
+        logger.info(
+            address + " has bundle ? " + participant.hasBundleSupport());
+
+        List<ContentPacketExtension> offer;
 
         try
         {
@@ -231,7 +231,7 @@ public class ChannelAllocator implements Runnable
 
             expireChannels = true;
         }
-        else
+        else if (!canceled)
         {
             OperationSetJingle jingle = meetConference.getJingle();
             boolean ack;
@@ -349,11 +349,18 @@ public class ChannelAllocator implements Runnable
                 CHANNEL_ALLOCATION_FAILED_ERR_CODE);
         }
 
-        participant.setColibriChannelsInfo(colibriChannels);
+        if (!canceled)
+        {
+            participant.setColibriChannelsInfo(colibriChannels);
 
-        craftOffer(contents, colibriChannels);
+            craftOffer(contents, colibriChannels);
 
-        return contents;
+            return contents;
+        }
+        else
+        {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -438,6 +438,7 @@ public class ChannelAllocator implements Runnable
                         != exc.getErrorCode())
                 {
                     bridgeSelector.updateBridgeOperationalStatus(jvb, false);
+                    bridgeDesc.bridgeHasFailed = true;
                 }
 
                 // Check if the conference is in progress

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -414,7 +414,7 @@ public class ChannelAllocator implements Runnable
                     return null;
                 }
 
-                bridgeSelector.updateBridgeOperationalStatus(jvb, true);
+                bridgeDesc.bridgeState.setIsOperational(true);
 
                 if (bridgeDesc.colibriConference.hasJustAllocated())
                 {
@@ -437,7 +437,7 @@ public class ChannelAllocator implements Runnable
                 if (OperationFailedException.ILLEGAL_ARGUMENT
                         != exc.getErrorCode())
                 {
-                    bridgeSelector.updateBridgeOperationalStatus(jvb, false);
+                    bridgeDesc.bridgeState.setIsOperational(false);
                     bridgeDesc.hasFailed = true;
                 }
 

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -106,7 +106,7 @@ public class ChannelAllocator implements Runnable
      * this makes the allocation thread discontinue the allocation process and
      * return.
      */
-    private boolean canceled = false;
+    private volatile boolean canceled = false;
 
     /**
      * Initializes a new {@link ChannelAllocator} instance which is meant to

--- a/src/main/java/org/jitsi/jicofo/ConferenceUtility.java
+++ b/src/main/java/org/jitsi/jicofo/ConferenceUtility.java
@@ -45,16 +45,6 @@ public class ConferenceUtility
     }
 
     /**
-     * Returns the ID of Colibri conference hosted on the videobridge.
-     */
-    public String getJvbConferenceId()
-    {
-        ColibriConference colibriConference = conference.getColibriConference();
-        return colibriConference != null
-            ? colibriConference.getConferenceId() : null;
-    }
-
-    /**
      * Returns the id of video channel allocated for the participant with given
      * JID.
      * @param participantJid the MUC JID of the participant for whom we want to

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -17,7 +17,10 @@
  */
 package org.jitsi.jicofo;
 
+import org.jitsi.protocol.xmpp.*;
 import org.jitsi.util.*;
+
+import java.util.*;
 
 /**
  * The conference interface extracted from {@link JitsiMeetConferenceImpl} for
@@ -49,4 +52,27 @@ public interface JitsiMeetConference
      * @return {@link Participant} instance or <tt>null</tt> if not found.
      */
     Participant findParticipantForRoomJid(String mucJid);
+
+    /**
+     * @return the list of {@link BridgeState} currently used by this
+     * conference.
+     */
+    List<BridgeState> getBridges();
+
+    /**
+     * Returns the name of conference multi-user chat room.
+     */
+    public String getRoomName();
+
+    /**
+     * Returns focus MUC JID if it is in the room or <tt>null</tt> otherwise.
+     * JID example: room_name@muc.server.com/focus_nickname.
+     */
+    public String getFocusJid();
+
+    /**
+     * Returns <tt>ChatRoom2</tt> instance for the MUC this instance is
+     * currently in or <tt>null</tt> if it isn't in any.
+     */
+    public ChatRoom2 getChatRoom();
 }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -17,7 +17,6 @@
  */
 package org.jitsi.jicofo;
 
-import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.util.*;
 
 /**
@@ -50,14 +49,4 @@ public interface JitsiMeetConference
      * @return {@link Participant} instance or <tt>null</tt> if not found.
      */
     Participant findParticipantForRoomJid(String mucJid);
-
-    /**
-     * The {@link ColibriConference} for this instance.
-     *
-     * @return {@link ColibriConference} currently allocated on the JVB for the
-     * conference handled by this {@link JitsiMeetConference} instance or
-     * <tt>null</tt> if there isn't any for some reason (not started, broken or
-     * ended).
-     */
-    ColibriConference getColibriConference();
 }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2181,7 +2181,7 @@ public class JitsiMeetConferenceImpl
         {
             List<Participant> terminatedParticipants = new LinkedList<>();
             // sync on what?
-            for (Participant participant : participants)
+            for (Participant participant : new LinkedList<>(participants))
             {
                 if (terminate(participant))
                 {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2105,7 +2105,7 @@ public class JitsiMeetConferenceImpl
             for (BridgeDesc bridgeDesc : bridges)
             {
                 // TODO: do we actually want the hasFailed check?
-                if (!bridgeDesc.bridgeHasFailed)
+                if (!bridgeDesc.hasFailed)
                 {
                     bridgeStates.add(bridgeDesc.bridgeState);
                 }
@@ -2155,7 +2155,7 @@ public class JitsiMeetConferenceImpl
          * this flag to skip channel expiration step when the conference is being
          * disposed of.
          */
-        public boolean bridgeHasFailed = false;
+        public boolean hasFailed = false;
 
         /**
          * Initializes a new {@link BridgeDesc} instance.
@@ -2177,7 +2177,7 @@ public class JitsiMeetConferenceImpl
         {
             // We will not expire channels if the bridge is faulty or
             // when our connection is down
-            if (!bridgeHasFailed && protocolProviderHandler.isRegistered())
+            if (!hasFailed && protocolProviderHandler.isRegistered())
             {
                 colibriConference.expireConference();
             }
@@ -2230,7 +2230,7 @@ public class JitsiMeetConferenceImpl
             ColibriConferenceIQ channelsInfo
                 = participant.getColibriChannelsInfo();
 
-            if (channelsInfo != null && !bridgeHasFailed)
+            if (channelsInfo != null && !hasFailed)
             {
                 logger.info("Expiring channels for: " + participant.getMucJid());
                 colibriConference.expireChannels(channelsInfo);

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1856,9 +1856,7 @@ public class JitsiMeetConferenceImpl
         bridgeDesc.terminate(participant);
 
         // Retry once.
-        // TODO: be smarter about re-trying: e.g. don't retry if we know there
-        // was a bridge bridge
-        //
+        // TODO: be smarter about re-trying
         boolean retry = !channelAllocator.isReInvite();
 
         if (retry)

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -522,13 +522,15 @@ public class JitsiMeetConferenceImpl
             {
                 for (final ChatRoomMember member : chatRoom.getMembers())
                 {
-                    inviteChatMember(member, member == chatRoomMember);
+                    inviteChatMember(
+                            (XmppChatMember) member,
+                            member == chatRoomMember);
                 }
             }
             // Only the one who has just joined
             else
             {
-                inviteChatMember(chatRoomMember, true);
+                inviteChatMember((XmppChatMember) chatRoomMember, true);
             }
         }
     }
@@ -560,7 +562,7 @@ public class JitsiMeetConferenceImpl
      * result of just having joined (as opposed to e.g. another participant
      * joining triggering the invite).
      */
-    private void inviteChatMember(ChatRoomMember chatRoomMember,
+    private void inviteChatMember(XmppChatMember chatRoomMember,
                                   boolean justJoined)
     {
         synchronized (participantLock)
@@ -579,7 +581,7 @@ public class JitsiMeetConferenceImpl
             final Participant participant
                 = new Participant(
                         this,
-                        (XmppChatMember) chatRoomMember,
+                        chatRoomMember,
                         globalConfig.getMaxSSRCsPerUser());
 
             participants.add(participant);

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2058,25 +2058,6 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
-     * Returns the JID of one of the bridges used by this conference.
-     * TODO: remove this when the bridge selection strategy is properly
-     * implemented.
-     * @return the JID of one of the bridges used by this conference or
-     * {@code null} if the conference doesn't currently use any bridges.
-     */
-    public String getJvbJid()
-    {
-        for (BridgeDesc bridgeDesc : bridges)
-        {
-            if (bridgeDesc != null)
-            {
-                return bridgeDesc.bridgeState.getJid();
-            }
-        }
-        return null;
-    }
-
-    /**
      * Returns the COLIBRI conference ID of one of the bridges used by this
      * conference.
      * TODO: remove this (it is only used for testing)

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1581,8 +1581,9 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
-     * Returns the name of conference multi-user chat room.
+     * {@inheritDoc}
      */
+    @Override
     public String getRoomName()
     {
         return roomName;
@@ -1621,9 +1622,9 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
-     * Returns focus MUC JID if it is in the room or <tt>null</tt> otherwise.
-     * JID example: room_name@muc.server.com/focus_nickname.
+     * {@inheritDoc}
      */
+    @Override
     public String getFocusJid()
     {
 
@@ -1871,9 +1872,9 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
-     * Returns <tt>ChatRoom2</tt> instance for the MUC this instance is
-     * currently in or <tt>null</tt> if it isn't in any.
+     * {@inheritDoc}
      */
+    @Override
     public ChatRoom2 getChatRoom()
     {
         return chatRoom;
@@ -2091,6 +2092,28 @@ public class JitsiMeetConferenceImpl
         }
         return null;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<BridgeState> getBridges()
+    {
+        List<BridgeState> bridgeStates = new LinkedList<>();
+        synchronized (bridges)
+        {
+            for (BridgeDesc bridgeDesc : bridges)
+            {
+                // TODO: do we actually want the hasFailed check?
+                if (!bridgeDesc.bridgeHasFailed)
+                {
+                    bridgeStates.add(bridgeDesc.bridgeState);
+                }
+            }
+        }
+        return  bridgeStates;
+    }
+
 
     /**
      * The interface used to listen for conference events.

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -911,8 +911,8 @@ public class JitsiMeetConferenceImpl
                 // conference.
                 // bridgeDesc.terminateAll();
                 bridgeDesc.dispose();
-                bridges.remove(bridgeDesc);
             }
+            bridges.clear();
         }
 
         // TODO: what about removing the participants and ending their jingle

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2224,6 +2224,7 @@ public class JitsiMeetConferenceImpl
         public boolean terminate(Participant participant)
         {
             //TODO synchronize?
+            // TODO: make sure this does not block waiting for a response
             boolean removed = participants.remove(participant);
 
             ColibriConferenceIQ channelsInfo

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConfig.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConfig.java
@@ -243,7 +243,7 @@ public class JitsiMeetConfig
      * Returns the value of the start muted audio property.
      * @return the value of the start muted audio property.
      */
-    public Integer getAudioMuted()
+    public Integer getStartAudioMuted()
     {
         return getInt(START_AUDIO_MUTED);
     }
@@ -252,7 +252,7 @@ public class JitsiMeetConfig
      * Returns the value of the start muted video property.
      * @return the value of the start muted video property.
      */
-    public Integer getVideoMuted()
+    public Integer getStartVideoMuted()
     {
         return getInt(START_VIDEO_MUTED);
     }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
@@ -250,10 +250,7 @@ public class JitsiMeetRecording
                     response.setTo(recState.from);
                     response.setFrom(recState.to);
 
-                    ColibriConference colibriConference
-                        = meetConference.getColibriConference();
-                    if(colibriConference != null)
-                        response.setName(colibriConference.getName());
+                    response.setName(meetConference.getRoomName());
 
                     response.setRecording(
                             new ColibriConferenceIQ.Recording(

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetRecording.java
@@ -53,7 +53,7 @@ public class JitsiMeetRecording
      * The <tt>JitsiMeetConferenceImpl</tt> for which this instance is dealing
      * with all the recording related stuff.
      */
-    private final JitsiMeetConferenceImpl meetConference;
+    private final JitsiMeetConference meetConference;
 
     /**
      * Recording functionality implementation backend.
@@ -165,7 +165,9 @@ public class JitsiMeetRecording
             String from, String token,
             ColibriConferenceIQ.Recording.State state, String path, String to)
     {
-        ChatRoomMember member = meetConference.findMember(from);
+        ChatRoom2 chatRoom = meetConference.getChatRoom();
+        ChatRoomMember member
+            = chatRoom == null ? null : chatRoom.findChatMember(from);
         if (member == null)
         {
             logger.error("No member found for address: " + from);

--- a/src/main/java/org/jitsi/jicofo/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/JvbDoctor.java
@@ -363,7 +363,7 @@ public class JvbDoctor
                 if (!tasks.containsKey(bridgeJid))
                 {
                     logger.info(
-                            "Health check task cancelled for: " + bridgeJid);
+                            "Health check task canceled for: " + bridgeJid);
                     return false;
                 }
                 return true;

--- a/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
+++ b/src/main/java/org/jitsi/jicofo/MeetExtensionsHandler.java
@@ -30,7 +30,6 @@ import org.jitsi.jicofo.event.*;
 import org.jitsi.jicofo.jigasi.*;
 import org.jitsi.jicofo.util.*;
 import org.jitsi.protocol.xmpp.*;
-import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.protocol.xmpp.util.*;
 import org.jitsi.util.*;
 import org.jitsi.eventadmin.*;

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -156,6 +156,17 @@ public class Participant
     private String displayName = null;
 
     /**
+     * Used to synchronize access to {@link #channelAllocator}.
+     */
+    private final Object channelAllocatorSyncRoot = new Object();
+
+    /**
+     * The {@link ChannelAllocator}, if any, which is currently allocating
+     * channels for this participant.
+     */
+    private ChannelAllocator channelAllocator = null;
+
+    /**
      * Creates new {@link Participant} for given chat room member.
      *
      * @param roomMember the {@link XmppChatMember} that represent this
@@ -747,5 +758,28 @@ public class Participant
     public String getMucJid()
     {
         return roomMember.getContactAddress();
+    }
+
+    /**
+     * Replaces the {@link ChannelAllocator}, which is currently allocating
+     * channels for this participant (if any) with the specified channel
+     * allocator (if any).
+     * @param channelAllocator the channel allocator to set, or {@code null}
+     * to clear it.
+     */
+    public void setChannelAllocator(ChannelAllocator channelAllocator)
+    {
+        synchronized (channelAllocatorSyncRoot)
+        {
+            if (this.channelAllocator != null)
+            {
+                // There is an ongoing thread allocating channels and sending
+                // an invite for this participant. Tell it to stop.
+                this.channelAllocator.cancel();
+                logger.warn("Canceling a ChannelAllocator.");
+            }
+
+            this.channelAllocator = channelAllocator;
+        }
     }
 }

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -782,4 +782,22 @@ public class Participant
             this.channelAllocator = channelAllocator;
         }
     }
+
+    /**
+     * Signals to this {@link Participant} that a specific
+     * {@link ChannelAllocator} has completed its task and its thread is about
+     * to terminate.
+     * @param channelAllocator the {@link ChannelAllocator} which has completed
+     * its task and its thread is about to terminate.
+     */
+    void channelAllocatorCompleted(ChannelAllocator channelAllocator)
+    {
+        synchronized (channelAllocatorSyncRoot)
+        {
+            if (this.channelAllocator == channelAllocator)
+            {
+                this.channelAllocator = null;
+            }
+        }
+    }
 }

--- a/src/main/java/org/jitsi/jicofo/VersionBroadcaster.java
+++ b/src/main/java/org/jitsi/jicofo/VersionBroadcaster.java
@@ -132,7 +132,7 @@ public class VersionBroadcaster
 
         String roomJid = (String) event.getProperty(EventFactory.ROOM_JID_KEY);
 
-        JitsiMeetConferenceImpl conference
+        JitsiMeetConference conference
             = focusManager.getConference(roomJid);
         if (conference == null)
         {

--- a/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/JireconRecorder.java
@@ -88,7 +88,7 @@ public class JireconRecorder
      * @param connection XMPP connection instance which will be used for
      * communication.
      */
-    public JireconRecorder(JitsiMeetConferenceImpl conference,
+    public JireconRecorder(JitsiMeetConference conference,
                            String recorderComponentJid,
                            XmppConnection connection)
     {

--- a/src/main/java/org/jitsi/protocol/xmpp/OperationSetSubscription.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/OperationSetSubscription.java
@@ -43,7 +43,7 @@ public interface OperationSetSubscription
 
     /**
      * Cancels subscriptions for given <tt>node</tt>.
-     * @param node the node for which subscription will be cancelled.
+     * @param node the node for which subscription will be canceled.
      * @param listener subscription listener to be registered.
      */
     void unSubscribe(String node, SubscriptionListener listener);

--- a/src/main/java/org/jitsi/protocol/xmpp/XmppChatMember.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/XmppChatMember.java
@@ -62,4 +62,9 @@ public interface XmppChatMember
      * otherwise.
      */
     boolean isRobot();
+
+    /**
+     * Gets the region (e.g. "us-east") of this {@link XmppChatMember}.
+     */
+    String getRegion();
 }

--- a/src/test/java/mock/muc/MockRoomMember.java
+++ b/src/test/java/mock/muc/MockRoomMember.java
@@ -168,4 +168,10 @@ public class MockRoomMember
         // FIXME: not implemented
         return null;
     }
+
+    @Override
+    public String getRegion()
+    {
+        return null;
+    }
 }

--- a/src/test/java/mock/util/TestConference.java
+++ b/src/test/java/mock/util/TestConference.java
@@ -48,7 +48,7 @@ public class TestConference
 
     private MockProtocolProvider focusProtocolProvider;
 
-    private JitsiMeetConference conference;
+    public JitsiMeetConferenceImpl conference;
 
     private MockVideobridge mockBridge;
 
@@ -168,7 +168,7 @@ public class TestConference
     public long[] getSimulcastLayersSSRCs(String peerJid)
     {
         ConferenceUtility confUtility = getConferenceUtility();
-        String conferenceId = confUtility.getJvbConferenceId();
+        String conferenceId = conference.getJvbConferenceId();
         String videoChannelId
             = confUtility.getParticipantVideoChannelId(peerJid);
         List<RTPEncodingDesc> layers

--- a/src/test/java/org/jitsi/jicofo/BridgeSelectorTest.java
+++ b/src/test/java/org/jitsi/jicofo/BridgeSelectorTest.java
@@ -49,6 +49,9 @@ public class BridgeSelectorTest
     private static String jvb1Jid = "jvb1.test.domain.net";
     private static String jvb2Jid = "jvb2.test.domain.net";
     private static String jvb3Jid = "jvb3.test.domain.net";
+    private static BridgeState jvb1State;
+    private static BridgeState jvb2State;
+    private static BridgeState jvb3State;
     private static String jvb1PubSubNode = "jvb1";
     private static String jvb2PubSubNode = "jvb2";
     private static String jvb3PubSubNode = "jvb3";
@@ -96,9 +99,9 @@ public class BridgeSelectorTest
         capsOpSet.addChildNode(jvb2Node);
         capsOpSet.addChildNode(jvb3Node);
 
-        meetServices.getBridgeSelector().addJvbAddress(jvb1Jid);
-        meetServices.getBridgeSelector().addJvbAddress(jvb2Jid);
-        meetServices.getBridgeSelector().addJvbAddress(jvb3Jid);
+        jvb1State = meetServices.getBridgeSelector().addJvbAddress(jvb1Jid);
+        jvb2State = meetServices.getBridgeSelector().addJvbAddress(jvb2Jid);
+        jvb3State = meetServices.getBridgeSelector().addJvbAddress(jvb3Jid);
     }
 
     @Test
@@ -127,33 +130,33 @@ public class BridgeSelectorTest
                      selector.getBridgeForPubSubNode(jvb3PubSubNode));
 
         // Test bridge operational status
-        List<String> workingBridges = new ArrayList<String>();
+        List<String> workingBridges = new ArrayList<>();
         workingBridges.add(jvb1Jid);
         workingBridges.add(jvb2Jid);
         workingBridges.add(jvb3Jid);
 
-        assertTrue(workingBridges.contains(
-                selector.selectVideobridge(null).getJid()));
+        BridgeState bridgeState = selector.selectVideobridge(null);
+        assertTrue(workingBridges.contains(bridgeState.getJid()));
 
         // Bridge 1 is down !!!
         workingBridges.remove(jvb1Jid);
-        selector.updateBridgeOperationalStatus(jvb1Jid, false);
+        jvb1State.setIsOperational(false);
 
         assertTrue(workingBridges.contains(
                 selector.selectVideobridge(null).getJid()));
 
         // Bridge 2 is down !!!
         workingBridges.remove(jvb2Jid);
-        selector.updateBridgeOperationalStatus(jvb2Jid, false);
+        jvb2State.setIsOperational(false);
 
         assertEquals(jvb3Jid, selector.selectVideobridge(null).getJid());
 
         // Bridge 1 is up again, but 3 is down instead
         workingBridges.add(jvb1Jid);
-        selector.updateBridgeOperationalStatus(jvb1Jid, true);
+        jvb1State.setIsOperational(true);
 
         workingBridges.remove(jvb3Jid);
-        selector.updateBridgeOperationalStatus(jvb3Jid, false);
+        jvb3State.setIsOperational(false);
 
         assertEquals(jvb1Jid, selector.selectVideobridge(null).getJid());
 
@@ -162,9 +165,9 @@ public class BridgeSelectorTest
         workingBridges.add(jvb1Jid);
         workingBridges.add(jvb2Jid);
         workingBridges.add(jvb3Jid);
-        selector.updateBridgeOperationalStatus(jvb1Jid, true);
-        selector.updateBridgeOperationalStatus(jvb2Jid, true);
-        selector.updateBridgeOperationalStatus(jvb3Jid, true);
+        jvb1State.setIsOperational(true);
+        jvb2State.setIsOperational(true);
+        jvb3State.setIsOperational(true);
 
         MockSubscriptionOpSetImpl mockSubscriptions
             = mockProvider.getMockSubscriptionOpSet();
@@ -189,20 +192,20 @@ public class BridgeSelectorTest
         assertEquals(jvb1Jid, selector.selectVideobridge(null).getJid());
 
         // Jvb 1 is gone
-        selector.updateBridgeOperationalStatus(jvb1Jid, false);
+        jvb1State.setIsOperational(false);
 
         assertEquals(jvb2Jid, selector.selectVideobridge(null).getJid());
 
         // TEST all bridges down
-        selector.updateBridgeOperationalStatus(jvb2Jid, false);
-        selector.updateBridgeOperationalStatus(jvb3Jid, false);
+        jvb2State.setIsOperational(false);
+        jvb3State.setIsOperational(false);
         assertEquals(null, selector.selectVideobridge(null));
 
         // Now bridges are up and select based on conference count
         // with pre-configured bridge
-        selector.updateBridgeOperationalStatus(jvb1Jid, true);
-        selector.updateBridgeOperationalStatus(jvb2Jid, true);
-        selector.updateBridgeOperationalStatus(jvb3Jid, true);
+        jvb1State.setIsOperational(true);
+        jvb2State.setIsOperational(true);
+        jvb3State.setIsOperational(true);
 
         mockSubscriptions.fireSubscriptionNotification(
                 jvb1PubSubNode, itemId, createJvbStats(1));
@@ -233,7 +236,7 @@ public class BridgeSelectorTest
         while (selector.selectVideobridge(null) != null)
         {
             BridgeState bridge = selector.selectVideobridge(null);
-            selector.updateBridgeOperationalStatus(bridge.getJid(), false);
+            bridge.setIsOperational(false);
             if (--maxCount < 0)
             {
                 fail("Max count exceeded");
@@ -246,6 +249,8 @@ public class BridgeSelectorTest
             throws InterruptedException
     {
         String[] nodes = new String[]{ jvb1Jid, jvb2Jid, jvb3Jid};
+        BridgeState[] states
+            = new BridgeState[] {jvb1State, jvb2State, jvb3State};
 
         String[] pubSubNodes
             = new String[] { jvb1PubSubNode, jvb2PubSubNode, jvb3PubSubNode};
@@ -266,7 +271,7 @@ public class BridgeSelectorTest
                     createJvbStats(isTestNode ? 0 : 100));
 
                 // ... and is not operational
-                selector.updateBridgeOperationalStatus(nodes[idx], !isTestNode);
+                states[idx].setIsOperational(!isTestNode);
             }
             // Should not be selected now
             assertNotEquals(

--- a/src/test/java/org/jitsi/jicofo/JvbDoctorTest.java
+++ b/src/test/java/org/jitsi/jicofo/JvbDoctorTest.java
@@ -35,8 +35,7 @@ import org.junit.runners.*;
 
 import java.util.concurrent.*;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import static org.mockito.Mockito.*;
 
@@ -170,7 +169,7 @@ public class JvbDoctorTest
             assertNotNull(conference);
 
             // No jvb currently in use
-            assertNull(testConf.conference.getJvbJid());
+            assertTrue(testConf.conference.getBridges().isEmpty());
         }
 
         // Bridge is now healthy again
@@ -189,7 +188,7 @@ public class JvbDoctorTest
 
             assertNotNull(conference);
 
-            assertNotNull(testConf.conference.getJvbJid());
+            assertFalse(testConf.conference.getBridges().isEmpty());
         }
 
         mockBridge.stop(osgi.bc);

--- a/src/test/java/org/jitsi/jicofo/JvbDoctorTest.java
+++ b/src/test/java/org/jitsi/jicofo/JvbDoctorTest.java
@@ -170,7 +170,7 @@ public class JvbDoctorTest
             assertNotNull(conference);
 
             // No jvb currently in use
-            assertNull(testConf.getConferenceUtility().getJvbConferenceId());
+            assertNull(testConf.conference.getJvbJid());
         }
 
         // Bridge is now healthy again
@@ -189,8 +189,7 @@ public class JvbDoctorTest
 
             assertNotNull(conference);
 
-            assertNotNull(
-                testConf.getConferenceUtility().getJvbConferenceId());
+            assertNotNull(testConf.conference.getJvbJid());
         }
 
         mockBridge.stop(osgi.bc);

--- a/src/test/java/org/jitsi/jicofo/MockJitsiMeetConference.java
+++ b/src/test/java/org/jitsi/jicofo/MockJitsiMeetConference.java
@@ -17,7 +17,6 @@
  */
 package org.jitsi.jicofo;
 
-import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.util.*;
 
 /**
@@ -42,15 +41,6 @@ public class MockJitsiMeetConference
      */
     @Override
     public Participant findParticipantForRoomJid(String jid)
-    {
-        return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ColibriConference getColibriConference()
     {
         return null;
     }

--- a/src/test/java/org/jitsi/jicofo/MockJitsiMeetConference.java
+++ b/src/test/java/org/jitsi/jicofo/MockJitsiMeetConference.java
@@ -17,7 +17,10 @@
  */
 package org.jitsi.jicofo;
 
+import org.jitsi.protocol.xmpp.*;
 import org.jitsi.util.*;
+
+import java.util.*;
 
 /**
  * Mock {@link JitsiMeetConference} implementation.
@@ -41,6 +44,30 @@ public class MockJitsiMeetConference
      */
     @Override
     public Participant findParticipantForRoomJid(String jid)
+    {
+        return null;
+    }
+
+    @Override
+    public List<BridgeState> getBridges()
+    {
+        return new LinkedList<>();
+    }
+
+    @Override
+    public String getRoomName()
+    {
+        return null;
+    }
+
+    @Override
+    public String getFocusJid()
+    {
+        return null;
+    }
+
+    @Override
+    public ChatRoom2 getChatRoom()
     {
         return null;
     }


### PR DESCRIPTION
Uses a list of bridges and refactors the invitations process to take
this into account.

This is in preparation for support for multi-bridge support (currently
the bridge selection algorithm is unmodified).