### PR TITLE
Move operations on items found in maps outside synchronized blocks.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/OperationSetJibri.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/OperationSetJibri.java
@@ -78,15 +78,23 @@ public class OperationSetJibri
     @Override
     public IQ handleIQRequest(IQ iq)
     {
+        CommonJibriStuff theJibri = null;
+
         synchronized (jibris)
         {
             for (CommonJibriStuff jibri : jibris)
             {
                 if (jibri.accept((JibriIq) iq))
                 {
-                    return jibri.handleIQRequest((JibriIq) iq);
+                    theJibri = jibri;
+                    break;
                 }
             }
+        }
+
+        if (theJibri != null)
+        {
+            return theJibri.handleIQRequest((JibriIq) iq);
         }
 
         return IQ.createErrorResponse(iq, XMPPError.getBuilder(


### PR DESCRIPTION
In ChatRoomImpl and OperationSetJibri.

Should fix a deadlock.

(Note this changes some indentation; you may wish to review hiding whitespace changes.) 