### PR TITLE
fix(octo): Prevents leaking of OctoEndpoint.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
@@ -208,9 +208,6 @@ public abstract class AbstractChannelAllocator implements Runnable
         catch (OperationFailedException e)
         {
             logger.error("Failed to invite participant: ", e);
-            // expire any channels that were successfully created, if the invite
-            // failed.
-            bridgeSession.colibriConference.expireChannels(colibriChannels);
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
@@ -98,6 +98,12 @@ public abstract class AbstractChannelAllocator implements Runnable
     protected final boolean reInvite;
 
     /**
+     * The colibri channels that this allocator has allocated. They'll be
+     * cleaned up if the allocator is canceled or failed at any point.
+     */
+    private ColibriConferenceIQ colibriChannels;
+
+    /**
      * Initializes a new {@link AbstractChannelAllocator} instance which is to
      * invite a specific {@link Participant} into a specific
      * {@link JitsiMeetConferenceImpl} (using a specific jitsi-videobridge
@@ -145,9 +151,15 @@ public abstract class AbstractChannelAllocator implements Runnable
         catch (Throwable e)
         {
             logger.error("Channel allocator failed: ", e);
+            cancel();
         }
         finally
         {
+            if (canceled && colibriChannels != null)
+            {
+                bridgeSession.colibriConference.expireChannels(colibriChannels);
+            }
+
             if (participant != null)
             {
                 participant.channelAllocatorCompleted(this);
@@ -166,15 +178,9 @@ public abstract class AbstractChannelAllocator implements Runnable
             return;
         }
 
-        ColibriConferenceIQ colibriChannels = allocateChannels(offer);
+        colibriChannels = allocateChannels(offer);
         if (canceled)
         {
-            // expire any channels that were successfully created, if the
-            // allocator was canceled while waiting for a reply.
-            if (colibriChannels != null)
-            {
-                bridgeSession.colibriConference.expireChannels(colibriChannels);
-            }
             return;
         }
 
@@ -195,9 +201,6 @@ public abstract class AbstractChannelAllocator implements Runnable
         offer = updateOffer(offer, colibriChannels);
         if (offer == null || canceled)
         {
-            // expire any channels that were successfully created, if the
-            // allocator was canceled while we updated the offer.
-            bridgeSession.colibriConference.expireChannels(colibriChannels);
             return;
         }
 

--- a/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
@@ -169,6 +169,12 @@ public abstract class AbstractChannelAllocator implements Runnable
         ColibriConferenceIQ colibriChannels = allocateChannels(offer);
         if (canceled)
         {
+            // expire any channels that were successfully created, if the
+            // allocator was canceled while waiting for a reply.
+            if (colibriChannels != null)
+            {
+                bridgeSession.colibriConference.expireChannels(colibriChannels);
+            }
             return;
         }
 
@@ -189,6 +195,9 @@ public abstract class AbstractChannelAllocator implements Runnable
         offer = updateOffer(offer, colibriChannels);
         if (offer == null || canceled)
         {
+            // expire any channels that were successfully created, if the
+            // allocator was canceled while we updated the offer.
+            bridgeSession.colibriConference.expireChannels(colibriChannels);
             return;
         }
 
@@ -199,6 +208,9 @@ public abstract class AbstractChannelAllocator implements Runnable
         catch (OperationFailedException e)
         {
             logger.error("Failed to invite participant: ", e);
+            // expire any channels that were successfully created, if the invite
+            // failed.
+            bridgeSession.colibriConference.expireChannels(colibriChannels);
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2903,6 +2903,10 @@ public class JitsiMeetConferenceImpl
 
             if (octo)
             {
+                if (participant != null)
+                {
+                    participant.setChannelAllocator(null);
+                }
                 this.octoParticipant = null;
             }
 


### PR DESCRIPTION
Cancels any pending octo allocations when the a bridge session is
terminated. This is fixes the following race as reported by @bgrozev:

1. A participant joins
2. We start an OctoChannelAllocator for a new bridge
3. We start a ParticipantChannelAllocator
4. The participant leaves (~150 ms after joining)
5. We cancel the ParticipantChannelAllocator