### PR TITLE
Fix NPE while parsing response on getting conference info

### DIFF
--- a/src/main/java/org/jitsi/impl/reservation/rest/json/ConferenceJsonHandler.java
+++ b/src/main/java/org/jitsi/impl/reservation/rest/json/ConferenceJsonHandler.java
@@ -112,9 +112,10 @@ public class ConferenceJsonHandler
         {
             assertString(primitive);
 
-            if (checkImmutableString(
-                    editedInstance.getName().toString(),
-                    (String) primitive, CONF_NAME_KEY))
+            if (editedInstance.getName() == null ||
+                    checkImmutableString(
+                            editedInstance.getName().toString(),
+                            (String) primitive, CONF_NAME_KEY))
             {
                 editedInstance.setName(Localpart.from((String)primitive));
             }


### PR DESCRIPTION
This is to fix behavior described at: https://community.jitsi.org/t/jitsi-reservation-system-conflict-workflow/20548
When reservation API returns HTTP 409, Jicofo fetches info about conflicting conference and NPE occurs on parsing response from GET /conference