### PR TITLE
Track num participants/total num participants

### DIFF
--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -21,7 +21,9 @@ import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.event.*;
 import net.java.sip.communicator.util.*;
 
+import org.jetbrains.annotations.*;
 import org.jitsi.jicofo.event.*;
+import org.jitsi.jicofo.stats.*;
 import org.jitsi.jicofo.util.*;
 import org.jitsi.meet.*;
 import org.jitsi.service.configuration.*;
@@ -228,6 +230,11 @@ public class FocusManager
      * IQs sent from conference participants to the focus.
      */
     private MeetExtensionsHandler meetExtensionsHandler;
+
+    /**
+     * A class that holds Jicofo-wide statistics
+     */
+    private final Statistics statistics = new Statistics();
 
     /**
      * Starts this manager for given <tt>hostName</tt>.
@@ -461,6 +468,8 @@ public class FocusManager
 
         conferences.put(room, conference);
         conferenceIds.add(id);
+
+        statistics.totalConferencesCreated.incrementAndGet();
 
         if (conference.getLogger().isInfoEnabled())
         {
@@ -731,6 +740,11 @@ public class FocusManager
             // Do initializations which require valid connection
             meetExtensionsHandler.init();
         }
+    }
+
+    public @NotNull Statistics getStatistics()
+    {
+        return statistics;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -3034,7 +3034,7 @@ public class JitsiMeetConferenceImpl
         return includeInStatistics;
     }
 
-    public FocusManager getFocusManager()
+    protected FocusManager getFocusManager()
     {
         return ServiceUtils.getService(FocusBundleActivator.bundleContext, FocusManager.class);
     }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -661,6 +661,7 @@ public class JitsiMeetConferenceImpl
             logger.info(
                     "Member "
                         + chatRoomMember.getContactAddress() + " joined.");
+            getFocusManager().getStatistics().totalParticipants.incrementAndGet();
 
             if (!isFocusMember(chatRoomMember))
             {
@@ -3031,6 +3032,11 @@ public class JitsiMeetConferenceImpl
     public boolean includeInStatistics()
     {
         return includeInStatistics;
+    }
+
+    public FocusManager getFocusManager()
+    {
+        return ServiceUtils.getService(FocusBundleActivator.bundleContext, FocusManager.class);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/rest/Statistics.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Statistics.java
@@ -28,6 +28,8 @@ public class Statistics
         json.put(CONFERENCES, snapshot.numConferences);
         json.put(LARGEST_CONFERENCE, snapshot.largestConferenceSize);
         json.put(TOTAL_CONFERENCES_CREATED, snapshot.totalConferencesCreated);
+        json.put(PARTICIPANTS, snapshot.numParticipants);
+        json.put(TOTAL_PARTICIPANTS, snapshot.totalNumParticipants);
         JSONArray conferenceSizesJson = new JSONArray();
         for (int size : snapshot.conferenceSizes)
         {

--- a/src/main/java/org/jitsi/jicofo/rest/Statistics.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Statistics.java
@@ -1,6 +1,7 @@
 package org.jitsi.jicofo.rest;
 
 import org.jitsi.jicofo.*;
+import org.jitsi.jicofo.stats.*;
 import org.jitsi.jicofo.util.*;
 import org.json.simple.*;
 
@@ -13,11 +14,6 @@ import static org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.*;
 @Path("/stats")
 public class Statistics
 {
-    /**
-     * The number of buckets to use for conference sizes.
-     */
-    private static final int CONFERENCE_SIZE_BUCKETS = 22;
-
     @Inject
     protected FocusManagerProvider focusManagerProvider;
 
@@ -26,47 +22,17 @@ public class Statistics
     public String getStats()
     {
         FocusManager focusManager = focusManagerProvider.get();
+
+        JicofoStatisticsSnapshot snapshot = JicofoStatisticsSnapshot.generate(focusManager);
         JSONObject json = new JSONObject();
-
-        int conferenceCount = focusManager.getConferenceCount();
-        json.put(CONFERENCES, conferenceCount);
-
-        int[] conferenceSizes = new int[CONFERENCE_SIZE_BUCKETS];
-        int largestConferenceSize = 0;
-        for (JitsiMeetConference conference : focusManager.getConferences())
-        {
-            if (!conference.includeInStatistics())
-            {
-                continue;
-            }
-            int confSize = conference.getParticipantCount();
-            // getParticipantCount only includes endpoints with allocated media channels,
-            // so if a single participant is waiting in a meeting they wouldn't
-            // be counted.  In stats, calling this a conference with size 0
-            // would be misleading, so we add 1 in this case to properly show
-            // it as a conference of size 1.  (If there really weren't any
-            // participants in there at all, the conference wouldn't have
-            // existed in the first place).
-            if (confSize == 0)
-            {
-                confSize = 1;
-            }
-            if (confSize > largestConferenceSize)
-            {
-                largestConferenceSize = confSize;
-            }
-            int conferenceSizeIndex = confSize < conferenceSizes.length
-                ? confSize
-                : conferenceSizes.length - 1;
-            conferenceSizes[conferenceSizeIndex]++;
-        }
-
+        json.put(CONFERENCES, snapshot.numConferences);
+        json.put(LARGEST_CONFERENCE, snapshot.largestConferenceSize);
+        json.put(TOTAL_CONFERENCES_CREATED, snapshot.totalConferencesCreated);
         JSONArray conferenceSizesJson = new JSONArray();
-        for (int size : conferenceSizes)
+        for (int size : snapshot.conferenceSizes)
         {
             conferenceSizesJson.add(size);
         }
-        json.put(LARGEST_CONFERENCE, largestConferenceSize);
         json.put(CONFERENCE_SIZES, conferenceSizesJson);
 
         return json.toJSONString();

--- a/src/main/java/org/jitsi/jicofo/stats/JicofoStatisticsSnapshot.java
+++ b/src/main/java/org/jitsi/jicofo/stats/JicofoStatisticsSnapshot.java
@@ -14,16 +14,29 @@ public class JicofoStatisticsSnapshot
      */
     private static final int CONFERENCE_SIZE_BUCKETS = 22;
 
+    /**
+     * The total number of conferences created on this Jicofo since
+     * it was started
+     */
     public int totalConferencesCreated;
+    /**
+     * The current number of conferences on this Jicofo
+     */
     public int numConferences;
+    /**
+     * The number of participants in the largest, currently-active conference
+     */
     public int largestConferenceSize;
 
     public int[] conferenceSizes = new int[CONFERENCE_SIZE_BUCKETS];
 
-    public static JicofoStatisticsSnapshot generate(@NotNull FocusManager focusManager)
+    public static JicofoStatisticsSnapshot generate(
+        @NotNull FocusManager focusManager
+    )
     {
         JicofoStatisticsSnapshot snapshot = new JicofoStatisticsSnapshot();
-        snapshot.totalConferencesCreated = focusManager.getStatistics().totalConferencesCreated.get();
+        snapshot.totalConferencesCreated =
+            focusManager.getStatistics().totalConferencesCreated.get();
         snapshot.numConferences = focusManager.getConferenceCount();
         for (JitsiMeetConference conference : focusManager.getConferences())
         {
@@ -32,13 +45,13 @@ public class JicofoStatisticsSnapshot
                 continue;
             }
             int confSize = conference.getParticipantCount();
-            // getParticipantCount only includes endpoints with allocated media channels,
-            // so if a single participant is waiting in a meeting they wouldn't
-            // be counted.  In stats, calling this a conference with size 0
-            // would be misleading, so we add 1 in this case to properly show
-            // it as a conference of size 1.  (If there really weren't any
-            // participants in there at all, the conference wouldn't have
-            // existed in the first place).
+            // getParticipantCount only includes endpoints with allocated media
+            // channels, so if a single participant is waiting in a meeting
+            // they wouldn't be counted.  In stats, calling this a conference
+            // with size 0 would be misleading, so we add 1 in this case to
+            // properly show it as a conference of size 1.  (If there really
+            // weren't any participants in there at all, the conference
+            // wouldn't have existed in the first place).
             if (confSize == 0)
             {
                 confSize = 1;

--- a/src/main/java/org/jitsi/jicofo/stats/JicofoStatisticsSnapshot.java
+++ b/src/main/java/org/jitsi/jicofo/stats/JicofoStatisticsSnapshot.java
@@ -15,8 +15,7 @@ public class JicofoStatisticsSnapshot
     private static final int CONFERENCE_SIZE_BUCKETS = 22;
 
     /**
-     * The total number of conferences created on this Jicofo since
-     * it was started
+     * See {@link Statistics#totalConferencesCreated}
      */
     public int totalConferencesCreated;
     /**
@@ -28,6 +27,16 @@ public class JicofoStatisticsSnapshot
      */
     public int largestConferenceSize;
 
+    /**
+     * See {@link Statistics#totalParticipants}
+     */
+    public int totalNumParticipants;
+
+    /**
+     * The current number of participants on this Jicofo
+     */
+    public int numParticipants;
+
     public int[] conferenceSizes = new int[CONFERENCE_SIZE_BUCKETS];
 
     public static JicofoStatisticsSnapshot generate(
@@ -35,6 +44,8 @@ public class JicofoStatisticsSnapshot
     )
     {
         JicofoStatisticsSnapshot snapshot = new JicofoStatisticsSnapshot();
+        snapshot.totalNumParticipants =
+            focusManager.getStatistics().totalParticipants.get();
         snapshot.totalConferencesCreated =
             focusManager.getStatistics().totalConferencesCreated.get();
         snapshot.numConferences = focusManager.getConferenceCount();
@@ -56,6 +67,7 @@ public class JicofoStatisticsSnapshot
             {
                 confSize = 1;
             }
+            snapshot.numParticipants += confSize;
             if (confSize > snapshot.largestConferenceSize)
             {
                 snapshot.largestConferenceSize = confSize;

--- a/src/main/java/org/jitsi/jicofo/stats/JicofoStatisticsSnapshot.java
+++ b/src/main/java/org/jitsi/jicofo/stats/JicofoStatisticsSnapshot.java
@@ -1,0 +1,57 @@
+package org.jitsi.jicofo.stats;
+
+import org.jetbrains.annotations.*;
+import org.jitsi.jicofo.*;
+
+/**
+ * A snapshot of the current state of Jicofo, as well as
+ * the current values for long-running statistics
+ */
+public class JicofoStatisticsSnapshot
+{
+    /**
+     * The number of buckets to use for conference sizes.
+     */
+    private static final int CONFERENCE_SIZE_BUCKETS = 22;
+
+    public int totalConferencesCreated;
+    public int numConferences;
+    public int largestConferenceSize;
+
+    public int[] conferenceSizes = new int[CONFERENCE_SIZE_BUCKETS];
+
+    public static JicofoStatisticsSnapshot generate(@NotNull FocusManager focusManager)
+    {
+        JicofoStatisticsSnapshot snapshot = new JicofoStatisticsSnapshot();
+        snapshot.totalConferencesCreated = focusManager.getStatistics().totalConferencesCreated.get();
+        snapshot.numConferences = focusManager.getConferenceCount();
+        for (JitsiMeetConference conference : focusManager.getConferences())
+        {
+            if (!conference.includeInStatistics())
+            {
+                continue;
+            }
+            int confSize = conference.getParticipantCount();
+            // getParticipantCount only includes endpoints with allocated media channels,
+            // so if a single participant is waiting in a meeting they wouldn't
+            // be counted.  In stats, calling this a conference with size 0
+            // would be misleading, so we add 1 in this case to properly show
+            // it as a conference of size 1.  (If there really weren't any
+            // participants in there at all, the conference wouldn't have
+            // existed in the first place).
+            if (confSize == 0)
+            {
+                confSize = 1;
+            }
+            if (confSize > snapshot.largestConferenceSize)
+            {
+                snapshot.largestConferenceSize = confSize;
+            }
+            int conferenceSizeIndex = confSize < snapshot.conferenceSizes.length
+                ? confSize
+                : snapshot.conferenceSizes.length - 1;
+            snapshot.conferenceSizes[conferenceSizeIndex]++;
+        }
+        return snapshot;
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/stats/Statistics.java
+++ b/src/main/java/org/jitsi/jicofo/stats/Statistics.java
@@ -1,0 +1,11 @@
+package org.jitsi.jicofo.stats;
+
+import java.util.concurrent.atomic.*;
+
+/**
+ * Track persistent, long-running Jicofo statistics
+ */
+public class Statistics
+{
+    public final AtomicInteger totalConferencesCreated = new AtomicInteger(0);
+}

--- a/src/main/java/org/jitsi/jicofo/stats/Statistics.java
+++ b/src/main/java/org/jitsi/jicofo/stats/Statistics.java
@@ -7,5 +7,15 @@ import java.util.concurrent.atomic.*;
  */
 public class Statistics
 {
+    /**
+     * The total number of conferences created on this Jicofo since
+     * it was started
+     */
     public final AtomicInteger totalConferencesCreated = new AtomicInteger(0);
+
+    /**
+     * The total number of participants that have connected to this
+     * Jicofo since it was started
+     */
+    public final AtomicInteger totalParticipants = new AtomicInteger(0);
 }


### PR DESCRIPTION
(This is built on top of the code in https://github.com/jitsi/jicofo/pull/401, so the first 3 commits here will go away once that is merged and I rebase).

This adds tracking for the current number of participants and the total number of participants since start.  I don't know if `FocusManager` is the best place to be the central location for stats, but it seemed reasonable so let me know if somewhere else would be appropriate.