### PR TITLE
add a log when we receive a jibri status

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
@@ -126,6 +126,8 @@ public class JibriDetector
         EntityFullJid jid,
         JibriStatusPacketExt presenceExt)
     {
+        logger.info("Received Jibri status " + presenceExt.toXML());
+
         JibriStatusPacketExt.Status status = presenceExt.getStatus();
 
         if (JibriStatusPacketExt.Status.UNDEFINED.equals(status))


### PR DESCRIPTION
We're seeing Jicofo randomly report Jibris as going offline.  Jicofo will think a Jibri went offline if it gets an 'undefined' status extension from Jibri, so adding a log here to see if that's what may be going on.