### PR TITLE
Do not reuse HTTP client connections during reservation

### DIFF
--- a/src/main/java/org/jitsi/impl/reservation/rest/ApiHandler.java
+++ b/src/main/java/org/jitsi/impl/reservation/rest/ApiHandler.java
@@ -22,6 +22,7 @@ import org.apache.http.*;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.*;
 import org.apache.http.client.methods.*;
+import org.apache.http.impl.*;
 import org.apache.http.impl.client.*;
 import org.apache.http.message.*;
 import org.apache.http.util.*;
@@ -56,7 +57,10 @@ public class ApiHandler
      * HTTP client used for sending requests.
      */
     private final CloseableHttpClient client
-            = HttpClientBuilder.create().build();
+            = HttpClientBuilder
+              .create()
+              .setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE)
+              .build();
 
     /**
      * <tt>JSONParser</tt> instance used for parsing JSON.


### PR DESCRIPTION
When Jicofo sends HTTP requests to the reservation system using the reservation API, the request would fail with NoHttpResponseException for roughly every even numbered request. e.g. When creating conferences one after another, the second conference creation would fail. This causes Jicofo to return error which is shown at the Jitsi Meet client.

We have pin point the cause of the error to incorrect usage of the Apache HTTP client by Jicofo. This patch is an attempt to work around the bug by not reusing a HTTP connection.

Several other attempts have been made to mitigate the error, but none have been successful. We verified that there is no problem with the HTTP server, as it doesn't receive any HTTP request, even with dummy HTTP server running at localhost. We tested this against manual build of the master branch on Ubuntu.

There might be other ways to fix the problem, but I am not a Java expert and this is the best solution I can find. Feel free to take other approach as long as this bug can be fixed.

Following is a sampled stack trace of the error (With some details altered):

```
Jicofo 2017-12-11 06:42:22.993 INFO: [64] org.jitsi.jicofo.xmpp.FocusComponent.handleConferenceIq().402 Focus request for room: test@muc.conference.jitsi.test
Jicofo 2017-12-11 06:42:22.993 INFO: [64] org.jitsi.impl.reservation.rest.ApiHandler.createNewConference().124 Sending post: {name=test, start_time=2017-12-11T06:
42:22.993Z, duration=-1}
Jicofo 2017-12-11 06:42:22.995 SEVERE: [64] org.jitsi.impl.reservation.rest.RESTReservations.createConference().193 org.apache.http.NoHttpResponseException: 127.0.0.1:8080 failed to respond
org.apache.http.NoHttpResponseException: 127.0.0.1:8080 failed to respond
        at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:143)
        at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:57)
        at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:261)
        at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:165)
        at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:167)
        at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:272)
        at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:124)
        at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:271)
        at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184)
        at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:88)
        at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:107)
        at org.jitsi.impl.reservation.rest.ApiHandler.createNewConference(ApiHandler.java:130)
        at org.jitsi.impl.reservation.rest.RESTReservations.createConference(RESTReservations.java:141)
        at org.jitsi.jicofo.xmpp.FocusComponent.processExtensions(FocusComponent.java:380)
        at org.jitsi.jicofo.xmpp.FocusComponent.handleConferenceIq(FocusComponent.java:415)
        at org.jitsi.jicofo.xmpp.FocusComponent.handleIQSetImpl(FocusComponent.java:260)
        at org.jitsi.xmpp.component.ComponentBase.handleIQSet(ComponentBase.java:362)
        at org.xmpp.component.AbstractComponent.processIQRequest(AbstractComponent.java:515)
        at org.xmpp.component.AbstractComponent.processIQ(AbstractComponent.java:289)
        at org.xmpp.component.AbstractComponent.processQueuedPacket(AbstractComponent.java:239)
        at org.xmpp.component.AbstractComponent.access$100(AbstractComponent.java:81)
        at org.xmpp.component.AbstractComponent$PacketProcessor.run(AbstractComponent.java:1051)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jitsi/jicofo/248)
<!-- Reviewable:end -->
