### PR TITLE
make sure we pull the jid from a received message when handling a status

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
@@ -274,7 +274,7 @@ public class JibriSession
                     stopRequest,
                     stanza -> {
                         JibriIq resp = (JibriIq)stanza;
-                        handleJibriStatusUpdate(currentJibriJid, resp.getStatus(), resp.getFailureReason());
+                        handleJibriStatusUpdate(resp.getFrom(), resp.getStatus(), resp.getFailureReason());
                     },
                     exception -> {
                         logger.error("Error sending stop iq: " + exception.toString());
@@ -408,7 +408,7 @@ public class JibriSession
         try
         {
             JibriIq result = (JibriIq)xmpp.sendPacketAndGetReply(startIq);
-            handleJibriStatusUpdate(jibriJid, result.getStatus(), result.getFailureReason());
+            handleJibriStatusUpdate(result.getFrom(), result.getStatus(), result.getFailureReason());
         }
         catch (OperationFailedException e)
         {
@@ -457,6 +457,12 @@ public class JibriSession
         jibriStatus = newStatus;
         logger.info("Got Jibri status update: Jibri " + jibriJid + " has status " + newStatus +
                 " and failure reason " + failureReason);
+        if (jibriJid != currentJibriJid)
+        {
+            logger.info("This status update is from " + jibriJid +
+                    "but the current Jibri is " + currentJibriJid + ", ignoring");
+            return;
+        }
         // First: if we're no longer pending (regardless of the Jibri's new state), make sure we stop
         // the pending timeout task
         if (pendingTimeoutTask != null && !Status.PENDING.equals(newStatus))


### PR DESCRIPTION
and make sure we ignore status updates from jibris which aren't the
current one.

What happened here was the following:
* We get a start request and select Jibri A
* Jibri A times out, so we tell it to stop and fallback to Jibri B
* Jibri A responds to the stop and tells us it's off
* We take the status from Jibri A and assume it came from the current Jibri (Jibri B) by calling `handleJibriStatusUpdate(currentJibriJid...)` instead of `handleJibriStatusUpdate(status.getFrom()...)`, so we think it's from Jibri B
* We see the current Jibri has stopped so we shut things down

This change tweaks 2 places to pull the status jid from the update itself:
1) When we handle the reply from sending a stop IQ (this is where the bug was)
2) When we handle the reply from sending a start IQ (this was less critical, because although we didn't use the `fromJid` from the reply, we used a local variable that was who we sent the request to, but I changed it anyway for consistency).

NOTE that there is still one place where we use `currentJibriJid` when handling a status (`PendingStatusTimeout#run`), but this is intentional.