### PR TITLE
Avoid usage of Videobridge.getOrCreateLocalEndpoint method

### DIFF
--- a/src/test/java/mock/jvb/MockVideobridge.java
+++ b/src/test/java/mock/jvb/MockVideobridge.java
@@ -179,7 +179,7 @@ public class MockVideobridge
             String confId, String endpointId)
     {
         Conference conference = bridge.getConference(confId, null);
-        Endpoint endpoint = conference.getOrCreateLocalEndpoint(endpointId);
+        Endpoint endpoint = conference.getLocalEndpoint(endpointId);
 
         MediaStreamTrackDesc[] tracks = endpoint.getMediaStreamTracks();
 

--- a/src/test/java/mock/jvb/MockVideobridge.java
+++ b/src/test/java/mock/jvb/MockVideobridge.java
@@ -179,7 +179,7 @@ public class MockVideobridge
             String confId, String endpointId)
     {
         Conference conference = bridge.getConference(confId, null);
-        Endpoint endpoint = conference.getLocalEndpoint(endpointId);
+        AbstractEndpoint endpoint = conference.getEndpoint(endpointId);
 
         MediaStreamTrackDesc[] tracks = endpoint.getMediaStreamTracks();
 


### PR DESCRIPTION
This PR is an code adaption to changes proposed in https://github.com/jitsi/jitsi-videobridge/pull/927, where `getOrCreateLocalEndpoint` has been removed and replaced with two dedicated methods `getLocalEndpoint` and `createLocalEndpoint`.

This changes are backward compatible, so it is not necessary to wait until https://github.com/jitsi/jitsi-videobridge/pull/927 is merged to merge this PR.