### PR TITLE
fix: re-arrange shared thread pools

### DIFF
--- a/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
+++ b/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
@@ -209,7 +209,7 @@ public class ComponentsDiscovery
             pubSubBridgeDiscovery
                 = new ThroughPubSubDiscovery(
                         subOpSet, capsOpSet,
-                        FocusBundleActivator.getSharedThreadPool());
+                        FocusBundleActivator.getSharedScheduledThreadPool());
 
             pubSubBridgeDiscovery.start(
                     FocusBundleActivator.bundleContext);

--- a/src/main/java/org/jitsi/jicofo/FocusBundleActivator.java
+++ b/src/main/java/org/jitsi/jicofo/FocusBundleActivator.java
@@ -73,14 +73,9 @@ public class FocusBundleActivator
 
     /**
      * A cached pool registered as {@link ExecutorService} to be shared by
-     * different Jicofo components through OSGi.
+     * different Jicofo components.
      */
-    private ExecutorService cachedPool;
-
-    /**
-     * {@link ServiceRegistration} for {@link #cachedPool}.
-     */
-    private ServiceRegistration<ExecutorService> cachedPoolRegistration;
+    private static ExecutorService cachedPool;
 
     /**
      * {@link org.jitsi.jicofo.FocusManager} instance created by this activator.
@@ -120,9 +115,6 @@ public class FocusBundleActivator
 
         jingleOfferFactory = new JingleOfferFactory(configServiceRef.get());
 
-        this.cachedPoolRegistration = context.registerService(
-                ExecutorService.class, cachedPool, null);
-
         this.scheduledPoolRegistration = context.registerService(
                 ScheduledExecutorService.class, scheduledPool, null);
 
@@ -159,12 +151,6 @@ public class FocusBundleActivator
         {
             scheduledPool.shutdownNow();
             scheduledPool = null;
-        }
-
-        if (cachedPoolRegistration != null)
-        {
-            cachedPoolRegistration.unregister();
-            cachedPoolRegistration = null;
         }
 
         if (cachedPool != null)
@@ -220,11 +206,10 @@ public class FocusBundleActivator
     }
 
     /**
-     * Returns a cached {@link ExecutorService} shared by all components through
-     * OSGi.
+     * Returns a cached {@link ExecutorService} shared by Jicofo components.
      */
     public static ExecutorService getSharedThreadPool()
     {
-        return ServiceUtils2.getService(bundleContext, ExecutorService.class);
+        return cachedPool;
     }
 }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -436,7 +436,7 @@ public class JitsiMeetConferenceImpl
                             osgiCtx,
                             this,
                             getXmppConnection(),
-                            FocusBundleActivator.getSharedThreadPool(),
+                            FocusBundleActivator.getSharedScheduledThreadPool(),
                             globalConfig);
 
                 jibriOpSet.addJibri(jibriSipGateway);

--- a/src/main/java/org/jitsi/jicofo/util/DaemonThreadFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/DaemonThreadFactory.java
@@ -27,6 +27,18 @@ import java.util.concurrent.*;
 public class DaemonThreadFactory
     implements ThreadFactory
 {
+    private final String threadName;
+
+    public DaemonThreadFactory()
+    {
+        this(null);
+    }
+
+    public DaemonThreadFactory(String threadName)
+    {
+        this.threadName = threadName;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -37,6 +49,11 @@ public class DaemonThreadFactory
         if (!t.isDaemon())
         {
             t.setDaemon(true);
+
+            if (threadName != null)
+            {
+                t.setName(threadName + "-" + t.getId());
+            }
         }
         return t;
     }


### PR DESCRIPTION
The scheduled ExecutorService pool shared by all Jicofo
components had a silly size of 20, so bump it to 200. Any timing out
requests can easily block the pipeline. This pool is used
by components that run things at fixed rate or schedule tasks
with delays.

Adds a cached ExecutorService and make channel allocator threads
use it instead of the scheduled executor pool which has limited size.