### PR TITLE
Fix #203 - Disables GSSAPI

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -36,7 +36,7 @@ import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.filter.*;
 import org.jivesoftware.smack.iqrequest.*;
 import org.jivesoftware.smack.packet.*;
-import org.jivesoftware.smack.sasl.javax.SASLGSSAPIMechanism;
+import org.jivesoftware.smack.sasl.javax.*;
 import org.jivesoftware.smack.tcp.*;
 import org.jivesoftware.smackx.disco.packet.*;
 import org.jxmpp.jid.*;
@@ -204,9 +204,11 @@ public class XmppProtocolProvider
                 .setXmppDomain(serviceName);
         ReconnectionManager.setEnabledPerDefault(true);
 
-        // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but tries to authenticate
-        // with GSSAPI when it's offered by the server. Disable GSSAPI.
-        SASLAuthentication.unregisterSASLMechanism( SASLGSSAPIMechanism.class.getName() );
+        // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but tries
+        // authenticate with GSSAPI when it's offered by the server.
+        // Disable GSSAPI.
+        SASLAuthentication.unregisterSASLMechanism(
+            SASLGSSAPIMechanism.class.getName());
 
         if (jabberAccountID.isAnonymousAuthUsed())
         {

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -36,6 +36,7 @@ import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.filter.*;
 import org.jivesoftware.smack.iqrequest.*;
 import org.jivesoftware.smack.packet.*;
+import org.jivesoftware.smack.sasl.javax.SASLGSSAPIMechanism;
 import org.jivesoftware.smack.tcp.*;
 import org.jivesoftware.smackx.disco.packet.*;
 import org.jxmpp.jid.*;
@@ -202,6 +203,10 @@ public class XmppProtocolProvider
                 .setPort(serverPort)
                 .setXmppDomain(serviceName);
         ReconnectionManager.setEnabledPerDefault(true);
+
+        // focus uses SASL Mechanisms ANONYMOUS and PLAIN, but tries to authenticate
+        // with GSSAPI when it's offered by the server. Disable GSSAPI.
+        SASLAuthentication.unregisterSASLMechanism( SASLGSSAPIMechanism.class.getName() );
 
         if (jabberAccountID.isAnonymousAuthUsed())
         {


### PR DESCRIPTION
Focus fails to connect when other SASLMechs are offered by Openfire. This should address #203 