### PR TITLE
fix(PacketDebugger): total totalPacketsRecv

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/PacketDebugger.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/PacketDebugger.java
@@ -68,6 +68,8 @@ public class PacketDebugger
     {
         super(connection, writer, reader);
 
+        AbstractDebugger.printInterpreted = true;
+
         debuggerMap.put(connection, this);
     }
 
@@ -97,16 +99,16 @@ public class PacketDebugger
     @Override
     protected void log(String logMessage)
     {
-        if (logMessage.contains("SENT"))
+        if (logMessage.startsWith("SENT"))
         {
             totalPacketsSent += 1;
         }
-        else if (logMessage.contains("RECV"))
+        else if (logMessage.startsWith("RCV PKT ("))
         {
             totalPacketsRecv += 1;
         }
 
-        if (packetLoggingEnabled)
+        if (packetLoggingEnabled && !logMessage.startsWith("RECV ("))
         {
             logger.info(logMessage);
         }


### PR DESCRIPTION
Fixes total XMPP packets received counter
by enabling AbstractDebugger.printInterpreted.

Smack's TCP connection sends packets one by one,
but reads the text in batches without splitting
into packets. The option enables logging at
the later phase after the raw text was parsed to XML.
That's where the packets will be counted now.