### PR TITLE
Fixes logoutIQ to xml/string.

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/extensions/LogoutIq.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/extensions/LogoutIq.java
@@ -106,6 +106,7 @@ public class LogoutIq
                 throw new RuntimeException(e);
             }
         }
+        xml.setEmptyElement();
         return xml;
     }
 


### PR DESCRIPTION
Fixes error when authentication is enabled and you try to logout:
Jicofo 2017-12-13 10:57:25.604 SEVERE: [80] org.jitsi.jicofo.xmpp.FocusComponent.handleIQSetImpl().325 org.dom4j.DocumentException: Error on line 1 of document  : Element type "logout" must be followed by either attribute specifications, ">" or "/>". Nested exception: Element type "logout" must be followed by either attribute specifications, ">" or "/>".
org.dom4j.DocumentException: Error on line 1 of document  : Element type "logout" must be followed by either attribute specifications, ">" or "/>". Nested exception: Element type "logout" must be followed by either attribute specifications, ">" or "/>".
at org.dom4j.io.SAXReader.read(SAXReader.java:482)
at org.dom4j.io.SAXReader.read(SAXReader.java:365)
at org.jitsi.xmpp.util.IQUtils.convert(IQUtils.java:68)
at org.jitsi.jicofo.xmpp.FocusComponent.handleIQSetImpl(FocusComponent.java:316)