### PR TITLE
Secure domain + Coturn - Need adapted instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ from anonymous domain. Here's what has to be configured:
  ```
 (Note that guest.jitsi-meet.example.com is internal to jitsi, and you do not need to (and should not) create a DNS record for it, or generate an SSL/TLS certificate, or do any web server configuration.)
 
-**NOTE:** If you want to use coturn with authentication enabled, add this instead:
+**NOTE:** Mmake sure you enable desired modules to the guest virtual host like `turncredentials` (if you use STUN/TURN together with secure domain) and/or `conference_duration` etc., by adding the `modules_enabled` option:
 
 ```
 VirtualHost "guest.jitsi-meet.example.com"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ from anonymous domain. Here's what has to be configured:
  ```
 (Note that guest.jitsi-meet.example.com is internal to jitsi, and you do not need to (and should not) create a DNS record for it, or generate an SSL/TLS certificate, or do any web server configuration.)
 
-**NOTE:** Mmake sure you enable desired modules to the guest virtual host like `turncredentials` (if you use STUN/TURN together with secure domain) and/or `conference_duration` etc., by adding the `modules_enabled` option:
+**NOTE:** Make sure you enable desired modules to the guest virtual host like `turncredentials` (if you use STUN/TURN together with secure domain) and/or `conference_duration` etc., by adding the `modules_enabled` option:
 
 ```
 VirtualHost "guest.jitsi-meet.example.com"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ from anonymous domain. Here's what has to be configured:
  ```
 (Note that guest.jitsi-meet.example.com is internal to jitsi, and you do not need to (and should not) create a DNS record for it, or generate an SSL/TLS certificate, or do any web server configuration.)
 
+**NOTE:** If you want to use coturn with authentication enabled, add this instead:
+
+```
+VirtualHost "guest.jitsi-meet.example.com"
+    authentication = "anonymous"
+    modules_enabled = {
+     "turncredentials";
+    }
+    c2s_require_encryption = false
+```
+
 2 In Jitsi Meet config.js configure 'anonymousdomain':<br/>
 
 (If you have installed jitsi-meet from the Debian package, these changes should be made in /etc/jitsi/meet/[your-hostname]-config.js)


### PR DESCRIPTION
Since I enabled LDAP auth, the TURN/TURNS did not work. I came across this post: https://community.jitsi.org/t/cant-get-jitsi-meet-to-work-with-turn-solved/32300/14?u=webcf and this did the trick.

This PR adds this information.