### PR TITLE
fix: prevent hiding original exception when MUC start fails.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -364,7 +364,18 @@ public class JitsiMeetConferenceImpl
         }
         catch (Exception e)
         {
-            stop();
+            try
+            {
+                stop();
+            }
+            catch (Exception x)
+            {
+                logger.warn("An exception was caught while invoking stop()"
+                    + " as part of handling another exception that occurred"
+                    + " while invoking start(). This is the exception that"
+                    + " stop() threw (start()'s exception will be thrown"
+                    + " next).", x);
+            }
 
             throw e;
         }


### PR DESCRIPTION
When starting/joining a MUC fails, 'leave' is called as part of the
exception handling. In case 'leave' throws an exception, this exception
should not be thrown instead of the original exception that was thrown
when start failed.