### PR TITLE
fix deadlock

### DIFF
--- a/src/main/java/org/jitsi/jicofo/auth/AbstractAuthAuthority.java
+++ b/src/main/java/org/jitsi/jicofo/auth/AbstractAuthAuthority.java
@@ -410,10 +410,7 @@ public abstract class AbstractAuthAuthority
     public IQ processAuthentication(
             ConferenceIq query, ConferenceIq response)
     {
-        synchronized (syncRoot)
-        {
-            return processAuthLocked(query, response);
-        }
+        return processAuthLocked(query, response);
     }
 
     /**


### PR DESCRIPTION
I believe this lock to be greedy.  I've tested by rapidly requesting conferences to jicofo.  With this fix jicofo is not running in to deadlock i reported here: https://github.com/jitsi/jicofo/issues/309