### PR TITLE
ref: remove sync channel expire

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -560,16 +560,6 @@ public class ColibriConferenceImpl
     @Override
     public void expireChannels(ColibriConferenceIQ channelInfo)
     {
-        expireChannels(channelInfo, false);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void expireChannels(ColibriConferenceIQ channelInfo,
-                               boolean             synchronous)
-    {
         ColibriConferenceIQ request;
 
         synchronized (syncRoot)
@@ -591,23 +581,8 @@ public class ColibriConferenceImpl
         {
             logRequest("Expire peer channels", request);
 
-            if (synchronous)
-            {
-                // Send and wait for the RESULT packet
-                try
-                {
-                    connection.sendPacketAndGetReply(request);
-                }
-                catch (OperationFailedException e)
-                {
-                    logger.error("Channel expire error", e);
-                }
-            }
-            else
-            {
-                // Send and forget
-                connection.sendStanza(request);
-            }
+            // Send and forget
+            connection.sendStanza(request);
 
             synchronized (stateEstimationSync)
             {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2620,23 +2620,7 @@ public class JitsiMeetConferenceImpl
         {
             for (Participant participant : participants)
             {
-                boolean synchronousExpire = false;
-                BridgeSession session = participant.getBridgeSession();
-                // If Participant is being re-invited to a healthy session
-                // do a graceful channel expire with waiting for the
-                // RESULT response. At the time of this writing the JVB may
-                // process packets out of order and in the ICE failed scenario
-                // the channel may not be expired correctly thus not
-                // resulting in the restart at all. The ICE transport manager
-                // must be recreated on the bridge to get new ICE credentials.
-                if (session != null
-                        && session.bridge.isOperational()
-                        && !session.hasFailed)
-                {
-                    synchronousExpire = true;
-                }
-
-                participant.terminateBridgeSession(synchronousExpire);
+                participant.terminateBridgeSession();
             }
             for (Participant participant : participants)
             {
@@ -2880,7 +2864,7 @@ public class JitsiMeetConferenceImpl
 
             if (octoParticipant != null)
             {
-                terminate(octoParticipant, false);
+                terminate(octoParticipant);
             }
 
             return terminatedParticipants;
@@ -2892,15 +2876,11 @@ public class JitsiMeetConferenceImpl
          * {@link #participants}.
          * @param participant the {@link Participant} for which to expire the
          * COLIBRI channels.
-         * @param syncExpire - whether or not the Colibri channels should be
-         * expired in a synchronous manner, that is with blocking the current
-         * thread until the RESULT packet is received.
          * @return {@code true} if the participant was a member of
          * {@link #participants} and was removed as a result of this call, and
          * {@code false} otherwise.
          */
-        public boolean terminate(AbstractParticipant participant,
-                                 boolean syncExpire)
+        public boolean terminate(AbstractParticipant participant)
         {
             boolean octo = participant == this.octoParticipant;
             boolean removed = octo || participants.remove(participant);
@@ -2920,7 +2900,7 @@ public class JitsiMeetConferenceImpl
                         ? ((Participant) participant).getMucJid().toString()
                         : "octo";
                 logger.info("Expiring channels for: " + id + " on: " + bridge);
-                colibriConference.expireChannels(channelsInfo, syncExpire);
+                colibriConference.expireChannels(channelsInfo);
             }
 
             if (octo)

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -511,38 +511,25 @@ public class Participant
      * Terminates the current {@code BridgeSession}, terminates the channel
      * allocator and resets any fields related to the session.
      *
-     * @param syncExpire whether or not the expire Colibri channels operation
-     * should be performed in a synchronous manner.
-     *
      * @return {@code BridgeSession} from which this {@code Participant} has
      * been removed or {@code null} if this {@link Participant} was not part
      * of any bridge session.
      * @see org.jitsi.protocol.xmpp.colibri.ColibriConference#expireChannels(ColibriConferenceIQ)
      */
-    @Deprecated
-    JitsiMeetConferenceImpl.BridgeSession terminateBridgeSession(
-            boolean syncExpire)
+    JitsiMeetConferenceImpl.BridgeSession terminateBridgeSession()
     {
         JitsiMeetConferenceImpl.BridgeSession _session = this.bridgeSession;
 
         if (_session != null)
         {
             this.setChannelAllocator(null);
-            _session.terminate(this, syncExpire);
+            _session.terminate(this);
             this.clearTransportInfo();
             this.setColibriChannelsInfo(null);
             this.bridgeSession = null;
         }
 
         return _session;
-    }
-
-    /**
-     * See {@link #terminateBridgeSession(boolean)}.
-     */
-    JitsiMeetConferenceImpl.BridgeSession terminateBridgeSession()
-    {
-        return terminateBridgeSession(false);
     }
 
     @Override

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -295,25 +295,6 @@ public interface ColibriConference
     void expireChannels(ColibriConferenceIQ channelInfo);
 
     /**
-     * Expires the channels described by given <tt>ColibriConferenceIQ</tt>.
-     * Optionally will wait for the response if <tt>synchronous</tt> is set to
-     * <tt>true</tt>.
-     *
-     * The method is deprecated to discourage it's usage. It's been added to
-     * mitigate temporarily JVB's out of order processing issue where it can
-     * happen that two packets regarding one conference will be processed not in
-     * the order in which they were received. The issues is to be fixed on
-     * the JVB side.
-     *
-     * @param channelInfo the <tt>ColibriConferenceIQ</tt> that contains
-     * information about the channel to be expired.
-     * @param synchronous if <tt>true</tt> the current thread must be blocked
-     * until the response packet is received.
-     */
-    @Deprecated
-    void expireChannels(ColibriConferenceIQ channelInfo, boolean synchronous);
-
-    /**
      * Expires all channels in current conference and this instance goes into
      * disposed state(like calling {@link #dispose()} method). It must not be
      * used anymore.


### PR DESCRIPTION
Doing synchronous expire blocks Smack's Single Threaded
executor and builds up a delay on the processing queue.
It also may time out other jobs that are waiting for
a packet to arrive if the expire will block and timeout.

It's recommended to run the JVB2 with the IQ_HANDLER_MODE
set to 'sync' in the MUC configuration to have ICE restarts
working.