### PR TITLE
Introduces StatsId and colibri changes around it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <assembly.skipAssembly>true</assembly.skipAssembly>
     <jetty.version>8.1.16.v20140903</jetty.version>
     <smack.version>4.2.1</smack.version>
-    <jitsi-desktop.version>2.13.77e7a10</jitsi-desktop.version>
+    <jitsi-desktop.version>2.13.9aab784</jitsi-desktop.version>
   </properties>
 
   <dependencies>
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-videobridge</artifactId>
-      <version>1.1-20171010.193133-1</version>
+      <version>1.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-videobridge</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.1-20171017.010459-5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
@@ -95,6 +95,11 @@ public class ChatMemberImpl
      */
     private Boolean videoMuted;
 
+    /**
+     * Stores statistics ID for the member.
+     */
+    private String statsId;
+
     public ChatMemberImpl(EntityFullJid participant, ChatRoomImpl chatRoom,
                           int joinOrderNumber)
     {
@@ -304,6 +309,15 @@ public class ChatMemberImpl
                 chatRoom.setStartMuted(startMuted);
             }
         }
+
+        StatsId statsIdPacketExt
+            = presence.getExtension(
+                    StatsId.ELEMENT_NAME,
+                    StatsId.NAMESPACE);
+        if (statsIdPacketExt != null)
+        {
+            statsId = statsIdPacketExt.getStatsId();
+        }
     }
 
     /**
@@ -313,6 +327,15 @@ public class ChatMemberImpl
     public String getRegion()
     {
         return region;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getStatsId()
+    {
+        return statsId;
     }
 
     /**

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolActivator.java
@@ -81,6 +81,10 @@ public class XmppProtocolActivator
                 RegionPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<>(
                         RegionPacketExtension.class));
+        ProviderManager.addExtensionProvider(
+                StatsId.ELEMENT_NAME,
+                StatsId.NAMESPACE,
+                new StatsId.Provider());
 
         // Override original Smack Version IQ class
         ProviderManager.addIQProvider(

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -125,8 +125,10 @@ public class ColibriConferenceImpl
         = new ColibriBuilder(conferenceState);
 
     /**
-     * Flag used to figure out if Colibri conference has been allocated during
-     * last {@link #createColibriChannels(boolean, String, boolean, List)} call.
+     * Flag used to figure out if Colibri conference has been
+     * allocated during last
+     * {@link #createColibriChannels(boolean, String, String, boolean, List)}
+     * call.
      */
     private boolean justAllocated = false;
 
@@ -253,6 +255,7 @@ public class ColibriConferenceImpl
     public ColibriConferenceIQ createColibriChannels(
             boolean useBundle,
             String endpointName,
+            String statsId,
             boolean peerIsInitiator,
             List<ContentPacketExtension> contents)
         throws OperationFailedException
@@ -287,7 +290,11 @@ public class ColibriConferenceImpl
                 colibriBuilder.reset();
 
                 colibriBuilder.addAllocateChannelsReq(
-                    useBundle, endpointName, peerIsInitiator, contents);
+                    useBundle,
+                    endpointName,
+                    statsId,
+                    peerIsInitiator,
+                    contents);
 
                 allocateRequest = colibriBuilder.getRequest(jitsiVideobridge);
             }
@@ -477,7 +484,8 @@ public class ColibriConferenceImpl
 
     /**
      * Sends Colibri packet and waits for response in
-     * {@link #createColibriChannels(boolean, String, boolean, List)} call.
+     * {@link #createColibriChannels(boolean, String, String, boolean, List)}
+     * call.
      *
      * Exposed for unit tests purpose.
      *

--- a/src/main/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/BridgeSelector.java
@@ -850,7 +850,7 @@ public class BridgeSelector
      * A {@link BridgeSelectionStrategy} implementation which keeps all
      * participants in a conference on the same bridge.
      */
-    private static class SingleBridgeSelectionStrategy
+    public static class SingleBridgeSelectionStrategy
         extends BridgeSelectionStrategy
     {
         /**

--- a/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ChannelAllocator.java
@@ -413,6 +413,7 @@ public class ChannelAllocator implements Runnable
                     = bridgeSession.colibriConference.createColibriChannels(
                             participant.hasBundleSupport(),
                             participant.getEndpointId(),
+                            participant.getStatId(),
                             true /* initiator */, contents);
 
                 // null means canceled, because colibriConference has been

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -743,6 +743,15 @@ public class Participant
     }
 
     /**
+     * Returns the stats ID of the participant.
+     * @return the stats ID of the participant.
+     */
+    public String getStatId()
+    {
+        return roomMember.getStatsId();
+    }
+
+    /**
      * Sets the display name of the participant.
      * @param displayName the display name to set.
      */

--- a/src/main/java/org/jitsi/protocol/xmpp/XmppChatMember.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/XmppChatMember.java
@@ -73,4 +73,10 @@ public interface XmppChatMember
      * Gets the region (e.g. "us-east") of this {@link XmppChatMember}.
      */
     String getRegion();
+
+    /**
+     * Gets the statistics id if any.
+     * @return the statistics ID for this member.
+     */
+    String getStatsId();
 }

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -95,6 +95,7 @@ public interface ColibriConference
      * @param useBundle <tt>true</tt> if channel transport bundle should be used
      *                  for this allocation.
      * @param endpointName the name that will identify channels endpoint.
+     * @param statsId the statistics Id to use if any.
      * @param peerIsInitiator <tt>true</tt> if peer is ICE an initiator
      *                        of ICE session.
      * @param contents content list that describes peer media.
@@ -106,6 +107,7 @@ public interface ColibriConference
     ColibriConferenceIQ createColibriChannels(
             boolean                         useBundle,
             String                          endpointName,
+            String                          statsId,
             boolean                         peerIsInitiator,
             List<ContentPacketExtension>    contents)
         throws    OperationFailedException;

--- a/src/test/java/mock/muc/MockRoomMember.java
+++ b/src/test/java/mock/muc/MockRoomMember.java
@@ -188,4 +188,10 @@ public class MockRoomMember
     {
         return null;
     }
+
+    @Override
+    public String getStatsId()
+    {
+        return null;
+    }
 }

--- a/src/test/java/org/jitsi/jicofo/ColibriTest.java
+++ b/src/test/java/org/jitsi/jicofo/ColibriTest.java
@@ -113,13 +113,13 @@ public class ColibriTest
 
         ColibriConferenceIQ peer1Channels
             = colibriConf.createColibriChannels(
-                peer1UseBundle, peer1, true, contents);
+                peer1UseBundle, peer1, null, true, contents);
 
         assertEquals(3 , mockBridge.getChannelsCount());
 
         ColibriConferenceIQ peer2Channels
             = colibriConf.createColibriChannels(
-                peer2UseBundle, peer2, true, contents);
+                peer2UseBundle, peer2, null, true, contents);
 
         assertEquals(6 , mockBridge.getChannelsCount());
 
@@ -132,6 +132,14 @@ public class ColibriTest
                      1, peer1Channels.getChannelBundles().size());
         assertEquals("Peer 2 should have single bundle allocated !",
                      1, peer2Channels.getChannelBundles().size());
+        assertEquals("Peer 1 should have single endpoint allocated !",
+            1, peer1Channels.getEndpoints().size());
+        assertEquals("Peer 2 should have single endpoint allocated !",
+            1, peer2Channels.getEndpoints().size());
+        assertEquals("Peer 1 have wrong endpoint id allocated !",
+            peer1, peer1Channels.getEndpoints().get(0).getId());
+        assertEquals("Peer 2 have wrong endpoint id allocated !",
+            peer2, peer2Channels.getEndpoints().get(0).getId());
 
         colibriConf.expireChannels(peer2Channels);
 

--- a/src/test/java/org/jitsi/jicofo/ColibriThreadingTest.java
+++ b/src/test/java/org/jitsi/jicofo/ColibriThreadingTest.java
@@ -362,9 +362,8 @@ public class ColibriThreadingTest
                 {
                     try
                     {
-                        channels
-                            = colibriConference.createColibriChannels(
-                                    true, endpointName, true, createContents());
+                        channels = colibriConference.createColibriChannels(
+                            true, endpointName, null, true, createContents());
                     }
                     catch (OperationFailedException e)
                     {


### PR DESCRIPTION
Changes colibri to use <endpoint and stops using <channel-bundle. Uses statsId if available.