### PR TITLE
ref(AbstractAuthAuthority): relax sync on read methods

### DIFF
--- a/src/main/java/org/jitsi/jicofo/auth/AbstractAuthAuthority.java
+++ b/src/main/java/org/jitsi/jicofo/auth/AbstractAuthAuthority.java
@@ -19,6 +19,7 @@ package org.jitsi.jicofo.auth;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.*;
 
 import org.jitsi.impl.protocol.xmpp.extensions.*;
 import org.jitsi.jicofo.*;
@@ -138,6 +139,25 @@ public abstract class AbstractAuthAuthority
     }
 
     /**
+     * Finds an {@link AuthenticationSession} session.
+     *
+     * @param selector - Must return <tt>true</tt> when a match is found.
+     * @return the first {@link AuthenticationSession} that matches given
+     * predicate or <tt>null</tt>.
+     */
+    protected AuthenticationSession findSession(
+        Predicate<AuthenticationSession> selector)
+    {
+        ArrayList<AuthenticationSession> sessions
+            = new ArrayList<>(authenticationSessions.values());
+
+        return sessions
+            .stream()
+            .filter(selector)
+            .findFirst().orElse(null);
+    }
+
+    /**
      * Creates new <tt>AuthenticationSession</tt> for given parameters.
      *
      * @param machineUID unique machine identifier for new session.
@@ -236,19 +256,10 @@ public abstract class AbstractAuthAuthority
         {
             return null;
         }
-        synchronized (syncRoot)
-        {
-            for (AuthenticationSession session
-                    : authenticationSessions.values())
-            {
-                if (session.getUserIdentity().equals(authIdentity)
-                        && session.getMachineUID().equals(machineUID))
-                {
-                    return session;
-                }
-            }
-            return null;
-        }
+
+        return findSession(
+            session -> session.getUserIdentity().equals(authIdentity)
+                            && session.getMachineUID().equals(machineUID));
     }
 
     /**
@@ -266,17 +277,9 @@ public abstract class AbstractAuthAuthority
         {
             return null;
         }
-        synchronized (syncRoot)
-        {
-            for(AuthenticationSession session : authenticationSessions.values())
-            {
-                if (jabberId.equals(session.getUserJabberId()))
-                {
-                    return session;
-                }
-            }
-        }
-        return null;
+
+        return findSession(
+            session -> jabberId.equals(session.getUserJabberId()));
     }
 
     /**


### PR DESCRIPTION
It is fine for the read-only methods to not lock the syncRoot. This
tries to fix the following deadlock:

Found one Java-level deadlock:
=============================
"pool-7-thread-17":
  waiting to lock monitor 0x00007f1c780375a8 (object 0x000000070048bdf0, a java.lang.Object),
  which is held by "pool-7-thread-10"
"pool-7-thread-10":
  waiting to lock monitor 0x00007f1c78035ef8 (object 0x0000000782512f08, a java.util.HashMap),
  which is held by "Smack-Single Threaded Executor 0 (0)"
"Smack-Single Threaded Executor 0 (0)":
  waiting to lock monitor 0x00007f1c780375a8 (object 0x000000070048bdf0, a java.lang.Object),
  which is held by "pool-7-thread-10"

Java stack information for the threads listed above:
===================================================
"pool-7-thread-17":
	at org.jitsi.jicofo.auth.AbstractAuthAuthority.processAuthentication(AbstractAuthAuthority.java:347)
	- waiting to lock <0x000000070048bdf0> (a java.lang.Object)
	at org.jitsi.jicofo.xmpp.FocusComponent.processExtensions(FocusComponent.java:292)
	at org.jitsi.jicofo.xmpp.FocusComponent.handleConferenceIq(FocusComponent.java:343)
	at org.jitsi.jicofo.xmpp.FocusComponent.handleIQSetImpl(FocusComponent.java:221)
	at org.jitsi.xmpp.component.ComponentBase.handleIQSet(ComponentBase.java:362)
	at org.xmpp.component.AbstractComponent.processIQRequest(AbstractComponent.java:515)
	at org.xmpp.component.AbstractComponent.processIQ(AbstractComponent.java:289)
	at org.xmpp.component.AbstractComponent.processQueuedPacket(AbstractComponent.java:239)
	at org.xmpp.component.AbstractComponent.access$100(AbstractComponent.java:81)
	at org.xmpp.component.AbstractComponent$PacketProcessor.run(AbstractComponent.java:1051)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
"pool-7-thread-10":
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.getMembers(ChatRoomImpl.java:597)
	- waiting to lock <0x0000000782512f08> (a java.util.HashMap)
	at org.jitsi.jicofo.ChatRoomRoleAndPresence.jidAuthenticated(ChatRoomRoleAndPresence.java:313)
	at org.jitsi.jicofo.auth.AbstractAuthAuthority.notifyUserAuthenticated(AbstractAuthAuthority.java:336)
	at org.jitsi.jicofo.auth.AbstractAuthAuthority.authenticateJidWithSession(AbstractAuthAuthority.java:413)
	at org.jitsi.jicofo.auth.XMPPDomainAuthAuthority.processAuthLocked(XMPPDomainAuthAuthority.java:98)
	at org.jitsi.jicofo.auth.AbstractAuthAuthority.processAuthentication(AbstractAuthAuthority.java:347)
	- locked <0x000000070048bdf0> (a java.lang.Object)
	at org.jitsi.jicofo.xmpp.FocusComponent.processExtensions(FocusComponent.java:292)
	at org.jitsi.jicofo.xmpp.FocusComponent.handleConferenceIq(FocusComponent.java:343)
	at org.jitsi.jicofo.xmpp.FocusComponent.handleIQSetImpl(FocusComponent.java:221)
	at org.jitsi.xmpp.component.ComponentBase.handleIQSet(ComponentBase.java:362)
	at org.xmpp.component.AbstractComponent.processIQRequest(AbstractComponent.java:515)
	at org.xmpp.component.AbstractComponent.processIQ(AbstractComponent.java:289)
	at org.xmpp.component.AbstractComponent.processQueuedPacket(AbstractComponent.java:239)
	at org.xmpp.component.AbstractComponent.access$100(AbstractComponent.java:81)
	at org.xmpp.component.AbstractComponent$PacketProcessor.run(AbstractComponent.java:1051)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
"Smack-Single Threaded Executor 0 (0)":
	at org.jitsi.jicofo.auth.AbstractAuthAuthority.findSessionForJabberId(AbstractAuthAuthority.java:226)
	- waiting to lock <0x000000070048bdf0> (a java.lang.Object)
	at org.jitsi.jicofo.auth.AbstractAuthAuthority.getSessionForJid(AbstractAuthAuthority.java:251)
	at org.jitsi.jicofo.ChatRoomRoleAndPresence.checkGrantOwnerToAuthUser(ChatRoomRoleAndPresence.java:294)
	at org.jitsi.jicofo.ChatRoomRoleAndPresence.memberPresenceChanged(ChatRoomRoleAndPresence.java:146)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.lambda$notifyMemberJoined$32(ChatRoomImpl.java:915)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl$$Lambda$7/204059536.accept(Unknown Source)
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:890)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.notifyMemberJoined(ChatRoomImpl.java:915)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.processOtherPresence(ChatRoomImpl.java:1198)
	- locked <0x0000000782512f08> (a java.util.HashMap)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.processPresence(ChatRoomImpl.java:1239)
	at org.jivesoftware.smackx.muc.MultiUserChat$3.processStanza(MultiUserChat.java:251)
	at org.jivesoftware.smack.AbstractXMPPConnection$5.run(AbstractXMPPConnection.java:1229)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

Found 1 deadlock.