### PR TITLE
Update jitsi-utils to work with new format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
-      <version>1.0-19-ge5cd0ce</version>
+      <version>1.0-21-gb09b57b</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
jitsi-utils was split into 2 repos (`jitsi-utils` and `jitsi-utils-kotlin`).  We need to update to a version which includes that change in order for the tests which depend on jvb to work.