### PR TITLE
Shibboleth Authentification Fix

### DIFF
--- a/src/main/java/org/jitsi/jicofo/auth/ShibbolethHandler.java
+++ b/src/main/java/org/jitsi/jicofo/auth/ShibbolethHandler.java
@@ -81,7 +81,7 @@ class ShibbolethHandler
             throws IOException,
             ServletException
     {
-        if (!SHIBBOLETH_TARGET.equals(target))
+        if (!target.startsWith(SHIBBOLETH_TARGET))
         {
             return;
         }


### PR DESCRIPTION
Replacing equals with startsWith should fix #446 for Shibboleth.