### PR TITLE
Try to fallback to another Jibri in case of an error

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriDetector.java
@@ -133,7 +133,7 @@ public class JibriDetector
         Jid jid,
         JibriStatusPacketExt presenceExt)
     {
-        logger.info("Received Jibri status " + presenceExt.toXML());
+        logger.info("Received Jibri " + jid + " status " + presenceExt.toXML());
 
         if (presenceExt.isAvailable())
         {


### PR DESCRIPTION
If a jibri session encounters an error, we'll try and find another
available jibri to continue the current service.