### PR TITLE
fix(JvbDoctor): release the lock for feature discovery

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
@@ -456,23 +456,24 @@ public class JvbDoctor
                 return;
             }
 
-            // Sync on start/stop and bridges state
-            synchronized (JvbDoctor.this)
+            if (taskInvalid())
             {
-                if (taskInvalid())
-                    return;
-
-                // Check for health-check support
-                verifyHealthCheckSupport();
-
-                if (!Boolean.TRUE.equals(hasHealthCheckSupport))
-                {
-                    // This JVB does not support health-checks
-                    return;
-                }
-
-                logger.debug("Sending health-check request to: " + bridgeJid);
+                return;
             }
+
+            // Check for health-check support
+            verifyHealthCheckSupport();
+
+            if (taskInvalid())
+                return;
+
+            if (!Boolean.TRUE.equals(hasHealthCheckSupport))
+            {
+                // This JVB does not support health-checks
+                return;
+            }
+
+            logger.debug("Sending health-check request to: " + bridgeJid);
 
             IQ response
                 = connection.sendPacketAndGetReply(


### PR DESCRIPTION
verifyHealthCheckSupport() calls to DiscoveryUtil.checkFeatureSupport
which is a blocking operation while waiting for disco info response.