### PR TITLE
Simplifies stop logic.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
@@ -324,10 +324,7 @@ public class JibriSession
                 "Updating status from JIBRI: "
                     + iq.toXML() + " for " + roomName);
 
-            // We stop either on "off" or on "failed"
-            if ((JibriIq.Status.OFF.equals(status)
-                    || JibriIq.Status.FAILED.equals(status))
-                    && currentJibriJid != null)
+            if (JibriIq.Status.FAILED.equals(status) && currentJibriJid != null)
             {
                 // Make sure that there is XMPPError for eventual ERROR status
                 XMPPError error = iq.getError();


### PR DESCRIPTION
Fixes a sync issue where when we decide to give up waiting for jibri and
 mark it as stopped, jibri enters the room. We make sure we send stop to
  it if we stop waiting.