### PR TITLE
Uses an error message to prevent NPE in smack.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/xmpp/FocusComponent.java
+++ b/src/main/java/org/jitsi/jicofo/xmpp/FocusComponent.java
@@ -365,7 +365,8 @@ public class FocusComponent
                 if (identity == null)
                 {
                     // Error not authorized
-                    return ErrorFactory.createNotAuthorizedError(query, null);
+                    return ErrorFactory.createNotAuthorizedError(
+                        query, "not authorized user domain");
                 }
             }
         }


### PR DESCRIPTION
Smack currently do not support errors without text and NPE is thrown
when operating over these stanzas. There is a PR to fix that https://github.com/igniterealtime/Smack/pull/178