### PR TITLE
feat: add dedicated XMPP connection for JVB communication

### DIFF
--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -738,6 +738,14 @@ public class FocusManager
     }
 
     /**
+     * Returns {@link ProtocolProviderService} for the JVB XMPP connection.
+     */
+    public ProtocolProviderService getJvbProtocolProvider()
+    {
+        return jvbProtocolProvider.getProtocolProvider();
+    }
+
+    /**
      * Interface used to listen for focus lifecycle events.
      */
     public interface FocusAllocationListener

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -124,6 +124,13 @@ public class JitsiMeetConferenceImpl
     private final ProtocolProviderHandler protocolProviderHandler;
 
     /**
+     * XMPP protocol provider used for the JVB connection. Unless configured
+     * with properties defined in {@link BridgeMucDetector} it wil be the same
+     * as {@link #protocolProviderHandler}
+     */
+    private final ProtocolProviderHandler jvbXmppConnection;
+
+    /**
      * The name of XMPP user used by the focus to login.
      */
     private final Resourcepart focusUserName;
@@ -282,6 +289,7 @@ public class JitsiMeetConferenceImpl
     public JitsiMeetConferenceImpl(EntityBareJid            roomName,
                                    Resourcepart             focusUserName,
                                    ProtocolProviderHandler  protocolProviderHandler,
+                                   ProtocolProviderHandler  jvbXmppConnection,
                                    ConferenceListener       listener,
                                    JitsiMeetConfig          config,
                                    JitsiMeetGlobalConfig    globalConfig,
@@ -292,6 +300,9 @@ public class JitsiMeetConferenceImpl
         this.protocolProviderHandler
             = Objects.requireNonNull(
                     protocolProviderHandler, "protocolProviderHandler");
+        this.jvbXmppConnection
+            = Objects.requireNonNull(
+                    jvbXmppConnection, "jvbXmppConnection");
         this.config = Objects.requireNonNull(config, "config");
 
         this.id = id;
@@ -311,14 +322,15 @@ public class JitsiMeetConferenceImpl
     public JitsiMeetConferenceImpl(EntityBareJid            roomName,
                                    Resourcepart             focusUserName,
                                    ProtocolProviderHandler  protocolProviderHandler,
+                                   ProtocolProviderHandler  jvbXmppConnection,
                                    ConferenceListener       listener,
                                    JitsiMeetConfig          config,
                                    JitsiMeetGlobalConfig    globalConfig,
                                    Level                    logLevel,
                                    String                   id)
     {
-       this(roomName, focusUserName, protocolProviderHandler, listener,
-           config, globalConfig, logLevel, id, false);
+       this(roomName, focusUserName, protocolProviderHandler, jvbXmppConnection,
+            listener, config, globalConfig, logLevel, id, false);
     }
 
     /**
@@ -343,7 +355,7 @@ public class JitsiMeetConferenceImpl
         try
         {
             colibri
-                = protocolProviderHandler.getOperationSet(
+                = jvbXmppConnection.getOperationSet(
                         OperationSetColibriConference.class);
             jingle
                 = protocolProviderHandler.getOperationSet(

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetServices.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetServices.java
@@ -107,6 +107,11 @@ public class JitsiMeetServices
     private final DomainBareJid jicofoUserDomain;
 
     /**
+     * The {@link ProtocolProviderHandler} for JVB XMPP connection.
+     */
+    private final ProtocolProviderHandler jvbBreweryProtocolProvider;
+
+    /**
      * The {@link ProtocolProviderHandler} for Jicofo XMPP connection.
      */
     private final ProtocolProviderHandler protocolProvider;
@@ -142,15 +147,20 @@ public class JitsiMeetServices
      * Creates new instance of <tt>JitsiMeetServices</tt>
      *  @param protocolProviderHandler {@link ProtocolProviderHandler} for Jicofo
      *        XMPP connection.
+     * @param jvbMucProtocolProvider {@link ProtocolProviderHandler} for JVB
+     *        XMPP connection.
      * @param jicofoUserDomain the name of the XMPP domain to which Jicofo user
      */
     public JitsiMeetServices(ProtocolProviderHandler protocolProviderHandler,
+                             ProtocolProviderHandler jvbMucProtocolProvider,
                              DomainBareJid jicofoUserDomain)
     {
         super(new String[] { BridgeEvent.HEALTH_CHECK_FAILED });
 
         Objects.requireNonNull(
             protocolProviderHandler, "protocolProviderHandler");
+        Objects.requireNonNull(
+            jvbMucProtocolProvider, "jvbMucProtocolProvider");
 
         OperationSetSubscription subscriptionOpSet
             = protocolProviderHandler.getOperationSet(
@@ -160,6 +170,7 @@ public class JitsiMeetServices
 
         this.jicofoUserDomain = jicofoUserDomain;
         this.protocolProvider = protocolProviderHandler;
+        this.jvbBreweryProtocolProvider = jvbMucProtocolProvider;
         this.bridgeSelector = new BridgeSelector(subscriptionOpSet);
     }
 
@@ -390,7 +401,9 @@ public class JitsiMeetServices
         {
             BridgeMucDetector bridgeMucDetector
                 = new BridgeMucDetector(
-                    protocolProvider, bridgeBreweryName, bridgeSelector);
+                    jvbBreweryProtocolProvider,
+                    bridgeBreweryName,
+                    bridgeSelector);
             logger.info(
                 "Using a Bridge MUC detector with MUC: " + bridgeBreweryName);
 

--- a/src/main/java/org/jitsi/jicofo/ProtocolProviderHandler.java
+++ b/src/main/java/org/jitsi/jicofo/ProtocolProviderHandler.java
@@ -69,12 +69,14 @@ public class ProtocolProviderHandler
     /**
      * Start this instance by created XMPP account using the given parameters.
      * @param serverAddress XMPP server address.
+     * @param serverPort XMPP server port.
      * @param xmppDomain XMPP authentication domain.
      * @param xmppLoginPassword XMPP login(optional).
      * @param nickName authentication login.
      *
      */
     public void start(String serverAddress,
+                      String  serverPort,
                       DomainBareJid xmppDomain,
                       String xmppLoginPassword,
                       Resourcepart nickName)
@@ -90,7 +92,10 @@ public class ProtocolProviderHandler
                 = xmppProviderFactory.createAccount(
                 FocusAccountFactory.createFocusAccountProperties(
                     serverAddress,
-                    xmppDomain, nickName, xmppLoginPassword));
+                    serverPort,
+                    xmppDomain,
+                    nickName,
+                    xmppLoginPassword));
         }
         else
         {
@@ -98,7 +103,9 @@ public class ProtocolProviderHandler
                 = xmppProviderFactory.createAccount(
                 FocusAccountFactory.createFocusAccountProperties(
                     serverAddress,
-                    xmppDomain, nickName));
+                    serverPort,
+                    xmppDomain,
+                    nickName));
         }
 
         if (!xmppProviderFactory.loadAccount(xmppAccount))
@@ -134,6 +141,8 @@ public class ProtocolProviderHandler
     @Override
     public void registrationStateChanged(RegistrationStateChangeEvent evt)
     {
+        logger.info(this + ": " + evt);
+
         for(RegistrationStateChangeListener l : regListeners)
         {
             try

--- a/src/main/java/org/jitsi/jicofo/bridge/BridgeMucDetector.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/BridgeMucDetector.java
@@ -18,10 +18,14 @@
 package org.jitsi.jicofo.bridge;
 
 import org.jitsi.jicofo.*;
+import org.jitsi.service.configuration.*;
+import org.jitsi.utils.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import net.java.sip.communicator.util.*;
 import org.jitsi.jicofo.xmpp.*;
 import org.jxmpp.jid.*;
+import org.jxmpp.jid.impl.*;
+import org.jxmpp.jid.parts.*;
 
 /**
  * Detects jitsi-videobridge instances through a MUC.
@@ -42,6 +46,88 @@ public class BridgeMucDetector
      */
     public static final String BRIDGE_MUC_PNAME
         = "org.jitsi.jicofo.BRIDGE_MUC";
+
+    /**
+     * Config property for JVB connection's XMPP host.
+     */
+    private static final String BRIDGE_MUC_XMPP_HOST
+            = "org.jitsi.jicofo.BRIDGE_MUC_XMPP_HOST";
+
+    /**
+     * Config property for JVB connection's XMPP username.
+     */
+    private static final String BRIDGE_MUC_XMPP_USER
+            = "org.jitsi.jicofo.BRIDGE_MUC_XMPP_USER";
+
+    /**
+     * Config property for JVB connection's XMPP user domain.
+     */
+    private static final String BRIDGE_MUC_XMPP_USER_DOMAIN
+            = "org.jitsi.jicofo.BRIDGE_MUC_XMPP_USER_DOMAIN";
+
+    /**
+     * Config property for JVB connection's XMPP user password.
+     */
+    private static final String BRIDGE_MUC_XMPP_USER_PASS
+            = "org.jitsi.jicofo.BRIDGE_MUC_XMPP_USER_PASS";
+
+    /**
+     * Config property for JVB connection's XMPP port.
+     */
+    private static final String BRIDGE_MUC_XMPP_PORT
+            = "org.jitsi.jicofo.BRIDGE_MUC_XMPP_PORT";
+
+    /**
+     * Tries to load a {@link ProtocolProviderHandler}  for dedicated JVB
+     * connection if configured. See static properties starting with
+     * "BRIDGE_MUC" in this class for config properties names.
+     * @param config - The  configuration service instance.
+     * @return protocol provider or {@code null} if not configured or failed
+     * to load.
+     */
+    static public ProtocolProviderHandler tryLoadingJvbXmppProvider(
+            ConfigurationService config)
+    {
+        try
+        {
+            String hostName = config.getString(BRIDGE_MUC_XMPP_HOST);
+
+            //  Assume not configured if there's no XMPP host
+            if (StringUtils.isNullOrEmpty(hostName)) {
+                return null;
+            }
+
+            String xmppServerPort = config.getString(BRIDGE_MUC_XMPP_PORT);
+
+            DomainBareJid userDomain
+                = JidCreate.domainBareFrom(config.getString(
+                        BRIDGE_MUC_XMPP_USER_DOMAIN));
+            Resourcepart userName
+                = Resourcepart.from(
+                        config.getString(BRIDGE_MUC_XMPP_USER));
+            String userPassword
+                = config.getString(BRIDGE_MUC_XMPP_USER_PASS);
+
+            ProtocolProviderHandler protocolProviderHandler
+                = new ProtocolProviderHandler();
+
+            protocolProviderHandler.start(
+                    hostName,
+                    xmppServerPort,
+                    userDomain,
+                    userPassword,
+                    userName);
+
+            return protocolProviderHandler;
+        }
+        catch (Exception e)
+        {
+            logger.error(
+                "Failed to create dedicated JVB XMPP connection provider", e);
+
+            return null;
+        }
+    }
 
     /**
      * The {@link BridgeSelector} instance which will be notified when new

--- a/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
@@ -182,10 +182,11 @@ public class JvbDoctor
         this.executorServiceRef
             = new OSGIServiceRef<>(osgiBc, ScheduledExecutorService.class);
 
-        // We assume that in Jicofo there is only one XMPP provider running at a
-        // time.
+        FocusManager focusManager
+            = ServiceUtils.getService(osgiBc, FocusManager.class);
+
         protocolProvider
-            = ServiceUtils.getService(osgiBc, ProtocolProviderService.class);
+            = focusManager.getJvbProtocolProvider();
 
         Objects.requireNonNull(protocolProvider, "protocolProvider");
 

--- a/src/main/java/org/jitsi/jicofo/util/FocusAccountFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/FocusAccountFactory.java
@@ -19,6 +19,7 @@ package org.jitsi.jicofo.util;
 
 import net.java.sip.communicator.service.protocol.*;
 import net.java.sip.communicator.service.protocol.jabber.*;
+import org.jitsi.utils.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.parts.*;
 import org.jxmpp.stringprep.*;
@@ -40,6 +41,7 @@ public class FocusAccountFactory
      * <tt>domain</tt> which uses anonymous login method.
      *
      * @param serverAddress XMPP server address.
+     * @param serverPort XMPP server port(5222 by default).
      * @param domain name of the XMPP domain on which the focus will register.
      * @param userName user name used by the focus user.
      *
@@ -47,6 +49,7 @@ public class FocusAccountFactory
      */
     public static Map<String, String> createFocusAccountProperties(
             String serverAddress,
+            String serverPort,
             DomainBareJid domain,
             Resourcepart userName)
     {
@@ -67,7 +70,13 @@ public class FocusAccountFactory
 
         properties.put(ProtocolProviderFactory.USER_ID, userID);
         properties.put(ProtocolProviderFactory.SERVER_ADDRESS, serverAddress);
-        properties.put(ProtocolProviderFactory.SERVER_PORT, "5222");
+
+        if (StringUtils.isNullOrEmpty(serverPort, true)) {
+            properties.put(ProtocolProviderFactory.SERVER_PORT, "5222");
+        } else {
+            properties.put(ProtocolProviderFactory.SERVER_PORT, serverPort.trim());
+        }
+
 
         // This is used as the multi user chat nick when joining the room
         properties.put(ProtocolProviderFactory.DISPLAY_NAME, userName.toString());
@@ -128,6 +137,7 @@ public class FocusAccountFactory
      *  the room).
      *
      * @param serverAddress XMPP server address.
+     * @param serverPort XMPP server port(5222 by default).
      * @param domain name of the XMPP domain on which the focus will register.
      * @param userName the nickname used by the focus in MUC room
      *                 (also used as login name).
@@ -137,13 +147,17 @@ public class FocusAccountFactory
      */
     public static Map<String, String> createFocusAccountProperties(
             String serverAddress,
+            String serverPort,
             DomainBareJid domain,
             Resourcepart userName,
             String password)
     {
         Map<String, String> properties
             = createFocusAccountProperties(
-                    serverAddress, domain, userName);
+                    serverAddress,
+                    serverPort,
+                    domain,
+                    userName);
 
         properties.put(
                 ProtocolProviderFactory.AUTHORIZATION_NAME,


### PR DESCRIPTION
The following properties can be used to add separate XMPP connection for
JVB communication:
org.jitsi.jicofo.BRIDGE_MUC=JvbBrewery@muc.jvb.server.com
org.jitsi.jicofo.BRIDGE_MUC_XMPP_HOST=jvb.server.com
org.jitsi.jicofo.BRIDGE_MUC_XMPP_USER_DOMAIN=auth.jvb.server.com
org.jitsi.jicofo.BRIDGE_MUC_XMPP_PORT=6222
org.jitsi.jicofo.BRIDGE_MUC_XMPP_USER=focus
org.jitsi.jicofo.BRIDGE_MUC_XMPP_USER_PASS=topsecret