### PR TITLE
Don't start an unused SOCKS5 proxy.

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
@@ -99,6 +99,8 @@ public class XmppProtocolActivator
 
         SmackConfiguration.setPacketReplyTimeout(15000);
 
+        SmackConfiguration.setLocalSocks5ProxyEnabled(false);
+
         registerXmppExtensions();
 
         XmppProviderFactory focusFactory


### PR DESCRIPTION
This commit prevents the default SOCKS5 proxy (from Smack) from being started.