### PR TITLE
Update pom.xml for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,19 @@
       <artifactId>jetty-util</artifactId>
       <version>${jetty.version}</version>
     </dependency>
+	  <!-- API, java.xml.bind module -->
+<dependency>
+    <groupId>jakarta.xml.bind</groupId>
+    <artifactId>jakarta.xml.bind-api</artifactId>
+    <version>2.3.2</version>
+</dependency>
+
+<!-- Runtime, com.sun.xml.bind module -->
+<dependency>
+    <groupId>org.glassfish.jaxb</groupId>
+    <artifactId>jaxb-runtime</artifactId>
+    <version>2.3.2</version>
+</dependency>
     <dependency>
       <groupId>org.igniterealtime</groupId>
       <artifactId>tinder</artifactId>


### PR DESCRIPTION
This is not serious. But this is part of the upgrade to Java 11 (from 8 currently) and such an upgrade can be made potentially for good reason.

Java 11 (or 9 already) will address two fundamental needs of large Java applications: Reliable configuration and strong encapsulation.

    Reliable configuration — Developers have long suffered with the brittle, error-prone class-path mechanism for configuring program components. The class path cannot express relationships between components, so if a necessary component is missing then that will not be discovered until an attempt is made to use it. The class path also allows classes in the same package to be loaded from different components, leading to unpredictable behavior and difficult-to-diagnose errors. Java 11 will allow a component to declare that it depends upon other components, as other components depend upon it.

    Strong encapsulation — The access-control mechanism of the Java programming language and the Java virtual machine provides no way for a component to prevent other components from accessing its internal packages. Java 11 will allow a component to declare which of its packages are accessible by other components, and which are not.