### PR TITLE
Add option to always trust XMPP domain certificate.

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -47,8 +47,7 @@ import org.jxmpp.stringprep.*;
 
 import javax.net.ssl.*;
 import java.io.*;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
+import java.security.cert.*;
 import java.util.*;
 import java.util.concurrent.*;
 

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -25,14 +25,12 @@ import net.java.sip.communicator.util.*;
 
 import org.jitsi.eventadmin.*;
 import org.jitsi.impl.protocol.xmpp.colibri.*;
-import org.jitsi.jicofo.FocusBundleActivator;
-import org.jitsi.jicofo.FocusManager;
+import org.jitsi.jicofo.*;
 import org.jitsi.jicofo.recording.jibri.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.retry.*;
-import org.jitsi.service.configuration.ConfigurationService;
-import org.jitsi.util.Logger;
+import org.jitsi.service.configuration.*;
 
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.filter.*;

--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -100,6 +100,14 @@ public class FocusManager
         = "org.jitsi.jicofo.FOCUS_USER_PASSWORD";
 
     /**
+     * The name of the configuration property that specifies if certificates of
+     * the XMPP domain name should be verified, or always trusted. If not
+     * provided then 'false' (should verify) is used.
+     */
+    public static final String ALWAYS_TRUST_PNAME
+        = "org.jitsi.jicofo.ALWAYS_TRUST_MODE_ENABLED";
+
+    /**
      * The name of the property used to configure a 1-byte identifier of this
      * Jicofo instance, used for the purpose of generating conference IDs unique
      * across a set of Jicofo instances.


### PR DESCRIPTION
When jicofo connects to the XMPP domain, it uses a default, Smack-provided
implementation that controls verification and validation of the server-provided
TLS certificate. In certain setups, it is desirable to override this behavior,
and allow any certificate that's provided.

This commit adds an option that, once enabled, causes Jicofo to trust any and
all certificate that is provided by the XMPP server that it conntects to.