### PR TITLE
feat(stats): add info about Jibri sessions

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConference.java
@@ -19,6 +19,7 @@ package org.jitsi.jicofo;
 
 import net.java.sip.communicator.service.protocol.*;
 import org.jitsi.jicofo.bridge.*;
+import org.jitsi.jicofo.recording.jibri.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.utils.logging.*;
 import org.jxmpp.jid.*;
@@ -86,6 +87,12 @@ public interface JitsiMeetConference
      * array is copied.
      */
     void setStartMuted(boolean[] startMuted);
+
+    /**
+     * @return a stats snapshot for all {@link JibriSession}s used in this
+     * conference.
+     */
+    JibriSessionStats getJibriSessionStats();
 
     /**
      * Gets the role of a member in the conference.

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -3122,6 +3122,27 @@ public class JitsiMeetConferenceImpl
      * {@inheritDoc}
      */
     @Override
+    public JibriSessionStats getJibriSessionStats()
+    {
+        List<JibriSession> sessions = new ArrayList<>();
+
+        if (jibriRecorder != null)
+        {
+            sessions.addAll(jibriRecorder.getJibriSessions());
+        }
+
+        if  (jibriSipGateway != null)
+        {
+            sessions.addAll(jibriSipGateway.getJibriSessions());
+        }
+
+        return new JibriSessionStats(sessions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString()
     {
         return

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/CommonJibriStuff.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/CommonJibriStuff.java
@@ -157,6 +157,11 @@ public abstract class CommonJibriStuff
     protected abstract JibriSession getJibriSessionForMeetIq(JibriIq iq);
 
     /**
+     * @return a list with all {@link JibriSession}s used by this instance.
+     */
+    public abstract List<JibriSession> getJibriSessions();
+
+    /**
      * This method will be called when start IQ arrives from Jitsi Meet
      * participant and {@link #getJibriSessionForMeetIq(JibriIq)} returns
      * <tt>null</tt>. The implementing class should allocate and store new

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriRecorder.java
@@ -27,6 +27,7 @@ import org.jitsi.utils.logging.*;
 import org.jivesoftware.smack.packet.*;
 import org.osgi.framework.*;
 
+import java.util.*;
 import java.util.concurrent.*;
 
 import static org.jitsi.jicofo.recording.jibri.JibriSession.StartException;
@@ -118,6 +119,22 @@ public class JibriRecorder
     protected JibriSession getJibriSessionForMeetIq(JibriIq iq)
     {
         return jibriSession;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<JibriSession> getJibriSessions()
+    {
+        List<JibriSession> sessions = new ArrayList<>(1);
+
+        if (jibriSession != null)
+        {
+            sessions.add(jibriSession);
+        }
+
+        return sessions;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
@@ -276,24 +276,49 @@ public class JibriSession
      */
     private void emitSessionFailedEvent()
     {
-        JibriSessionEvent.Type jibriType;
-        if (isSIP)
-        {
-            jibriType = JibriSessionEvent.Type.SIP_CALL;
-        }
-        else if (StringUtils.isNullOrEmpty(streamID))
-        {
-            jibriType = JibriSessionEvent.Type.RECORDING;
-        }
-        else
-        {
-            jibriType = JibriSessionEvent.Type.LIVE_STREAMING;
-        }
-
         eventAdminProvider
                 .get()
                 .postEvent(
-                        JibriSessionEvent.newFailedToStartEvent(jibriType));
+                        JibriSessionEvent.newFailedToStartEvent(
+                                getJibriType()));
+    }
+
+    /**
+     * @return The {@link JibriSessionEvent.Type} of this session.
+     */
+    public JibriSessionEvent.Type getJibriType()
+    {
+        if (isSIP)
+        {
+            return JibriSessionEvent.Type.SIP_CALL;
+        }
+        else if (StringUtils.isNullOrEmpty(streamID))
+        {
+            return JibriSessionEvent.Type.RECORDING;
+        }
+        else
+        {
+            return JibriSessionEvent.Type.LIVE_STREAMING;
+        }
+    }
+
+    /**
+     * @return {@code true} if this sessions is active or {@code false}
+     * otherwise.
+     */
+    public boolean isActive()
+    {
+        return Status.ON.equals(jibriStatus);
+    }
+
+    /**
+     * @return {@code true} if this session is pending or {@code false}
+     * otherwise.
+     */
+    public boolean isPending()
+    {
+        return Status.UNDEFINED.equals(jibriStatus)
+                || Status.PENDING.equals(jibriStatus);
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSessionStats.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSessionStats.java
@@ -1,0 +1,168 @@
+package org.jitsi.jicofo.recording.jibri;
+
+import org.json.simple.*;
+
+import java.util.*;
+import java.util.function.*;
+
+/**
+ * Statistics snapshot for {@link JibriSession}.
+ */
+public class JibriSessionStats
+{
+    /**
+     * Counts active {@link JibriSession}s.
+     * @param sessions the list of sessions.
+     * @param jibriType the type of Jibri to count.
+     * @return how many active Jibri sessions of given type are in the list.
+     */
+    private static int countActive(List<JibriSession> sessions,
+                                   JibriSessionEvent.Type jibriType)
+    {
+        return countJibris(sessions, jibriType, JibriSession::isActive);
+    }
+
+    /**
+     * Counts Jibri sessions.
+     * @param sessions the list of sessions to scan.
+     * @param jibriType the type of jibri session to be count.
+     * @param selector the selector which makes the decision on whether or not
+     * to count the given instance.
+     * @return the count of Jibri sessions of given type that pass
+     * the selector's test.
+     */
+    private static int countJibris(
+            List<JibriSession> sessions,
+            JibriSessionEvent.Type jibriType,
+            Function<JibriSession, Boolean> selector)
+    {
+        int count = 0;
+
+        for (JibriSession session : sessions)
+        {
+            if (session.getJibriType().equals(jibriType)
+                    && selector.apply(session))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * Counts pending Jibri sessions of given type.
+     * @param sessions the list of sessions to scan.
+     * @param jibriType the type of Jibri session to count.
+     * @return how many Jibri sessions of given type and in the pending state
+     * are there on the list.
+     */
+    private static int countPending(List<JibriSession> sessions,
+                                    JibriSessionEvent.Type jibriType)
+    {
+        return countJibris(sessions, jibriType, JibriSession::isPending);
+    }
+
+    /**
+     * How many active recording Jibri sessions.
+     */
+    private int activeRecordingSessions;
+
+    /**
+     * How many active lice streaming Jibri sessions.
+     */
+    private int activeLiveStreamingSessions;
+
+    /**
+     * How many active SIP call Jibri sessions.
+     */
+    private int activeSipCallSessions;
+
+    /**
+     * How many pending recording Jibri sessions.
+     */
+    private int pendingRecordingSessions;
+
+    /**
+     * How many pending live streaming Jibri sessions
+     */
+    private int pendingLiveStreamingSessions;
+
+    /**
+     * How many pending SIP call Jibri sessions.
+     */
+    private int pendingSipCallSessions;
+
+    /**
+     * Creates empty instance initialized with 0 stats.
+     */
+    public JibriSessionStats()
+    {
+
+    }
+
+    /**
+     * Creates new {@link JibriSessionStats} computed for the given list of
+     * {@link JibriSession}.
+     *
+     * @param sessions the list for which the stats will be generated.
+     */
+    public JibriSessionStats(List<JibriSession> sessions)
+    {
+        activeLiveStreamingSessions
+            = countActive(
+                sessions,
+                JibriSessionEvent.Type.LIVE_STREAMING);
+        activeRecordingSessions
+            = countActive(
+                sessions,
+                JibriSessionEvent.Type.RECORDING);
+        activeSipCallSessions
+            = countActive(
+                sessions,
+                JibriSessionEvent.Type.SIP_CALL);
+
+        pendingLiveStreamingSessions
+            = countPending(
+                sessions,
+                JibriSessionEvent.Type.LIVE_STREAMING);
+        pendingRecordingSessions
+            = countPending(
+                sessions,
+                JibriSessionEvent.Type.RECORDING);
+        pendingSipCallSessions
+            = countPending(
+                sessions,
+                JibriSessionEvent.Type.SIP_CALL);
+    }
+
+    /**
+     * Merges statistics stored in the given instance with this instance's
+     * state by adding up values.
+     * @param stats the other stats to merge.
+     */
+    public void merge(JibriSessionStats stats)
+    {
+        this.activeLiveStreamingSessions += stats.activeLiveStreamingSessions;
+        this.activeRecordingSessions += stats.activeRecordingSessions;
+        this.activeSipCallSessions += stats.activeSipCallSessions;
+        this.pendingLiveStreamingSessions += stats.pendingLiveStreamingSessions;
+        this.pendingRecordingSessions += stats.pendingRecordingSessions;
+        this.pendingSipCallSessions += stats.pendingSipCallSessions;
+    }
+
+    /**
+     * Describes as JSON.
+     * @param stats the JSON object where the stats will end up.
+     */
+    public void toJSON(JSONObject stats)
+    {
+        stats.put("live_streaming_active", activeLiveStreamingSessions);
+        stats.put("recording_active", activeRecordingSessions);
+        stats.put("sip_call_active", activeSipCallSessions);
+
+        stats.put("live_streaming_pending", pendingLiveStreamingSessions);
+        stats.put("recording_pending", pendingRecordingSessions);
+        stats.put("sip_call_pending", pendingSipCallSessions);
+    }
+}

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSipGateway.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSipGateway.java
@@ -125,6 +125,19 @@ public class JibriSipGateway
         return sipSessions.get(sipAddress);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<JibriSession> getJibriSessions()
+    {
+        List<JibriSession> sessions = new ArrayList<>(sipSessions.size());
+
+        sessions.addAll(sipSessions.values());
+
+        return sessions;
+    }
+
     @Override
     protected IQ handleStartRequest(JibriIq iq)
     {

--- a/src/test/java/org/jitsi/jicofo/MockJitsiMeetConference.java
+++ b/src/test/java/org/jitsi/jicofo/MockJitsiMeetConference.java
@@ -19,6 +19,7 @@ package org.jitsi.jicofo;
 
 import net.java.sip.communicator.service.protocol.*;
 import org.jitsi.jicofo.bridge.*;
+import org.jitsi.jicofo.recording.jibri.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.utils.logging.*;
 import org.jxmpp.jid.*;
@@ -78,6 +79,12 @@ public class MockJitsiMeetConference
     @Override
     public void setStartMuted(boolean[] startMuted)
     {
+    }
+
+    @Override
+    public JibriSessionStats getJibriSessionStats()
+    {
+        return new JibriSessionStats();
     }
 
     @Override


### PR DESCRIPTION
Adds the following to the JSON stats:

"live_streaming_active" - active Jibri live streaming sessions
"recording_active" - active Jibri recording sessions
"sip_call_active" - active Jibri SIP calls
"live_streaming_pending" - pending live streaming Jibri sessions
"recording_pending" - pending recording Jibri sessions
"sip_call_pending" - pending SIP call Jibri sessions