### PR TITLE
change the ice4j dependency to not be in only  test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@
       <artifactId>xpp3</artifactId>
       <version>1.1.4c</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>ice4j</artifactId>
+      <version>3.0-1-ge854e4e</version>
+    </dependency>
     <!-- runtime -->
     <dependency>
       <groupId>rusv</groupId>
@@ -202,12 +207,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-videobridge</artifactId>
       <version>2.0-32-g08fd750</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>ice4j</artifactId>
-      <version>3.0-1-ge854e4e</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
for some reason, having it in the test scope caused conflicts in
sub-libraries and led to  issues with jetty starting  up,  but  having
it outside that scope  seems  to fix it.