### PR TITLE
remove pre-spec bundle signaling

### DIFF
--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -197,13 +197,6 @@ public abstract class AbstractOperationSetJingle
                 = GroupPacketExtension.createBundleGroup(contents);
 
             inviteIQ.addExtension(group);
-
-            for (ContentPacketExtension content : contents)
-            {
-                // FIXME: is it mandatory ?
-                // http://estos.de/ns/bundle
-                content.addChildExtension(new BundlePacketExtension());
-            }
         }
 
         // FIXME Move this to a place where offer's contents are created or

--- a/src/main/java/org/jitsi/protocol/xmpp/util/JicofoJingleUtils.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/util/JicofoJingleUtils.java
@@ -28,11 +28,8 @@ import org.jitsi.xmpp.extensions.jitsimeet.*;
 public class JicofoJingleUtils
 {
     /**
-     * Adds a group packet extension to a {@link JingleIQ}, and a
-     * {@link BundlePacketExtension} to each of its contents. I.e. adds
-     * everything that we deem necessary to enable {@code bundle} in an offer.
-     * It is unclear how much of this is actually necessary for
-     * {@code jitsi-meet}.
+     * Adds a group packet extension to a {@link JingleIQ} which is
+     * necessary to enable {@code bundle} in an offer.
      *
      * @param jingleIQ the IQ to add extensions to.
      */
@@ -42,13 +39,6 @@ public class JicofoJingleUtils
             = GroupPacketExtension.createBundleGroup(jingleIQ.getContentList());
 
         jingleIQ.addExtension(group);
-
-        for (ContentPacketExtension content : jingleIQ.getContentList())
-        {
-            // FIXME: is it mandatory ?
-            // http://estos.de/ns/bundle
-            content.addChildExtension(new BundlePacketExtension());
-        }
     }
 
     /**

--- a/src/test/java/org/jitsi/jicofo/BundleTest.java
+++ b/src/test/java/org/jitsi/jicofo/BundleTest.java
@@ -142,20 +142,6 @@ public class BundleTest
                                     ContentPacketExtension firstContent,
                                     boolean isBundle)
     {
-        // We expect to find estos bundle
-        BundlePacketExtension bundle
-            = content.getFirstChildOfType(
-                    BundlePacketExtension.class);
-
-        if (isBundle)
-        {
-            assertNotNull(bundle);
-        }
-        else
-        {
-            assertNull(bundle);
-        }
-
         // We expect to find rtcp-mux if there is an RTP description
         RtpDescriptionPacketExtension rtpDesc
             = JingleUtils.getRtpDescription(content);


### PR DESCRIPTION
removes the legacy
  http://estos.de/ns/bundle
version of signaling bundle. This has been superseeded by
  https://xmpp.org/extensions/xep-0338.html