### PR TITLE
fix and reenable JvbDoctorTest

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -806,7 +806,7 @@ public class JitsiMeetConferenceImpl
                         reInvite);
 
             participant.setChannelAllocator(channelAllocator);
-            FocusBundleActivator.getSharedThreadPool().submit(channelAllocator);
+            FocusBundleActivator.getSharedThreadPool().execute(channelAllocator);
         }
     }
 
@@ -2852,7 +2852,7 @@ public class JitsiMeetConferenceImpl
                     JitsiMeetConferenceImpl.this, this, octoParticipant);
             octoParticipant.setChannelAllocator(channelAllocator);
 
-            FocusBundleActivator.getSharedThreadPool().submit(channelAllocator);
+            FocusBundleActivator.getSharedThreadPool().execute(channelAllocator);
 
             return octoParticipant;
         }

--- a/src/main/java/org/jitsi/jicofo/jigasi/TranscriberManager.java
+++ b/src/main/java/org/jitsi/jicofo/jigasi/TranscriberManager.java
@@ -167,11 +167,11 @@ public class TranscriberManager
             // puts the stopping in the single threaded executor
             // so we can order the events and avoid indicating active = false
             // while we are starting due to concurrent presences processed
-            executorService.submit(this::stopTranscribing);
+            executorService.execute(this::stopTranscribing);
         }
         if(isRequestingTranscriber(presence) && !active)
         {
-            executorService.submit(this::startTranscribing);
+            executorService.execute(this::startTranscribing);
         }
     }
 


### PR DESCRIPTION
I was able to replicate the problem with the randomly failing `JvbDoctorTest` locally by running the test repeatedly (~ 20 times).
The failure was due to asynchronous event dispatch and [Mockito picking up the first invocation when using verification timeouts](https://stackoverflow.com/questions/22944202/mockito-wait-for-an-invocation-that-matches-arguments). I've fixed and reenabled the test.

Also, I've changed `executorService.submit(...)` invocations in JiCoFo to `executorService.execute(...)`, since the former [will not pass the Throwable to the UncaughtExceptionHandler](https://stackoverflow.com/a/3986509). 
This is also a problem in other repositories of the Jitsi codebase. Sometimes, this is addressed by having the submitted `Runnable`s  log any thrown `Exception`s in a `try/catch`, but it's safer to use `execute` since this also handles `Error`s appropriately.