### PR TITLE
Add a /stats REST endpoint to Jicofo, expose some data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,36 @@
       <artifactId>ice4j</artifactId>
       <version>3.0-1-ge854e4e</version>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-jetty-http</artifactId>
+      <version>2.29</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>2.29</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>2.29</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <version>2.29</version>
+    </dependency>
+    <!-- jersey relies on this version of javassist or we get hk2
+    errors, but other libs (Powermock, at this time) also rely on
+    it but an older version, and that version is getting selected
+    which breaks jersey, so we explicitly depend on this here to
+    force the version -->
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.22.0-CR2</version>
+    </dependency>
     <!-- runtime -->
     <dependency>
       <groupId>rusv</groupId>

--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -573,6 +573,20 @@ public class FocusManager
     }
 
     /**
+     * Get the conferences of this Jicofo.  Note that the
+     * List returned is a snapshot of the conference
+     * references at the time of the call.
+     * @return the list of conferences
+     */
+    public List<JitsiMeetConference> getConferences()
+    {
+        synchronized (conferencesSyncRoot)
+        {
+            return new ArrayList<>(conferences.values());
+        }
+    }
+
+    /**
      * Enables shutdown mode which means that no new focus instances will
      * be allocated. After conference count drops to zero the process will exit.
      */

--- a/src/main/java/org/jitsi/jicofo/auth/AuthBundleActivator.java
+++ b/src/main/java/org/jitsi/jicofo/auth/AuthBundleActivator.java
@@ -20,6 +20,9 @@ package org.jitsi.jicofo.auth;
 import net.java.sip.communicator.util.*;
 
 import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.servlet.*;
+import org.glassfish.jersey.servlet.*;
+import org.jitsi.jicofo.rest.*;
 import org.jitsi.rest.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.utils.*;
@@ -148,6 +151,10 @@ public class AuthBundleActivator
         // optional as well (in a way similar to Videobridge, for example).
         handlers.add(new org.jitsi.jicofo.rest.HandlerImpl(bundleContext));
 
+        ServletContextHandler appHandler = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        appHandler.setContextPath("/");
+        appHandler.addServlet(new ServletHolder(new ServletContainer(new Application(bundleContext))), "/*");
+        handlers.add(appHandler);
 
         // Shibboleth
         if (authAuthority instanceof ShibbolethAuthAuthority)

--- a/src/main/java/org/jitsi/jicofo/rest/Application.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Application.java
@@ -1,0 +1,14 @@
+package org.jitsi.jicofo.rest;
+
+import org.glassfish.jersey.server.*;
+import org.jitsi.jicofo.util.*;
+import org.osgi.framework.*;
+
+public class Application extends ResourceConfig
+{
+    public Application(BundleContext bundleContext)
+    {
+        register(new OsgiServiceBinder(bundleContext));
+        packages("org.jitsi.jicofo.rest");
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/rest/Statistics.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Statistics.java
@@ -8,9 +8,16 @@ import javax.inject.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 
+import static org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.*;
+
 @Path("/stats")
 public class Statistics
 {
+    /**
+     * The number of buckets to use for conference sizes.
+     */
+    private static final int CONFERENCE_SIZE_BUCKETS = 22;
+
     @Inject
     protected FocusManagerProvider focusManagerProvider;
 
@@ -22,7 +29,41 @@ public class Statistics
         JSONObject json = new JSONObject();
 
         int conferenceCount = focusManager.getConferenceCount();
-        json.put("conference_count", conferenceCount);
+        json.put(CONFERENCES, conferenceCount);
+
+        int[] conferenceSizes = new int[CONFERENCE_SIZE_BUCKETS];
+        int largestConferenceSize = 0;
+        for (JitsiMeetConference conference : focusManager.getConferences())
+        {
+            int confSize = conference.getParticipantCount();
+            // getParticipantCount only includes endpoints with allocated media channels,
+            // so if a single participant is waiting in a meeting they wouldn't
+            // be counted.  In stats, calling this a conference with size 0
+            // would be misleading, so we add 1 in this case to properly show
+            // it as a conference of size 1.  (If there really weren't any
+            // participants in there at all, the conference wouldn't have
+            // existed in the first place).
+            if (confSize == 0)
+            {
+                confSize = 1;
+            }
+            if (confSize > largestConferenceSize)
+            {
+                largestConferenceSize = confSize;
+            }
+            int conferenceSizeIndex = confSize < conferenceSizes.length
+                ? confSize
+                : conferenceSizes.length - 1;
+            conferenceSizes[conferenceSizeIndex]++;
+        }
+
+        JSONArray conferenceSizesJson = new JSONArray();
+        for (int size : conferenceSizes)
+        {
+            conferenceSizesJson.add(size);
+        }
+        json.put(LARGEST_CONFERENCE, largestConferenceSize);
+        json.put(CONFERENCE_SIZES, conferenceSizesJson);
 
         return json.toJSONString();
     }

--- a/src/main/java/org/jitsi/jicofo/rest/Statistics.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Statistics.java
@@ -1,0 +1,29 @@
+package org.jitsi.jicofo.rest;
+
+import org.jitsi.jicofo.*;
+import org.jitsi.jicofo.util.*;
+import org.json.simple.*;
+
+import javax.inject.*;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+
+@Path("/stats")
+public class Statistics
+{
+    @Inject
+    protected FocusManagerProvider focusManagerProvider;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getStats()
+    {
+        FocusManager focusManager = focusManagerProvider.get();
+        JSONObject json = new JSONObject();
+
+        int conferenceCount = focusManager.getConferenceCount();
+        json.put("conference_count", conferenceCount);
+
+        return json.toJSONString();
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/util/FocusManagerProvider.java
+++ b/src/main/java/org/jitsi/jicofo/util/FocusManagerProvider.java
@@ -1,0 +1,11 @@
+package org.jitsi.jicofo.util;
+
+import org.jitsi.jicofo.*;
+import org.osgi.framework.*;
+
+public class FocusManagerProvider extends OsgiServiceProvider<FocusManager>
+{
+    public FocusManagerProvider(BundleContext bundleContext) {
+        super(bundleContext, FocusManager.class);
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/util/OsgiServiceBinder.java
+++ b/src/main/java/org/jitsi/jicofo/util/OsgiServiceBinder.java
@@ -1,0 +1,20 @@
+package org.jitsi.jicofo.util;
+
+import org.glassfish.hk2.utilities.binding.*;
+import org.osgi.framework.*;
+
+public class OsgiServiceBinder extends AbstractBinder
+{
+    protected final BundleContext bundleContext;
+
+    public OsgiServiceBinder(BundleContext bundleContext)
+    {
+        this.bundleContext = bundleContext;
+    }
+
+    @Override
+    protected void configure()
+    {
+        bind(new FocusManagerProvider(bundleContext)).to(FocusManagerProvider.class);
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/util/OsgiServiceProvider.java
+++ b/src/main/java/org/jitsi/jicofo/util/OsgiServiceProvider.java
@@ -1,0 +1,21 @@
+package org.jitsi.jicofo.util;
+
+import org.jitsi.osgi.*;
+import org.osgi.framework.*;
+
+public class OsgiServiceProvider<T>
+{
+    protected final BundleContext bundleContext;
+    protected final Class<T> typeClass;
+
+    public OsgiServiceProvider(BundleContext bundleContext, Class<T> typeClass)
+    {
+        this.bundleContext = bundleContext;
+        this.typeClass = typeClass;
+    }
+
+    public T get()
+    {
+        return ServiceUtils2.getService(bundleContext, typeClass);
+    }
+}


### PR DESCRIPTION
This PR adds a `/stats` REST endpoint in Jicofo to expose conference count, largest conference size, and a conference sizes histogram.  Previously, this data was being retrieved from the bridge, but due to Octo the bridge is unable to give reliable information, as it doesn't have the complete picture.

I added Jersey here to handle this; I've already updated all the REST code in the bridge to use it and I think it'd make sense to port over the other Jicofo endpoints, but I refrained from doing that as part of this work--though I can take a look at doing that in an immediate follow-up PR for consistency.