### PR TITLE
Fixes room destruction after duration expires.

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -877,7 +877,9 @@ public class ChatRoomImpl
     {
         try
         {
-            muc.destroy(reason, JidCreate.entityBareFrom(alternateAddress));
+            muc.destroy(reason,
+                alternateAddress != null ?
+                    JidCreate.entityBareFrom(alternateAddress) : null);
         }
         catch (XMPPException
                 | XmppStringprepException


### PR DESCRIPTION
This is to fix behaviour described at: https://community.jitsi.org/t/room-not-being-destroyed-after-duration-exceeded/29768
When reservation API sets duration for conference, this is not respected and room is not destroyed upon duration's expiry,
with error like that:
java.lang.RuntimeException: org.jxmpp.stringprep.XmppStringprepException: XmppStringprepException caused by 'null': org.jxmpp.stringprep.XmppStringprepException: Input 'domain' must not be null