### PR TITLE
Add expectedAdditionalChannels

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -907,6 +907,7 @@ public class JitsiMeetConferenceImpl
             }
 
             bridgeSession.participants.add(participant);
+            bridgeSession.bridge.expectAnotherParticipant();
             participant.setBridgeSession(bridgeSession);
             logger.info("Added participant jid= " + participant.getMucJid()
                             + ", bridge=" + bridgeSession.bridge.getJid());

--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -300,6 +300,10 @@ public class Bridge
         return Double.compare(this.getStress(), o.getStress());
     }
 
+    public void expectAnotherParticipant() {
+        onVideoChannelsChanged(1);
+    }
+
     void onVideoChannelsChanged(Integer diff)
     {
         if (diff == null)


### PR DESCRIPTION
This is my first try to implement my idea to enhance #477.

I don't know if [videoChannelsRate](https://github.com/krombel/jicofo/blob/4e5d8afd99dc134061e8ac75bc11c48705a34e38/src/main/java/org/jitsi/jicofo/bridge/Bridge.java#L112) would might be used for tracking sth similar, but as I don't know the mechanics of that I thought, it might be better/simpler to track this channels independently.

So after a restart - before the stats data received jicofo - this will cause some round-robin for the next unused bridge. And after that the "normal" behaviour as before takes place again.