### PR TITLE
Fix index out of bounds

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -943,13 +943,20 @@ public class ColibriConferenceImpl
             {
                 for (String contentName : descriptionMap.keySet())
                 {
-                    ColibriConferenceIQ.Channel channel
-                        = localChannelsInfo.getContent(contentName)
-                            .getChannels().get(0);
-                    send |= colibriBuilder.addRtpDescription(
-                            descriptionMap.get(contentName),
-                            contentName,
-                            channel);
+                    ColibriConferenceIQ.Content content = localChannelsInfo.getContent(contentName);
+                    if (content != null)
+                    {
+                        if (content.getChannelCount() > 0)
+                        {
+                            ColibriConferenceIQ.Channel channel
+                                    = localChannelsInfo.getContent(contentName)
+                                        .getChannels().get(0);
+                            send |= colibriBuilder.addRtpDescription(
+                                    descriptionMap.get(contentName),
+                                    contentName,
+                                    channel);
+                        }
+                    }
                 }
             }
             // SSRCs


### PR DESCRIPTION
Fix index out of bounds crash when description name does not exist or there
is no channel for the content. Example: Data content does not have a channel
but has SctpConnection instead.