### PR TITLE
Update XmppProtocolProvider.java

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -160,8 +160,8 @@ public class XmppProtocolProvider
         ConnectionConfiguration connConfig
             = new ConnectionConfiguration(
                     serverAddressUserSetting, serverPort, serviceName);
-                    // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but trys to authenticate
-                    // with GSSAPI when it's offered by the server. Disable GSSAPI.
+        // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but trys to authenticate
+        // with GSSAPI when it's offered by the server. Disable GSSAPI.
                     SASLAuthentication.unsupportSASLMechanism("GSSAPI");
                  
         connection = new XMPPConnection(connConfig);

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -160,6 +160,18 @@ public class XmppProtocolProvider
         ConnectionConfiguration connConfig
             = new ConnectionConfiguration(
                     serverAddressUserSetting, serverPort, serviceName);
+                    
+                    // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but might try to authenticate
+                    // with a non supported mechanism if one is offered by the server. 
+                    // This moves the preference of PLAIN to the top, and disables the unused mechanisms.
+                    
+                    SASLAuthentication.supportSASLMechanism("PLAIN",0);                    
+                    SASLAuthentication.unsupportSASLMechanism("DIGEST-MD5");
+                    SASLAuthentication.unsupportSASLMechanism("CRAM-MD5");
+                    SASLAuthentication.unsupportSASLMechanism("JIVE-SHAREDSECRET");
+                    SASLAuthentication.unsupportSASLMechanism("SCRAM-SHA-1");
+                    SASLAuthentication.unsupportSASLMechanism("GSSAPI");
+                    SASLAuthentication.unsupportSASLMechanism("EXTERNAL");
 
         connection = new XMPPConnection(connConfig);
 

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -162,7 +162,7 @@ public class XmppProtocolProvider
                     serverAddressUserSetting, serverPort, serviceName);
         // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but trys to authenticate
         // with GSSAPI when it's offered by the server. Disable GSSAPI.
-                    SASLAuthentication.unsupportSASLMechanism("GSSAPI");
+        SASLAuthentication.unsupportSASLMechanism("GSSAPI");
                  
         connection = new XMPPConnection(connConfig);
 

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -160,11 +160,8 @@ public class XmppProtocolProvider
         ConnectionConfiguration connConfig
             = new ConnectionConfiguration(
                     serverAddressUserSetting, serverPort, serviceName);
-                    
                     // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but trys to authenticate
-                    // with GSSAPI when it's offered is offered by the server. 
-                    //                   
-                                
+                    // with GSSAPI when it's offered by the server. Disable GSSAPI.
                     SASLAuthentication.unsupportSASLMechanism("GSSAPI");
                  
         connection = new XMPPConnection(connConfig);

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -161,18 +161,12 @@ public class XmppProtocolProvider
             = new ConnectionConfiguration(
                     serverAddressUserSetting, serverPort, serviceName);
                     
-                    // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but might try to authenticate
-                    // with a non supported mechanism if one is offered by the server. 
-                    // This moves the preference of PLAIN to the top, and disables the unused mechanisms.
-                    
-                    SASLAuthentication.supportSASLMechanism("PLAIN",0);                    
-                    SASLAuthentication.unsupportSASLMechanism("DIGEST-MD5");
-                    SASLAuthentication.unsupportSASLMechanism("CRAM-MD5");
-                    SASLAuthentication.unsupportSASLMechanism("JIVE-SHAREDSECRET");
-                    SASLAuthentication.unsupportSASLMechanism("SCRAM-SHA-1");
+                    // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but trys to authenticate
+                    // with GSSAPI when it's offered is offered by the server. 
+                    //                   
+                                
                     SASLAuthentication.unsupportSASLMechanism("GSSAPI");
-                    SASLAuthentication.unsupportSASLMechanism("EXTERNAL");
-
+                 
         connection = new XMPPConnection(connConfig);
 
         if (logger.isTraceEnabled())


### PR DESCRIPTION
The focus user connects with SASL Mechanisms ANONYMOUS or PLAIN, but might try to authenticate  with a non supported mechanism if one is offered by the server.  This moves the preference of PLAIN to the top, and disables the unused mechanisms.  This should resolve issue #203
https://github.com/jitsi/jicofo/issues/203