### PR TITLE
Fix health returned jvb list

### DIFF
--- a/src/main/java/org/jitsi/jicofo/auth/AuthBundleActivator.java
+++ b/src/main/java/org/jitsi/jicofo/auth/AuthBundleActivator.java
@@ -159,11 +159,12 @@ public class AuthBundleActivator
         // FIXME While Shibboleth is optional, the health checks of Jicofo (over
         // REST) are mandatory at the time of this writing. Make the latter
         // optional as well (in a way similar to Videobridge, for example).
-        ServletContextHandler appHandler = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        ServletContextHandler appHandler
+            = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
         appHandler.setContextPath("/");
-        appHandler.addServlet(new ServletHolder(new ServletContainer(new Application(bundleContext))), "/*");
+        appHandler.addServlet(new ServletHolder(new ServletContainer(
+            new Application(bundleContext))), "/*");
         handlers.add(appHandler);
-
 
         return initializeHandlerList(handlers);
     }

--- a/src/main/java/org/jitsi/jicofo/rest/Application.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Application.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jitsi.jicofo.rest;
 
 import org.glassfish.hk2.utilities.binding.*;
@@ -7,7 +22,11 @@ import org.osgi.framework.*;
 
 import java.time.*;
 
-public class Application extends ResourceConfig
+/**
+ * Adds the configuration for the REST web endpoints.
+ */
+public class Application
+    extends ResourceConfig
 {
     protected final Clock clock = Clock.systemUTC();
 

--- a/src/main/java/org/jitsi/jicofo/rest/Health.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Health.java
@@ -32,6 +32,12 @@ import java.time.*;
 import java.util.*;
 import java.util.logging.*;
 
+/**
+ * Checks the health of {@link FocusManager}.
+ *
+ * @author Lyubomir Marinov
+ * @author Pawel Domas
+ */
 @Path("/about/health")
 @Singleton()
 public class Health
@@ -59,7 +65,8 @@ public class Health
      * Interval which we consider bad for a health check and we will print
      * some debug information.
      */
-    private static final Duration BAD_HEALTH_CHECK_INTERVAL = Duration.ofSeconds(3);
+    private static final Duration BAD_HEALTH_CHECK_INTERVAL
+        = Duration.ofSeconds(3);
 
     /**
      * The pseudo-random generator used to generate random input for
@@ -102,10 +109,13 @@ public class Health
                 activeJvbsJson.put("jvbs", activeJvbs);
             }
 
-            if (Duration.between(lastHealthCheckTime, clock.instant()).compareTo(STATUS_CACHE_INTERVAL) < 0
+            if (Duration.between(
+                    lastHealthCheckTime,
+                    clock.instant()).compareTo(STATUS_CACHE_INTERVAL) < 0
                 && cachedStatus > 0)
             {
-                return Response.status(cachedStatus).entity(activeJvbsJson).build();
+                return Response.status(cachedStatus)
+                    .entity(activeJvbsJson).build();
             }
 
             HealthChecksMonitor monitor = null;
@@ -286,7 +296,8 @@ public class Health
         {
             this.startedAt = System.currentTimeMillis();
             this.monitorTimer = new Timer(getClass().getSimpleName(), true);
-            this.monitorTimer.schedule(this, BAD_HEALTH_CHECK_INTERVAL.toMillis());
+            this.monitorTimer
+                .schedule(this, BAD_HEALTH_CHECK_INTERVAL.toMillis());
         }
 
         /**

--- a/src/main/java/org/jitsi/jicofo/rest/Health.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Health.java
@@ -115,7 +115,7 @@ public class Health
                 && cachedStatus > 0)
             {
                 return Response.status(cachedStatus)
-                    .entity(activeJvbsJson).build();
+                    .entity(activeJvbsJson.toJSONString()).build();
             }
 
             HealthChecksMonitor monitor = null;
@@ -128,7 +128,7 @@ public class Health
             {
                 check(focusManager);
                 cacheStatus(HttpServletResponse.SC_OK);
-                return Response.ok(activeJvbsJson).build();
+                return Response.ok(activeJvbsJson.toJSONString()).build();
             }
             finally
             {
@@ -142,7 +142,8 @@ public class Health
         {
             logger.error("Health check of Jicofo failed!", ex);
             cacheStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            return Response.serverError().entity(activeJvbsJson).build();
+            return Response.serverError()
+                .entity(activeJvbsJson.toJSONString()).build();
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/rest/Health.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Health.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.*;
 import java.time.*;
 import java.util.*;
 import java.util.logging.*;
+import java.util.stream.*;
 
 /**
  * Checks the health of {@link FocusManager}.
@@ -106,7 +107,9 @@ public class Health
                         "The health check failed - 0 active JVB instances !");
                     throw new InternalServerErrorException();
                 }
-                activeJvbsJson.put("jvbs", activeJvbs);
+                activeJvbsJson.put("jvbs",
+                    activeJvbs.stream().map(j -> j.toString())
+                        .collect(Collectors.toList()));
             }
 
             if (Duration.between(

--- a/src/main/java/org/jitsi/jicofo/rest/Statistics.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Statistics.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jitsi.jicofo.rest;
 
 import org.jitsi.jicofo.*;
@@ -11,19 +26,27 @@ import javax.ws.rs.core.*;
 
 import static org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.*;
 
+/**
+ * Adds statistics REST endpoint exposes some internal Jicofo stats.
+ */
 @Path("/stats")
 public class Statistics
 {
     @Inject
     protected FocusManagerProvider focusManagerProvider;
 
+    /**
+     * Returns json string with statistics.
+     * @return json string with statistics.
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public String getStats()
     {
         FocusManager focusManager = focusManagerProvider.get();
 
-        JicofoStatisticsSnapshot snapshot = JicofoStatisticsSnapshot.generate(focusManager);
+        JicofoStatisticsSnapshot snapshot
+            = JicofoStatisticsSnapshot.generate(focusManager);
         JSONObject json = new JSONObject();
         json.put(CONFERENCES, snapshot.numConferences);
         json.put(LARGEST_CONFERENCE, snapshot.largestConferenceSize);

--- a/src/test/java/org/jitsi/jicofo/rest/HealthTest.java
+++ b/src/test/java/org/jitsi/jicofo/rest/HealthTest.java
@@ -22,6 +22,7 @@ import org.jitsi.jicofo.*;
 import org.jitsi.jicofo.testutils.*;
 import org.jitsi.jicofo.util.*;
 import org.json.simple.*;
+import org.json.simple.parser.*;
 import org.junit.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
@@ -129,7 +130,8 @@ public class HealthTest extends JerseyTest
         // Should still do the health check
         verify(focusManager).conferenceRequest(any(), any(), any(), eq(false));
         assertEquals(HttpServletResponse.SC_OK, resp.getStatus());
-        JSONObject respJson = resp.readEntity(JSONObject.class);
+        JSONObject respJson
+            = (JSONObject)new JSONParser().parse(resp.readEntity(String.class));
         assertNotNull(respJson.get("jvbs"));
         List jvbs = (List)respJson.get("jvbs");
         assertEquals(2, jvbs.size());
@@ -142,7 +144,8 @@ public class HealthTest extends JerseyTest
         setupHealthCheckError();
         Response resp = target("/about/health").queryParam("list_jvb", true).request().get();
         assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, resp.getStatus());
-        JSONObject respJson = resp.readEntity(JSONObject.class);
+        JSONObject respJson
+            = (JSONObject)new JSONParser().parse(resp.readEntity(String.class));
         assertNotNull(respJson.get("jvbs"));
         List jvbs = (List)respJson.get("jvbs");
         assertEquals(2, jvbs.size());


### PR DESCRIPTION
Before the change health check that returns jvb list (curl -v http://localhost:8888/about/health?list_jvb=true), in case of components returns:
`The JID 'jitsi-videobridge.jitsi.example.com' has no resourcepart (through reference chain: org.json.simple.JSONObject["jvbs"]->java.util.ArrayList[0]->org.jxmpp.jid.impl.DomainpartJid["resourceOrThrow"])`.
And in case of mucs returns:
`{"jvbs":[{"resourceOrNull":"damencho","localpartOrNull":"jvbbrewery","resourcepart":"damencho","localpart":"jvbbrewery","domain":"internal.auth.jitsi.example.com","domainBareJid":false,"entityBareJid":false,"entityJid":true,"domainFullJid":false,"entityFullJid":true,"resourceOrEmpty":"damencho","resourceOrThrow":"damencho","localpartOrThrow":"jvbbrewery"}]}`

After the change will return:
`{"jvbs":["jvbbrewery@internal.auth.jitsi.example.com/damencho"]}`
or
`{"jvbs":["jitsi-videobridge.jitsi.example.com"]}`

Reporrted by Bui_Xuan_Thu_n https://community.jitsi.org/t/jicofo-lastest-version-jicofo-1-0-508-1-i386-deb-error-api-about-health

