### PR TITLE
Fix : use of health-checks REST API with Shibboleth authentication

### DIFF
--- a/src/main/java/org/jitsi/jicofo/auth/AuthBundleActivator.java
+++ b/src/main/java/org/jitsi/jicofo/auth/AuthBundleActivator.java
@@ -143,6 +143,12 @@ public class AuthBundleActivator
     {
         List<Handler> handlers = new ArrayList<>();
 
+        // FIXME While Shibboleth is optional, the health checks of Jicofo (over
+        // REST) are mandatory at the time of this writing. Make the latter
+        // optional as well (in a way similar to Videobridge, for example).
+        handlers.add(new org.jitsi.jicofo.rest.HandlerImpl(bundleContext));
+
+
         // Shibboleth
         if (authAuthority instanceof ShibbolethAuthAuthority)
         {
@@ -151,12 +157,7 @@ public class AuthBundleActivator
 
             handlers.add(new ShibbolethHandler(shibbolethAuthAuthority));
         }
-
-        // FIXME While Shibboleth is optional, the health checks of Jicofo (over
-        // REST) are mandatory at the time of this writing. Make the latter
-        // optional as well (in a way similar to Videobridge, for example).
-        handlers.add(new org.jitsi.jicofo.rest.HandlerImpl(bundleContext));
-
+    
         return initializeHandlerList(handlers);
     }
 


### PR DESCRIPTION
When we enable the shibboleth authentication the health check REST API stop to work.
All HTTP requests are first processed by the Shibboleth Jetty Handler and this handler rejects the /about/health request du to missing auth mandatory parameter. 
The solution to enable health REST API and shibboleth is to switch jetty handlers order so HTTP request are firstly computed with the health-check handler and if the request is not an health-check it is then computed by the shibboleth part.
