### PR TITLE
fix(ChannelAllocator): break the loop if the jvb has failed

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -570,6 +570,17 @@ public class ChatRoomImpl
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean containsPresenceExtension(String elementName,
+                                             String namespace)
+    {
+        return lastPresenceSent != null
+            && lastPresenceSent.getExtension(elementName, namespace) != null;
+    }
+
     @Override
     public Message createMessage(byte[] content, String contentType,
                                  String contentEncoding, String subject)

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -399,7 +399,8 @@ public class ChannelAllocator implements Runnable
         // allocator thread dies before this thread get the chance to allocate
         // anything, then it will cancel and channels for this Participant will
         // be allocated from 'restartConference'
-        while (!bridgeSession.colibriConference.isDisposed())
+        while (!bridgeSession.colibriConference.isDisposed()
+                && !bridgeSession.hasFailed)
         {
             try
             {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -633,9 +633,17 @@ public class JitsiMeetConferenceImpl
             if (bridgeState == null)
             {
                 // Can not find a bridge to use.
-                logger.error("Can not invite participant -- no bridge"
-                                 + " available.");
-                // TODO: update presence with BRIDGE_NOT_AVAILABLE?
+                logger.error(
+                        "Can not invite participant -- no bridge available.");
+
+                if (chatRoom != null
+                    && !chatRoom.containsPresenceExtension(
+                            BridgeNotAvailablePacketExt.ELEMENT_NAME,
+                            BridgeNotAvailablePacketExt.NAMESPACE))
+                {
+                    meetTools.sendPresenceExtension(
+                            chatRoom, new BridgeNotAvailablePacketExt());
+                }
                 return null;
 
             }

--- a/src/main/java/org/jitsi/protocol/xmpp/ChatRoom2.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/ChatRoom2.java
@@ -54,6 +54,16 @@ public interface ChatRoom2
     Collection<PacketExtension> getPresenceExtensions();
 
     /**
+     * Checks if a packet extension is already in the presence.
+     *
+     * @param elementName the name of XML element of the presence extension.
+     * @param namespace the namespace of XML element of the presence extension.
+     *
+     * @return <tt>boolean</tt>
+     */
+    boolean containsPresenceExtension(String elementName, String namespace);
+
+    /**
      * Modifies our current MUC presence by adding and/or removing specified
      * extensions. The extension are compared by instance equality.
      * @param toRemove the list of extensions to be removed.

--- a/src/test/java/mock/muc/MockMultiUserChat.java
+++ b/src/test/java/mock/muc/MockMultiUserChat.java
@@ -89,6 +89,13 @@ public class MockMultiUserChat
     }
 
     @Override
+    public boolean containsPresenceExtension(
+        String elementName, String namespace)
+    {
+        return false;
+    }
+
+    @Override
     public void modifyPresence(
         Collection<PacketExtension> toRemove, Collection<PacketExtension> toAdd)
     {


### PR DESCRIPTION
Fixes problem with infinite loop when bridge is in the graceful shutdown mode.