### PR TITLE
Fix SSRC validation

### DIFF
--- a/src/main/java/org/jitsi/jicofo/SSRCValidator.java
+++ b/src/main/java/org/jitsi/jicofo/SSRCValidator.java
@@ -74,7 +74,7 @@ public class SSRCValidator
      * The limit sources count per media type allowed to be stored by
      * each {@link Participant} at a time.
      */
-    private int maxSourceCount;
+    private final int maxSourceCount;
 
     /**
      * Filters out FID groups that do belong to any simulcast grouping.
@@ -212,16 +212,6 @@ public class SSRCValidator
     }
 
     /**
-     * Returns how many sources per media type per participant is allowed in the
-     * conference.
-     * @return an integer
-     */
-    public int getMaxSourceCount()
-    {
-        return this.maxSourceCount;
-    }
-
-    /**
      * Checks how many sources are current in the conference for given
      * participant.
      *
@@ -240,19 +230,6 @@ public class SSRCValidator
                     SSRCSignaling.getSSRCOwner(source), owner))
             .count();
 
-    }
-
-    /**
-     * Sets how many sources can be advertised by each participant of each media
-     * type.
-     * @param maxSourceCount an integer value. If lesser or equal to zero no
-     * sources will be allowed which may or may not make any sense, but this
-     * value is configurable with the value default of
-     * {@link JitsiMeetGlobalConfig#DEFAULT_MAX_SSRC_PER_USER}.
-     */
-    public void setMaxSourceCount(int maxSourceCount)
-    {
-        this.maxSourceCount = maxSourceCount;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/SSRCValidator.java
+++ b/src/main/java/org/jitsi/jicofo/SSRCValidator.java
@@ -28,6 +28,7 @@ import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.*;
 
 import java.util.*;
+import java.util.stream.*;
 
 /**
  * Utility class that wraps the process of validating new sources and source
@@ -94,20 +95,13 @@ public class SSRCValidator
             return new ArrayList<>(fidGroups);
         }
 
-        List<SourceGroup> independentFidGroups = new LinkedList<>();
-
-        for (SourceGroup fidGroup : fidGroups)
-        {
-            for (SimulcastGrouping simGrouping : simGroupings)
-            {
-                if (!simGrouping.belongsToSimulcastGrouping(fidGroup))
-                {
-                    independentFidGroups.add(fidGroup);
-                }
-            }
-        }
-
-        return independentFidGroups;
+        return fidGroups.stream()
+            .filter(
+                fidGroup -> simGroupings.stream()
+                    .noneMatch(
+                        simGroup ->
+                            simGroup.belongsToSimulcastGrouping(fidGroup))
+                ).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/SSRCSignaling.java
@@ -251,7 +251,8 @@ public class SSRCSignaling
      * signaled through {@link SSRCInfoPacketExtension}.
      * @param ssrcPe the <tt>SourcePacketExtension</tt> instance for which we
      *               want to find an owner.
-     * @return MUC jid of the user who own this SSRC.
+     * @return MUC {@link Jid} of the user who owns this source or <tt>null</tt>
+     * if it's not owned by anyone.
      */
     public static Jid getSSRCOwner(SourcePacketExtension ssrcPe)
     {

--- a/src/test/java/org/jitsi/jicofo/SSRCValidatorTest.java
+++ b/src/test/java/org/jitsi/jicofo/SSRCValidatorTest.java
@@ -123,6 +123,49 @@ public class SSRCValidatorTest
                 new long[] { 50L, 60L }));
     }
 
+    /**
+     * This will add sources and groups to {@link #videoSources} and
+     * {@link #videoGroups} which will consist of one 3 layered SIM group,
+     * where each of those layers will consist of 2 RTX SSRCs (6 SSRC numbers
+     * needed).
+     *
+     * @param cname the cname that will be used in the source description.
+     * @param msid the msid that will be used in the source description.
+     * @param videoSourcesArray an array of exactly 6 SSRC numbers.
+     */
+    private void addSimAndRtxParticipantVideoSources(
+        String cname, String msid, long[] videoSourcesArray)
+    {
+        videoSources.add(createSSRC(videoSourcesArray[0], cname, msid));
+        videoSources.add(createSSRC(videoSourcesArray[1], cname, msid));
+        videoSources.add(createSSRC(videoSourcesArray[2], cname, msid));
+        videoSources.add(createSSRC(videoSourcesArray[3], cname, msid));
+        videoSources.add(createSSRC(videoSourcesArray[4], cname, msid));
+        videoSources.add(createSSRC(videoSourcesArray[5], cname, msid));
+
+        videoGroups.add(
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_FID,
+                new long[] { videoSourcesArray[0], videoSourcesArray[1] }));
+        videoGroups.add(
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_FID,
+                new long[] { videoSourcesArray[2], videoSourcesArray[3] }));
+        videoGroups.add(
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_FID,
+                new long[] { videoSourcesArray[4], videoSourcesArray[5] }));
+        videoGroups.add(
+            createGroup(
+                SourceGroupPacketExtension.SEMANTICS_SIMULCAST,
+                new long[]
+                    {
+                        videoSourcesArray[0],
+                        videoSourcesArray[2],
+                        videoSourcesArray[4]
+                    }));
+    }
+
     private SSRCValidator createValidator()
     {
         return new SSRCValidator(
@@ -132,6 +175,36 @@ public class SSRCValidatorTest
                 JitsiMeetGlobalConfig.getGlobalConfig(osgi.bc)
                     .getMaxSourcesPerUser(),
                 logger);
+    }
+
+    @Test
+    public void test2ParticipantsWithSimAndRtx()
+        throws InvalidSSRCsException
+    {
+        addSimAndRtxParticipantVideoSources(
+                "videocname",
+                "vstream vtrack",
+                new long[]
+                    {
+                        10L, 20L, 30L, 40L, 50L, 60L
+                    });
+
+        SSRCValidator validator = createValidator();
+        validator.tryAddSourcesAndGroups(sources, groups);
+
+        videoSources.clear();
+        videoGroups.clear();
+        addSimAndRtxParticipantVideoSources(
+                "videocname2",
+                "vstream2 vtrack2",
+                new long[]
+                    {
+                        100L, 200L, 300L, 400L, 500L, 600L
+                    });
+
+        // Not creating new validator instance will make it remember previously
+        // added sources and groups just like in the conference.
+        validator.tryAddSourcesAndGroups(sources, groups);
     }
 
     @Test

--- a/src/test/java/org/jitsi/jicofo/SSRCValidatorTest.java
+++ b/src/test/java/org/jitsi/jicofo/SSRCValidatorTest.java
@@ -166,15 +166,21 @@ public class SSRCValidatorTest
                     }));
     }
 
-    private SSRCValidator createValidator()
+    private SSRCValidator createValidator(int maxSourcesPerUser)
     {
         return new SSRCValidator(
                 "someEndpointId",
                 new MediaSourceMap(),
                 new MediaSourceGroupMap(),
-                JitsiMeetGlobalConfig.getGlobalConfig(osgi.bc)
-                    .getMaxSourcesPerUser(),
+                maxSourcesPerUser,
                 logger);
+    }
+
+    private SSRCValidator createValidator()
+    {
+        return createValidator(
+                JitsiMeetGlobalConfig.getGlobalConfig(osgi.bc)
+                    .getMaxSourcesPerUser());
     }
 
     @Test
@@ -564,8 +570,7 @@ public class SSRCValidatorTest
         audioSources.add(createSourceWithSsrc(5L));
         audioSources.add(createSourceWithSsrc(6L));
 
-        SSRCValidator ssrcValidator = createValidator();
-        ssrcValidator.setMaxSourceCount(maxSsrcCount);
+        SSRCValidator ssrcValidator = createValidator(maxSsrcCount);
 
         Object[] ssrcsAndGroups
             = ssrcValidator.tryAddSourcesAndGroups(sources, groups);


### PR DESCRIPTION
SSRCValidator used to check SSRC correctness only on per each participant basis, but it will not catch all of the problems. All sources have to be checked as a whole, from all participants, as this gets merged into one remote SDP on the client.