### PR TITLE
don't reset currentJibriJid to null too soon

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
@@ -254,6 +254,7 @@ public class JibriSession
         // skip stop request if its already stopped
         if (JibriIq.Status.OFF.equals(jibriStatus))
         {
+            currentJibriJid = null;
             return;
         }
 
@@ -334,7 +335,6 @@ public class JibriSession
                         XMPPError.Condition.internal_server_error,
                         "Unknown error").build();
                 }
-                this.currentJibriJid = null;
                 tryStartRestartJibri(error);
             }
             else


### PR DESCRIPTION
later on down this chain we need to send a stop messages and, if the jid
is already null we exit early.  there was one path that could exit
return before we reached that point, so it needs its own null
assignment.