### PR TITLE
ref: disable service rediscovery by default

### DIFF
--- a/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
+++ b/src/main/java/org/jitsi/jicofo/ComponentsDiscovery.java
@@ -60,7 +60,7 @@ public class ComponentsDiscovery
     /**
      * Re-discovers every 30 seconds.
      */
-    private static final long DEFAULT_REDISCOVERY_INT = 30L * 1000L;
+    private static final long DEFAULT_REDISCOVERY_INT = -1;
 
     /**
      * The name of configuration property which specifies how often XMPP


### PR DESCRIPTION
There should be no need for that as now the bridges and other components use MUC.