### PR TITLE
use compareTo when comparing Jids

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
@@ -490,10 +490,10 @@ public class JibriSession
         jibriStatus = newStatus;
         logger.info("Got Jibri status update: Jibri " + jibriJid + " has status " + newStatus +
                 " and failure reason " + failureReason);
-        if (jibriJid != currentJibriJid)
+        if (jibriJid.compareTo(currentJibriJid) != 0)
         {
             logger.info("This status update is from " + jibriJid +
-                    "but the current Jibri is " + currentJibriJid + ", ignoring");
+                    " but the current Jibri is " + currentJibriJid + ", ignoring");
             return;
         }
         // First: if we're no longer pending (regardless of the Jibri's new state), make sure we stop


### PR DESCRIPTION
the previous code was causing an issue where we'd compare the same JID
content (but different references) and Jicofo thought they weren't the
same.