### PR TITLE
Propagate sources upon ice restart + some.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1327,6 +1327,18 @@ public class JitsiMeetConferenceImpl
 
         if (bridgeSession != null)
         {
+            MediaSourceMap removedSources = participant.getSourcesCopy();
+            MediaSourceGroupMap removedGroups = participant.getSourceGroupsCopy();
+
+            synchronized (bridges)
+            {
+                operationalBridges()
+                    .filter(bridge -> !bridge.equals(bridgeSession))
+                    .forEach(
+                        bridge -> bridge.removeSourcesFromOcto(
+                            removedSources, removedGroups));
+            }
+
             maybeExpireBridgeSession(bridgeSession);
         }
     }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1800,6 +1800,15 @@ public class JitsiMeetConferenceImpl
                 errorMsg).build();
         }
 
+        JingleSession jingleSessionCopy = participant.getJingleSession();
+        if (jingleSessionCopy != null && jingleSession != jingleSessionCopy)
+        {
+            //FIXME: we should reject it ?
+            logger.error(
+                "Reassigning jingle session for participant: "
+                    + participantJid);
+        }
+
         // XXX We will be acting on the received session-accept bellow.
         // Unfortunately, we may have not received an acknowledgment of our
         // session-initiate yet and whatever we do bellow will be torn down when
@@ -1808,6 +1817,7 @@ public class JitsiMeetConferenceImpl
         // occurs, we may as well ignore the timeout.
         jingleSession.setAccepted(true);
 
+        participant.setJingleSession(jingleSession);
 
         // Extract and store various session information in the Participant
         participant.setRTPDescription(contents);

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1463,7 +1463,7 @@ public class JitsiMeetConferenceImpl
     {
         logger.info("Got session-accept from: " + jingleSession.getAddress());
 
-        return updateParticipant(jingleSession, answer);
+        return onSessionAcceptInternal(jingleSession, answer);
     }
 
     /**
@@ -1652,7 +1652,10 @@ public class JitsiMeetConferenceImpl
     {
         logger.info("Got transport-accept from: " + jingleSession.getAddress());
 
-        return updateParticipant(jingleSession, contents);
+        // We basically do the same processing as with session-accept by just
+        // forwarding transport/rtp information to the bridge + propagate the
+        // participants sources & source groups to remote bridges.
+        return onSessionAcceptInternal(jingleSession, contents);
     }
 
     /**
@@ -1783,7 +1786,7 @@ public class JitsiMeetConferenceImpl
      * @param contents
      * @return
      */
-    private XMPPError updateParticipant(
+    private XMPPError onSessionAcceptInternal(
         JingleSession jingleSession,
         List<ContentPacketExtension> contents)
     {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1825,14 +1825,12 @@ public class JitsiMeetConferenceImpl
         if (sourcesAdvertised.isEmpty()
             && globalConfig.injectSsrcForRecvOnlyEndpoints)
         {
-            // We inject an SSRC in order to insure that the participant has
+            // We inject an SSRC in order to ensure that the participant has
             // at least one SSRC advertised. Otherwise, non-local bridges in the
-            // conference will not be aware of the participant. We intentionally
-            // use a negative value, because this is an invalid SSRC and will
-            // not be actually used on the wire.
+            // conference will not be aware of the participant.
             SourcePacketExtension sourcePacketExtension
                 = new SourcePacketExtension();
-            long ssrc = RANDOM.nextInt() & 0xffff_ffffl;
+            long ssrc = RANDOM.nextInt() & 0xffff_ffffL;
             logger.info(participant
                 + " did not advertise any SSRCs. Injecting " + ssrc);
             sourcePacketExtension.setSSRC(ssrc);

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1812,14 +1812,6 @@ public class JitsiMeetConferenceImpl
                     + participantJid);
         }
 
-        // XXX We will be acting on the received session-accept or
-        // transport-accept Jingle IQs below. Unfortunately, we may have not
-        // received an acknowledgment of our IQ yet and whatever we do below
-        // will be torn down when the acknowledgement timeout occurs later on.
-        // Since we will have acted on the IQ by the time the acknowledgement
-        // timeout occurs, we may as well ignore the timeout.
-        jingleSession.setAccepted(true);
-
         participant.setJingleSession(jingleSession);
 
         // Extract and store various session information in the Participant

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1809,12 +1809,12 @@ public class JitsiMeetConferenceImpl
                     + participantJid);
         }
 
-        // XXX We will be acting on the received session-accept bellow.
-        // Unfortunately, we may have not received an acknowledgment of our
-        // session-initiate yet and whatever we do bellow will be torn down when
-        // the acknowledgement timeout occurs later on. Since we will have
-        // acted on the session-accept by the time the acknowledgement timeout
-        // occurs, we may as well ignore the timeout.
+        // XXX We will be acting on the received session-accept or
+        // transport-accept Jingle IQs below. Unfortunately, we may have not
+        // received an acknowledgment of our IQ yet and whatever we do below
+        // will be torn down when the acknowledgement timeout occurs later on.
+        // Since we will have acted on the IQ by the time the acknowledgement
+        // timeout occurs, we may as well ignore the timeout.
         jingleSession.setAccepted(true);
 
         participant.setJingleSession(jingleSession);

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -143,7 +143,18 @@ public abstract class AbstractOperationSetJingle
 
         IQ reply = getConnection().sendPacketAndGetReply(inviteIQ);
 
-        return wasInviteAccepted(session, reply);
+        if (reply == null || IQ.Type.result.equals(reply.getType()))
+        {
+            return true;
+        }
+        else
+        {
+            logger.error(
+                    "Unexpected response to 'session-initiate' from "
+                            + session.getAddress() + ": "
+                            + reply.toXML());
+            return false;
+        }
     }
 
     /**
@@ -210,58 +221,6 @@ public abstract class AbstractOperationSetJingle
     }
 
     /**
-     * Determines whether a specific {@link JingleSession} has been accepted by
-     * the client judging by a specific {@code reply} {@link IQ} (received in
-     * reply to an invite IQ sent withing the specified {@code JingleSession}).
-     *
-     * @param session <tt>JingleSession</tt> instance for which we're evaluating
-     * the response value.
-     * @param reply <tt>IQ</tt> response to Jingle invite IQ or <tt>null</tt> in
-     * case of timeout.
-     *
-     * @return <tt>true</tt> if the invite IQ to which {@code reply} replies is
-     * considered accepted; <tt>false</tt>, otherwise.
-     */
-    private boolean wasInviteAccepted(JingleSession session, IQ reply)
-    {
-        if (reply == null)
-        {
-            // XXX By the time the acknowledgement timeout occurs, we may have
-            // received and acted upon the session-accept. We have seen that
-            // happen multiple times: the conference is established, the media
-            // starts flowing between the participants (i.e. we have acted upon
-            // the session-accept), and the conference is suddenly torn down
-            // (because the acknowldegment timeout has occured eventually). As a
-            // workaround, we will ignore the lack of the acknowledgment if we
-            // have already acted upon the session-accept.
-            if (session.isAccepted())
-            {
-                return true;
-            }
-            else
-            {
-                logger.warn(
-                        "Timeout waiting for RESULT response to "
-                            + "'session-initiate' request from "
-                            + session.getAddress());
-                return false;
-            }
-        }
-        else if (IQ.Type.result.equals(reply.getType()))
-        {
-            return true;
-        }
-        else
-        {
-            logger.error(
-                    "Failed to send 'session-initiate' to "
-                        + session.getAddress() + ", error: "
-                        + reply.getError());
-            return false;
-        }
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -303,12 +262,20 @@ public abstract class AbstractOperationSetJingle
                     "Session does not exist for: " + address);
         }
 
-        // Reset 'accepted' flag on the session
-        session.setAccepted(false);
-
         IQ reply = getConnection().sendPacketAndGetReply(jingleIQ);
 
-        return wasInviteAccepted(session, reply);
+        if (reply == null || IQ.Type.result.equals(reply.getType()))
+        {
+            return true;
+        }
+        else
+        {
+            logger.error(
+                    "Unexpected response to 'transport-replace' from "
+                            + session.getAddress() + ": "
+                            + reply.toXML());
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/protocol/xmpp/JingleSession.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/JingleSession.java
@@ -46,16 +46,6 @@ public class JingleSession
     private final JingleRequestHandler requestHandler;
 
     /**
-     * The indicator which determines whether a {@code session-accept} was
-     * received from the remote peer in response to our {@code session-initiate}
-     * which initialized this instance. Introduced to work around a case in
-     * which we do not receive an acknowledgment from the remote peer in
-     * response to our {@code session-initiate} but do receive a
-     * {@code session-accept}.
-     */
-    private boolean _accepted = false;
-
-    /**
      * Creates new instance of <tt>JingleSession</tt> for given parameters.
      *
      * @param sid Jingle session identifier of new instance.
@@ -103,33 +93,5 @@ public class JingleSession
     public JingleRequestHandler getRequestHandler()
     {
         return requestHandler;
-    }
-
-    /**
-     * Determines whether a {@code session-accept} was received from the remote
-     * peer in response to our {@code session-initiate} which initialized this
-     * instance.
-     *
-     * @return {@code true} if a {@code session-accept} was received from the
-     * remote peer in response to our {@code session-initiate} which initialized
-     * this instance; otherwise, {@code false}
-     */
-    public boolean isAccepted()
-    {
-        return _accepted;
-    }
-
-    /**
-     * Sets the indicator which determines whether a {@code session-accept} was
-     * received from the remote peer in response to our {@code session-initiate}
-     * which initialized this instance.
-     *
-     * @param accepted {@code true} if a {@code session-accept} was received
-     * from the remote peer in response to our {@code session-initiate} which
-     * initialized this instance; otherwise, {@code false}
-     */
-    public void setAccepted(boolean accepted)
-    {
-        _accepted = accepted;
     }
 }

--- a/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
@@ -44,8 +44,7 @@ public interface OperationSetJingle
      * @param requestHandler <tt>JingleRequestHandler</tt> that will be bound
      * to new Jingle session instance.
      *
-     * @return {@code true} if a response of type {@code result} is received
-     * before the timeout.
+     * @return {@code true} the client didn't come back with en error response.
      *
      * @throws OperationFailedException with
      * {@link OperationFailedException#PROVIDER_NOT_REGISTERED} if the operation
@@ -77,7 +76,7 @@ public interface OperationSetJingle
      * @param jingleIQ the IQ which to be sent.
      * @param session the <tt>JingleSession</tt> for which the IQ will be sent.
      *
-     * @return {@code true} if an IQ of type {@code result} is received.
+     * @return {@code true} the client didn't come back with an error response.
      *
      * @throws OperationFailedException with
      * {@link OperationFailedException#PROVIDER_NOT_REGISTERED} if the operation


### PR DESCRIPTION
@JonathanLennox discovered an issue with Octo that could lead to broken rendering of Octo participants because we're not propagating the sources/source groups of a re-invited participants. That's fixed in the first commit.

In the second commit I remove sources/groups from octo, when a participant is terminated. I can't think of any side-effects if we don't do that, but it seems like a good idea to maintain a clean Octo state.