### PR TITLE
docs: fix typo and add port info for health checks

### DIFF
--- a/doc/health-checks.md
+++ b/doc/health-checks.md
@@ -1,4 +1,6 @@
-The REST API allows querying Jicofo whether it deems itself in a healthy state (i.e. the application is operational and the functionality it provides should perform as expected) at the time of the query or not. Videorbidge will run an internal test in response to the request to determine its current health status.
+The REST API allows querying Jicofo whether it deems itself in a healthy state (i.e. the application is operational and the functionality it provides should perform as expected) at the time of the query or not. Videobridge will run an internal test in response to the request to determine its current health status.
+
+The default port for the REST API is `8888` to have Videobridge and Jicofo running on the same machine with their defaults without them clashing.
 
 <table>
   <tr>


### PR DESCRIPTION
Fixed same typo like [here](https://github.com/jitsi/jitsi-videobridge/pull/867/files) and added the information behind which port I can find the REST API to access the health checks.
I was looking a while to find the right place in the code.