### PR TITLE
update jitsi-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
-      <version>1.0-11-g2c0bd54</version>
+      <version>1.0-19-ge5cd0ce</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
needed to bring in the property helpers so the jicofo unit tests can pass with the new jvb version