### PR TITLE
Relands support for the video content type header extension.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20181119.181042-364</version>
+      <version>1.0-20190130.211714-376</version>
     </dependency>
     <!-- TODO it should not be here, but for some reason ice4j version 1.0 is loaded without explicit declaration -->
     <dependency>

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -95,6 +95,13 @@ public class JingleOfferFactory
     public static final String ENABLE_TOF_PNAME = "org.jitsi.jicofo.ENABLE_TOF";
 
     /**
+     * The name of the property which enables the inclusion of the video content
+     * type RTP header extension.
+     */
+    public static final String ENABLE_VIDEO_CONTENT_TYPE_PNAME
+        = "org.jitsi.jicofo.ENABLE_VIDEO_CONTENT_TYPE";
+
+    /**
      * The VP8 payload type to include in the Jingle session-invite.
      */
     private final int VP8_PT;
@@ -141,6 +148,12 @@ public class JingleOfferFactory
     private final boolean enableTof;
 
     /**
+     * Whether to enable the video content type header extension in created
+     * offers.
+     */
+    private final boolean enableVideoContentType;
+
+    /**
      * Ctor.
      *
      * @param cfg the {@link ConfigurationService} to pull config options from.
@@ -162,6 +175,8 @@ public class JingleOfferFactory
         // (and currently clients seem to not use it when abs-send-time is
         // available).
         enableTof = cfg != null && cfg.getBoolean(ENABLE_TOF_PNAME, false);
+        enableVideoContentType = cfg != null
+            && cfg.getBoolean(ENABLE_VIDEO_CONTENT_TYPE_PNAME, false);
     }
 
     /**
@@ -333,6 +348,16 @@ public class JingleOfferFactory
             framemarking.setID("9");
             framemarking.setURI(URI.create(RTPExtension.FRAME_MARKING_URN));
             rtpDesc.addExtmap(framemarking);
+        }
+
+        if (enableVideoContentType)
+        {
+            // http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
+            RTPHdrExtPacketExtension videoContentType
+                = new RTPHdrExtPacketExtension();
+            videoContentType.setID("7");
+            videoContentType.setURI(URI.create(RTPExtension.VIDEO_CONTENT_TYPE_URN));
+            rtpDesc.addExtmap(videoContentType);
         }
 
         RTPHdrExtPacketExtension rtpStreamId = new RTPHdrExtPacketExtension();

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -102,6 +102,12 @@ public class JingleOfferFactory
         = "org.jitsi.jicofo.ENABLE_VIDEO_CONTENT_TYPE";
 
     /**
+     * The name of the property which enables the inclusion of the RID RTP
+     * header extension.
+     */
+    public static final String ENABLE_RID_PNAME = "org.jitsi.jicofo.ENABLE_RID";
+
+    /**
      * The VP8 payload type to include in the Jingle session-invite.
      */
     private final int VP8_PT;
@@ -154,6 +160,11 @@ public class JingleOfferFactory
     private final boolean enableVideoContentType;
 
     /**
+     * Whether to enable the RID header extension in created offers.
+     */
+    private final boolean enableRid;
+
+    /**
      * Ctor.
      *
      * @param cfg the {@link ConfigurationService} to pull config options from.
@@ -175,8 +186,11 @@ public class JingleOfferFactory
         // (and currently clients seem to not use it when abs-send-time is
         // available).
         enableTof = cfg != null && cfg.getBoolean(ENABLE_TOF_PNAME, false);
+
         enableVideoContentType = cfg != null
             && cfg.getBoolean(ENABLE_VIDEO_CONTENT_TYPE_PNAME, false);
+
+        enableRid = cfg != null && cfg.getBoolean(ENABLE_RID_PNAME, false);
     }
 
     /**
@@ -360,10 +374,13 @@ public class JingleOfferFactory
             rtpDesc.addExtmap(videoContentType);
         }
 
-        RTPHdrExtPacketExtension rtpStreamId = new RTPHdrExtPacketExtension();
-        rtpStreamId.setID("4");
-        rtpStreamId.setURI(URI.create(RTPExtension.RTP_STREAM_ID_URN));
-        rtpDesc.addExtmap(rtpStreamId);
+        if (enableRid)
+        {
+            RTPHdrExtPacketExtension rtpStreamId = new RTPHdrExtPacketExtension();
+            rtpStreamId.setID("4");
+            rtpStreamId.setURI(URI.create(RTPExtension.RTP_STREAM_ID_URN));
+            rtpDesc.addExtmap(rtpStreamId);
+        }
 
         // a=rtpmap:100 VP8/90000
         PayloadTypePacketExtension vp8


### PR DESCRIPTION
Relands https://github.com/jitsi/jicofo/pull/335 with the correct LJ version.