### PR TITLE
Provide default location of Jitsi-Meet config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ from anonymous domain. Here's what has to be configured:
      c2s_require_encryption = false
  ```
 2 In Jitsi Meet config.js configure 'anonymousdomain':<br/>
+
+(If you have installed jitsi-meet from the Debian package, these changes should be made in /etc/jitsi/meet/[your-hostname]-config.js)
+
 ```
 var config = {
     hosts: {


### PR DESCRIPTION
This patch saves users the trouble of having to find the Jitsi-Meet `config.js` file after installation from the Debian packages (same as is done for the Prosody config files in step #1 of the Secure Domain instructions).