### PR TITLE
fix the shibboleth web handler

### DIFF
--- a/src/main/java/org/jitsi/jicofo/auth/AuthBundleActivator.java
+++ b/src/main/java/org/jitsi/jicofo/auth/AuthBundleActivator.java
@@ -146,6 +146,16 @@ public class AuthBundleActivator
     {
         List<Handler> handlers = new ArrayList<>();
 
+        // Shibboleth
+        if (authAuthority instanceof ShibbolethAuthAuthority)
+        {
+            logger.info("Adding Shibboleth handler");
+            ShibbolethAuthAuthority shibbolethAuthAuthority
+                = (ShibbolethAuthAuthority) authAuthority;
+
+            handlers.add(new ShibbolethHandler(shibbolethAuthAuthority));
+        }
+
         // FIXME While Shibboleth is optional, the health checks of Jicofo (over
         // REST) are mandatory at the time of this writing. Make the latter
         // optional as well (in a way similar to Videobridge, for example).
@@ -154,15 +164,7 @@ public class AuthBundleActivator
         appHandler.addServlet(new ServletHolder(new ServletContainer(new Application(bundleContext))), "/*");
         handlers.add(appHandler);
 
-        // Shibboleth
-        if (authAuthority instanceof ShibbolethAuthAuthority)
-        {
-            ShibbolethAuthAuthority shibbolethAuthAuthority
-                = (ShibbolethAuthAuthority) authAuthority;
 
-            handlers.add(new ShibbolethHandler(shibbolethAuthAuthority));
-        }
-    
         return initializeHandlerList(handlers);
     }
 

--- a/src/main/java/org/jitsi/jicofo/auth/ShibbolethHandler.java
+++ b/src/main/java/org/jitsi/jicofo/auth/ShibbolethHandler.java
@@ -51,9 +51,13 @@ class ShibbolethHandler
     private static final Logger logger
             = Logger.getLogger(ShibbolethHandler.class);
 
+    /**
+     * The target on which shibboleth requests are made
+     */
+    private static final String SHIBBOLETH_TARGET = "/login";
+
     private final ShibbolethAuthAuthority shibbolethAuthAuthority;
 
-    private static final String SHIBBOLETH_TARGET = "/login";
 
     /**
      * Initializes a new <tt>ShibbolethHandler</tt> instance.

--- a/src/main/java/org/jitsi/jicofo/auth/ShibbolethHandler.java
+++ b/src/main/java/org/jitsi/jicofo/auth/ShibbolethHandler.java
@@ -53,6 +53,8 @@ class ShibbolethHandler
 
     private final ShibbolethAuthAuthority shibbolethAuthAuthority;
 
+    private static final String SHIBBOLETH_TARGET = "/login";
+
     /**
      * Initializes a new <tt>ShibbolethHandler</tt> instance.
      *
@@ -75,6 +77,11 @@ class ShibbolethHandler
             throws IOException,
             ServletException
     {
+        if (!SHIBBOLETH_TARGET.equals(target))
+        {
+            return;
+        }
+
         try
         {
             doHandle(target, baseRequest, request, response);


### PR DESCRIPTION
since the servlet has a path spec of '/*', it matches all urls and, if
it doesn't end up handling a request, that request is still marked as
'handled' so it doesn't fall through to the next handler.

now, we'll move the shibboleth handler first but make sure it handles
only the shibboleth urls: all others will not be marked as handled and
will fall through to the next handler.

addresses https://github.com/jitsi/jicofo/issues/404