### PR TITLE
Bridge selection max load

### DIFF
--- a/src/main/java/org/jitsi/jicofo/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/Bridge.java
@@ -294,7 +294,7 @@ public class Bridge
         return this.lastReportedBitrateKbps - o.lastReportedBitrateKbps;
     }
 
-    private int getEstimatedVideoStreamCount()
+    public int getEstimatedVideoStreamCount()
     {
         return videoStreamCount + videoStreamCountDiff;
     }


### PR DESCRIPTION
allow a configurable 'max participant count' for bridge selection such that no bridge with that many participants will be considered for selection.  i did this as a decorator, so it's totally orthogonal to the strategy itself, it just wraps whatever strategy is configured.