### PR TITLE
Don't consider failed and non-operational bridges for Octo.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -822,6 +822,16 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
+     * Get a stream of those bridges which are operational.
+     * Caller should be synchronized on bridges.
+     */
+    private Stream<BridgeSession> operationalBridges()
+    {
+        return bridges.stream().
+            filter(session -> !session.hasFailed && session.bridge.isOperational());
+    }
+
+    /**
      * Invites a {@link Participant} to the conference. Selects the
      * {@link BridgeSession} to use and starts a new {@link
      * ParticipantChannelAllocator} to allocate COLIBRI channels and initiate
@@ -869,7 +879,7 @@ public class JitsiMeetConferenceImpl
                     ConferenceProperties.KEY_BRIDGE_COUNT,
                     Integer.toString(bridges.size()));
 
-                if (bridges.size() >= 2)
+                if (operationalBridges().count() >= 2)
                 {
                     // Octo needs to be enabled (by inviting an Octo
                     // participant for each bridge), or if it is already enabled
@@ -916,7 +926,8 @@ public class JitsiMeetConferenceImpl
                                  ". All relays:" + allRelays);
             }
 
-            bridges.forEach(bridge -> bridge.setRelays(allRelays));
+            operationalBridges().
+                forEach(bridge -> bridge.setRelays(allRelays));
         }
     }
 
@@ -930,8 +941,7 @@ public class JitsiMeetConferenceImpl
         synchronized (bridges)
         {
             return
-                bridges.stream()
-                    .filter(session -> !session.hasFailed && session.bridge.isOperational())
+                operationalBridges()
                     .map(bridge -> bridge.bridge.getRelayId())
                     .filter(Objects::nonNull)
                     .filter(bridge -> !bridge.equals(exclude))
@@ -1677,7 +1687,7 @@ public class JitsiMeetConferenceImpl
     {
         synchronized (bridges)
         {
-            bridges.stream()
+            operationalBridges()
                 .filter(bridge -> !bridge.equals(exclude))
                 .forEach(
                     bridge -> bridge.addSourcesToOcto(sources, sourceGroups));
@@ -1962,7 +1972,7 @@ public class JitsiMeetConferenceImpl
 
         synchronized (bridges)
         {
-            bridges.stream()
+            operationalBridges()
                 .filter(bridge -> !bridge.equals(bridgeSession))
                 .forEach(
                     bridge -> bridge.removeSourcesFromOcto(


### PR DESCRIPTION
Note: it's possible more places need to use the new `operationalBridges()` method rather than use `bridges` directly, but this should be a start?