### PR TITLE
fix: add IntelliJ's metadata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .classpath
 .project
 .settings/
+**/.idea/
+*.iml


### PR DESCRIPTION
This is in line with what the videobridge project has.