### PR TITLE
Optimizations around participant re-invite and failure handling

### DIFF
--- a/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
@@ -174,9 +174,6 @@ public abstract class AbstractChannelAllocator implements Runnable
         {
             logger.error("Channel allocator failed: " + participant);
 
-            // Notify conference about failure
-            meetConference.onChannelAllocationFailed(this, !isReInvite());
-
             // Cancel this task - nothing to be done after failure
             cancel();
             return;
@@ -295,12 +292,12 @@ public abstract class AbstractChannelAllocator implements Runnable
                 if (!StringUtils.isNullOrEmpty(
                     bridgeSession.colibriConference.getConferenceId()))
                 {
+                    // Cancel this instance
+                    cancel();
+
                     // Notify the conference that this ColibriConference is now
                     // broken.
                     meetConference.onBridgeDown(jvb);
-
-                    // This thread will end after returning null here
-                    cancel();
                     return null;
                 }
             }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2188,100 +2188,16 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
-     * Method called by {@link AbstractChannelAllocator} when it fails to
-     * allocate channels with {@link OperationFailedException}. We need to make
-     * some decisions here.
-     *
-     * @param channelAllocator the {@link AbstractChannelAllocator} instance
-     * which is reporting the error.
-     */
-    void onChannelAllocationFailed(
-            AbstractChannelAllocator channelAllocator,
-            boolean retry)
-    {
-        // We're gonna handle this, no more work for this
-        // AbstractChannelAllocator.
-        channelAllocator.cancel();
-
-        if (channelAllocator instanceof ParticipantChannelAllocator)
-        {
-            // FIXME get rid of bridgeFailure argument and do separate method
-            // call.
-            onParticipantInviteFailed(
-                (ParticipantChannelAllocator) channelAllocator,
-                retry,
-                /* bridgeFailure */ true);
-        }
-        else if (channelAllocator instanceof OctoChannelAllocator)
-        {
-            onOctoChannelAllocationFailed(
-                (OctoChannelAllocator) channelAllocator);
-        }
-        else
-        {
-            logger.error("Unknown allocator type:");
-        }
-    }
-
-    /**
-     * Handles a failure to allocate channels for Octo.
-     * @param channelAllocator the {@link OctoChannelAllocator} which failed.
-     */
-    private void onOctoChannelAllocationFailed(
-        OctoChannelAllocator channelAllocator)
-    {
-        logger.error("Failed to allocate Octo channels.");
-        onBridgeDown(channelAllocator.getBridgeSession().bridge.getJid());
-    }
-
-    /**
      * A callback called by {@link ParticipantChannelAllocator} when
      * establishing the Jingle session with its participant fails.
      * @param channelAllocator the channel allocator which failed.
      */
     void onInviteFailed(ParticipantChannelAllocator channelAllocator)
     {
-        onParticipantInviteFailed(
-            channelAllocator,
-            /* retry */ false,
-            /* bridge failure */ false);
-    }
-
-    /**
-     * Handles a failure to invite a participant to the conference. This could
-     * be due to a failure to allocate colibri channels, or a Jingle failure.
-     *
-     * @param channelAllocator the {@link ParticipantChannelAllocator} which
-     * failed.
-     * @param retry whether we should re-try to invite the participant.
-     * @param bridgeFailure Whether the failure was a result of a problem with
-     * the jitsi-videobridge instance, in which case we should consider the
-     * bridge unhealthy.
-     */
-    private void onParticipantInviteFailed(
-        ParticipantChannelAllocator channelAllocator,
-        boolean retry,
-        boolean bridgeFailure)
-    {
-        Participant participant = channelAllocator.getParticipant();
-
-        if (retry)
-        {
-            reInviteParticipant(participant);
-        }
-        else
-        {
-            terminateParticipant(
-                participant,
+        terminateParticipant(
+                channelAllocator.getParticipant(),
                 Reason.GENERAL_ERROR,
-                "channel allocation or jingle session failed");
-
-            if (bridgeFailure)
-            {
-                onBridgeDown(
-                    channelAllocator.getBridgeSession().bridge.getJid());
-            }
-        }
+                "jingle session failed");
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -58,6 +58,14 @@ public class Participant
     }
 
     /**
+     * The {@code BridgeSession} of which this {@code Participant} is part of.
+     *
+     * Whenever this value is set to a non-null value it means that Jicofo
+     * has assigned a bridge to this instance.
+     */
+    private JitsiMeetConferenceImpl.BridgeSession bridgeSession;
+
+    /**
      * MUC chat member of this participant.
      */
     private final XmppChatMember roomMember;
@@ -131,6 +139,25 @@ public class Participant
     public JingleSession getJingleSession()
     {
         return jingleSession;
+    }
+
+    /**
+     * Sets the current {@code BridgeSession}.
+     *
+     * @param bridgeSession the new bridge session to set.
+     * @see #bridgeSession
+     */
+    void setBridgeSession(JitsiMeetConferenceImpl.BridgeSession bridgeSession)
+    {
+        if (this.bridgeSession != null)
+        {
+            logger.error(String.format(
+                    "Overwriting bridge session in %s new: %s old: %s",
+                    this,
+                    bridgeSession,
+                    this.bridgeSession));
+        }
+        this.bridgeSession = bridgeSession;
     }
 
     /**
@@ -452,6 +479,30 @@ public class Participant
     public boolean isSessionEstablished()
     {
         return jingleSession != null;
+    }
+
+    /**
+     * Terminates the current {@code BridgeSession}, terminates the channel
+     * allocator and resets any fields related to the session.
+     *
+     * @return {@code BridgeSession} from which this {@code Participant} has
+     * been removed or {@code null} if this {@link Participant} was not part
+     * of any bridge session.
+     */
+    JitsiMeetConferenceImpl.BridgeSession terminateBridgeSession()
+    {
+        JitsiMeetConferenceImpl.BridgeSession _session = this.bridgeSession;
+
+        if (_session != null)
+        {
+            this.setChannelAllocator(null);
+            _session.terminate(this);
+            this.clearTransportInfo();
+            this.setColibriChannelsInfo(null);
+            this.bridgeSession = null;
+        }
+
+        return _session;
     }
 
     @Override


### PR DESCRIPTION
First commit adds a method which does the cleanup when Participant is removed from BridgeSession.

The second one removes unnecessary code which was duplicating the failure handling from the channel allocator. When Jicofo fails to allocate channels it always calls onBridgeDown which effectively does what's been done in the methods removed.