### PR TITLE
fix: Handles a failure to establish a jingle session by retrying once…

### DIFF
--- a/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
@@ -220,7 +220,7 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
             // a failure to invite the participant in the jingle level, we will
             // not trigger a retry here.
             // In any case, try and expire the channels on the bridge.
-            bridgeSession.terminate(participant);
+            meetConference.onInviteFailed(this);
         }
         else if (reInvite)
         {


### PR DESCRIPTION
… and then removing the participant.