### PR TITLE
Require bundle

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.jitsi.impl.protocol.xmpp.colibri;
 
+import org.jetbrains.annotations.*;
 import org.jitsi.protocol.xmpp.colibri.exception.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
@@ -919,8 +920,7 @@ public class ColibriConferenceImpl
             Map<String, RtpDescriptionPacketExtension> descriptionMap,
             MediaSourceMap sources,
             MediaSourceGroupMap sourceGroups,
-            IceUdpTransportPacketExtension bundleTransport,
-            Map<String, IceUdpTransportPacketExtension> transportMap,
+            @NotNull IceUdpTransportPacketExtension bundleTransport,
             String endpointId,
             List<String> relays)
     {
@@ -970,17 +970,8 @@ public class ColibriConferenceImpl
             {
                 send = true;
             }
-            // Bundle transport...
-            if (bundleTransport != null
-                    && colibriBuilder.addBundleTransportUpdateReq(
-                            bundleTransport, endpointId))
-            {
-                send = true;
-            }
-            // ...or non-bundle transport
-            else if (transportMap != null
-                    && colibriBuilder.addTransportUpdateReq(
-                            transportMap, localChannelsInfo))
+            // Bundle transport
+            if (colibriBuilder.addBundleTransportUpdateReq(bundleTransport, endpointId))
             {
                 send = true;
             }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -645,41 +645,6 @@ public class ColibriConferenceImpl
      * Does not block or wait for a response.
      */
     @Override
-    public void updateTransportInfo(
-            Map<String, IceUdpTransportPacketExtension> transportMap,
-            ColibriConferenceIQ localChannelsInfo)
-    {
-        ColibriConferenceIQ request;
-
-        synchronized (syncRoot)
-        {
-            if (checkIfDisposed("updateTransportInfo"))
-            {
-                return;
-            }
-
-            colibriBuilder.reset();
-
-            colibriBuilder
-                .addTransportUpdateReq(transportMap, localChannelsInfo);
-
-            request = colibriBuilder.getRequest(jitsiVideobridge);
-        }
-
-        if (request != null)
-        {
-            logRequest("Sending transport info update: ", request);
-
-            connection.sendStanza(request);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     * </t>
-     * Does not block or wait for a response.
-     */
-    @Override
     public void updateSourcesInfo(MediaSourceMap sources,
                                   MediaSourceGroupMap sourceGroups,
                                   ColibriConferenceIQ localChannelsInfo)

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -247,7 +247,6 @@ public class ColibriConferenceImpl
      */
     @Override
     public ColibriConferenceIQ createColibriChannels(
-            boolean useBundle,
             String endpointId,
             String statsId,
             boolean peerIsInitiator,
@@ -287,7 +286,7 @@ public class ColibriConferenceImpl
                 colibriBuilder.reset();
 
                 colibriBuilder.addAllocateChannelsReq(
-                    useBundle,
+                    true /* use bundle */,
                     endpointId,
                     statsId,
                     peerIsInitiator,

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -17,24 +17,21 @@
  */
 package org.jitsi.impl.protocol.xmpp.colibri;
 
-import org.jetbrains.annotations.*;
-import org.jitsi.protocol.xmpp.colibri.exception.*;
-import org.jitsi.xmpp.extensions.colibri.*;
-import org.jitsi.xmpp.extensions.jingle.*;
 import net.java.sip.communicator.service.protocol.*;
-
 import org.jitsi.eventadmin.*;
 import org.jitsi.jicofo.*;
 import org.jitsi.jicofo.event.*;
 import org.jitsi.jicofo.util.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jitsi.protocol.xmpp.colibri.*;
+import org.jitsi.protocol.xmpp.colibri.exception.*;
 import org.jitsi.protocol.xmpp.util.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.utils.*;
-import org.jitsi.utils.logging.Logger;
+import org.jitsi.utils.logging.*;
+import org.jitsi.xmpp.extensions.colibri.*;
+import org.jitsi.xmpp.extensions.jingle.*;
 import org.jitsi.xmpp.util.*;
-
 import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.parts.*;
@@ -884,7 +881,7 @@ public class ColibriConferenceImpl
             Map<String, RtpDescriptionPacketExtension> descriptionMap,
             MediaSourceMap sources,
             MediaSourceGroupMap sourceGroups,
-            @NotNull IceUdpTransportPacketExtension bundleTransport,
+            IceUdpTransportPacketExtension bundleTransport,
             String endpointId,
             List<String> relays)
     {
@@ -935,7 +932,7 @@ public class ColibriConferenceImpl
                 send = true;
             }
             // Bundle transport
-            if (colibriBuilder.addBundleTransportUpdateReq(bundleTransport, endpointId))
+            if (bundleTransport != null && colibriBuilder.addBundleTransportUpdateReq(bundleTransport, endpointId))
             {
                 send = true;
             }

--- a/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/AbstractChannelAllocator.java
@@ -172,7 +172,15 @@ public abstract class AbstractChannelAllocator implements Runnable
     {
         List<ContentPacketExtension> offer;
 
-        offer = createOffer();
+        try
+        {
+            offer = createOffer();
+        }
+        catch (UnsupportedFeatureConfigurationException e)
+        {
+            logger.error("Error creating offer", e);
+            return;
+        }
         if (canceled)
         {
             return;
@@ -228,7 +236,7 @@ public abstract class AbstractChannelAllocator implements Runnable
      * Creates a Jingle offer for the {@link Participant} of this
      * {@link AbstractChannelAllocator}.
      */
-    protected abstract List<ContentPacketExtension> createOffer();
+    protected abstract List<ContentPacketExtension> createOffer() throws UnsupportedFeatureConfigurationException;
 
     /**
      * Allocates Colibri channels for this {@link AbstractChannelAllocator}'s

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1624,18 +1624,9 @@ public class JitsiMeetConferenceImpl
             return;
         }
 
-        if (participant.hasBundleSupport())
-        {
-            bridgeSession.colibriConference.updateBundleTransportInfo(
-                    participant.getBundleTransport(),
-                    participant.getEndpointId());
-        }
-        else
-        {
-            bridgeSession.colibriConference.updateTransportInfo(
-                    participant.getTransportMap(),
-                    participant.getColibriChannelsInfo());
-        }
+        bridgeSession.colibriConference.updateBundleTransportInfo(
+                participant.getBundleTransport(),
+                participant.getEndpointId());
     }
 
     /**
@@ -2949,7 +2940,6 @@ public class JitsiMeetConferenceImpl
                 participant.getSourcesCopy(),
                 participant.getSourceGroupsCopy(),
                 participant.getBundleTransport(),
-                participant.getTransportMap(),
                 participant.getEndpointId(),
                 null);
         }
@@ -2967,7 +2957,6 @@ public class JitsiMeetConferenceImpl
                     octoParticipant.getRtpDescriptionMap(),
                     octoParticipant.getSourcesCopy(),
                     octoParticipant.getSourceGroupsCopy(),
-                    null,
                     null,
                     null,
                     octoParticipant.getRelays());

--- a/src/main/java/org/jitsi/jicofo/OctoChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/OctoChannelAllocator.java
@@ -120,7 +120,6 @@ public class OctoChannelAllocator extends AbstractChannelAllocator
         // This is a blocking call.
         ColibriConferenceIQ result =
             bridgeSession.colibriConference.createColibriChannels(
-                true /* bundle */,
                 null /* endpoint */,
                 null /* statsId */,
                 false/* initiator */,

--- a/src/main/java/org/jitsi/jicofo/OctoChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/OctoChannelAllocator.java
@@ -180,7 +180,6 @@ public class OctoChannelAllocator extends AbstractChannelAllocator
                     participant.getSourceGroupsCopy(),
                     null,
                     null,
-                    null,
                     participant.getRelays());
             }
 

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -284,6 +284,9 @@ public class Participant
     {
         this.supportedFeatures
             = Objects.requireNonNull(supportedFeatures, "supportedFeatures");
+        if (!hasBundleSupport()) {
+            throw new IllegalStateException("Participant doesn't support bundle, which is required");
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -84,8 +84,7 @@ public class Participant
     private final Logger logger;
 
     /**
-     * Stores information about bundled transport if {@link #hasBundleSupport()}
-     * returns <tt>true</tt>.
+     * Stores information about bundled transport
      */
     private IceUdpTransportPacketExtension bundleTransport;
 
@@ -311,10 +310,9 @@ public class Participant
 
     /**
      * Extracts and stores transport information from given map of Jingle
-     * content. Depending on the {@link #hasBundleSupport()} either 'bundle' or
-     * 'non-bundle' transport information will be stored. If we already have the
-     * transport information it will be merged into the currently stored one
-     * with {@link TransportSignaling#mergeTransportExtension}.
+     * content.  If we already have the transport information it will be
+     * merged into the currently stored one with
+     * {@link TransportSignaling#mergeTransportExtension}.
      *
      * @param contents the list of <tt>ContentPacketExtension</tt> from one of
      * jingle message which can potentially contain transport info like

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -272,11 +272,12 @@ public class Participant
      * @param supportedFeatures the list of features to set.
      */
     public void setSupportedFeatures(List<String> supportedFeatures)
+        throws UnsupportedFeatureConfigurationException
     {
         this.supportedFeatures
             = Objects.requireNonNull(supportedFeatures, "supportedFeatures");
         if (!hasBundleSupport()) {
-            throw new IllegalStateException("Participant doesn't support bundle, which is required");
+            throw new UnsupportedFeatureConfigurationException("Participant doesn't support bundle, which is required");
         }
     }
 
@@ -487,4 +488,12 @@ public class Participant
         return "Participant[" + getMucJid() + "]@" + hashCode();
     }
 
+}
+
+class UnsupportedFeatureConfigurationException extends Exception
+{
+    public UnsupportedFeatureConfigurationException(String msg)
+    {
+        super(msg);
+    }
 }

--- a/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
@@ -249,10 +249,7 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
             jingleIQ = jingle.createTransportReplace(jingleSession, contents);
         }
 
-        if (participant.hasBundleSupport())
-        {
-            JicofoJingleUtils.addBundleExtensions(jingleIQ);
-        }
+        JicofoJingleUtils.addBundleExtensions(jingleIQ);
         if (startMuted[0] || startMuted[1])
         {
             JicofoJingleUtils.addStartMutedExtension(
@@ -318,32 +315,23 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
             for (ColibriConferenceIQ.Channel channel
                     : colibriContent.getChannels())
             {
-                IceUdpTransportPacketExtension transport;
+                ColibriConferenceIQ.ChannelBundle bundle
+                    = colibriChannels.getChannelBundle(
+                    channel.getChannelBundleId());
 
-                if (useBundle)
+                if (bundle == null)
                 {
-                    ColibriConferenceIQ.ChannelBundle bundle
-                        = colibriChannels.getChannelBundle(
-                                channel.getChannelBundleId());
-
-                    if (bundle == null)
-                    {
-                        logger.error(
-                            "No bundle for " + channel.getChannelBundleId());
-                        continue;
-                    }
-
-                    transport = bundle.getTransport();
-
-                    if (!transport.isRtcpMux())
-                    {
-                        transport.addChildExtension(
-                                new RtcpmuxPacketExtension());
-                    }
+                    logger.error(
+                        "No bundle for " + channel.getChannelBundleId());
+                    continue;
                 }
-                else
+
+                IceUdpTransportPacketExtension transport = bundle.getTransport();
+
+                if (!transport.isRtcpMux())
                 {
-                    transport = channel.getTransport();
+                    transport.addChildExtension(
+                            new RtcpmuxPacketExtension());
                 }
 
                 try
@@ -367,27 +355,18 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
             for (ColibriConferenceIQ.SctpConnection sctpConn
                     : colibriContent.getSctpConnections())
             {
-                IceUdpTransportPacketExtension transport;
+                ColibriConferenceIQ.ChannelBundle bundle
+                    = colibriChannels.getChannelBundle(
+                            sctpConn.getChannelBundleId());
 
-                if (useBundle)
+                if (bundle == null)
                 {
-                    ColibriConferenceIQ.ChannelBundle bundle
-                        = colibriChannels.getChannelBundle(
-                                sctpConn.getChannelBundleId());
-
-                    if (bundle == null)
-                    {
-                        logger.error(
-                            "No bundle for " + sctpConn.getChannelBundleId());
-                        continue;
-                    }
-
-                    transport = bundle.getTransport();
+                    logger.error(
+                        "No bundle for " + sctpConn.getChannelBundleId());
+                    continue;
                 }
-                else
-                {
-                    transport = sctpConn.getTransport();
-                }
+
+                IceUdpTransportPacketExtension transport = bundle.getTransport();
 
                 try
                 {

--- a/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
@@ -293,8 +293,6 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
             List<ContentPacketExtension> offer,
             ColibriConferenceIQ colibriChannels)
     {
-        boolean useBundle = participant.hasBundleSupport();
-
         MediaSourceMap conferenceSSRCs
             = meetConference.getAllSources(reInvite ? participant : null);
 
@@ -400,12 +398,9 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
                 = JingleUtils.getRtpDescription(cpe);
             if (rtpDescPe != null)
             {
-                if (useBundle)
-                {
-                    // rtcp-mux
-                    rtpDescPe.addChildExtension(
-                            new RtcpmuxPacketExtension());
-                }
+                // rtcp-mux is always used
+                rtpDescPe.addChildExtension(
+                        new RtcpmuxPacketExtension());
 
                 // Copy SSRC sent from the bridge(only the first one)
                 for (ColibriConferenceIQ.Channel channel

--- a/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
@@ -144,7 +144,7 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
         throws ColibriException
     {
         return bridgeSession.colibriConference.createColibriChannels(
-            participant.hasBundleSupport(),
+            true,
             participant.getEndpointId(),
             participant.getStatId(),
             true /* initiator */,

--- a/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
@@ -83,6 +83,7 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
      */
     @Override
     protected List<ContentPacketExtension> createOffer()
+        throws UnsupportedFeatureConfigurationException
     {
         EntityFullJid address = participant.getMucJid();
 
@@ -90,7 +91,6 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
         List<String> features = DiscoveryUtil.discoverParticipantFeatures(
             meetConference.getXmppProvider(), address);
         participant.setSupportedFeatures(features);
-
 
         List<ContentPacketExtension> contents = new ArrayList<>();
 

--- a/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
@@ -144,7 +144,6 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
         throws ColibriException
     {
         return bridgeSession.colibriConference.createColibriChannels(
-            true,
             participant.getEndpointId(),
             participant.getStatId(),
             true /* initiator */,

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -93,8 +93,6 @@ public interface ColibriConference
     /**
      * Creates channels on the videobridge for given parameters.
      *
-     * @param useBundle <tt>true</tt> if channel transport bundle should be used
-     * for this allocation.
      * @param endpointId the ID of the Colibri endpoint.
      * @param statsId the statistics Id to use if any.
      * @param peerIsInitiator <tt>true</tt> if peer is ICE an initiator
@@ -105,7 +103,6 @@ public interface ColibriConference
      * @throws OperationFailedException if channel allocation fails.
      */
     default ColibriConferenceIQ createColibriChannels(
-        boolean useBundle,
         String endpointId,
         String statsId,
         boolean peerIsInitiator,
@@ -113,7 +110,6 @@ public interface ColibriConference
         throws ColibriException
     {
         return createColibriChannels(
-            useBundle,
             endpointId,
             statsId,
             peerIsInitiator,
@@ -126,8 +122,6 @@ public interface ColibriConference
     /**
      * Creates channels on the videobridge for given parameters.
      *
-     * @param useBundle <tt>true</tt> if channel transport bundle should be used
-     * for this allocation.
      * @param endpointId the ID of the Colibri endpoint.
      * @param statsId the statistics Id to use if any.
      * @param peerIsInitiator <tt>true</tt> if peer is ICE an initiator
@@ -144,7 +138,6 @@ public interface ColibriConference
      * @throws ColibriException if channel allocation fails.
      */
     ColibriConferenceIQ createColibriChannels(
-            boolean useBundle,
             String endpointId,
             String statsId,
             boolean peerIsInitiator,

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -188,7 +188,7 @@ public interface ColibriConference
             rtpInfoMap,
             sources,
             sourceGroups,
-            null, null, null, null);
+            null, null, null);
     }
 
     /**
@@ -213,14 +213,10 @@ public interface ColibriConference
      * Colibri content name to a list of <tt>SourceGroupPacketExtension</tt>
      * which will be used to update SSRCs of the channel in corresponding
      * content described by <tt>localChannelsInfo</tt>.
-     * @param bundleTransport (optional) the
+     * @param bundleTransport (mandatory) the
      * <tt>IceUdpTransportPacketExtension</tt> which will be used to set
      * "bundle" transport of the first channel bundle from
      * <tt>localChannelsInfo</tt>.
-     * @param transportMap  (optional) the map of
-     * <tt>IceUdpTransportPacketExtension</tt> to Colibri content name
-     * which will be used to update transport of the channels in corresponding
-     * content described by <tt>localChannelsInfo</tt>.
      * @param endpointId the ID of the endpoint for which the update applies
      * (it is implicit that the update only works for channels of a single
      * @param relays the Octo relay IDs to set.
@@ -232,7 +228,6 @@ public interface ColibriConference
             MediaSourceMap sources,
             MediaSourceGroupMap sourceGroups,
             IceUdpTransportPacketExtension bundleTransport,
-            Map<String, IceUdpTransportPacketExtension> transportMap,
             String endpointId,
             List<String> relays);
 

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -237,19 +237,6 @@ public interface ColibriConference
             ColibriConferenceIQ localChannelsInfo);
 
     /**
-     * Updates transport information for active channels
-     * (existing on the bridge).
-     *
-     * @param map the map of content name to transport packet extension.
-     * @param localChannelsInfo <tt>ColibriConferenceIQ</tt> that contains
-     * the description of the channel for which transport information will be
-     * updated on the bridge.
-     */
-    void updateTransportInfo(
-            Map<String, IceUdpTransportPacketExtension>   map,
-            ColibriConferenceIQ                           localChannelsInfo);
-
-    /**
      * Updates simulcast layers on the bridge.
      * @param ssrcGroups the map of media SSRC groups that will be updated on
      * the bridge.

--- a/src/test/java/mock/MockParticipant.java
+++ b/src/test/java/mock/MockParticipant.java
@@ -53,8 +53,6 @@ public class MockParticipant
 
     private final String nick;
 
-    private final boolean useBundle;
-
     private XmppPeer xmppPeer;
 
     private MockRoomMember user;
@@ -99,13 +97,7 @@ public class MockParticipant
 
     public MockParticipant(String nick)
     {
-        this(nick, true);
-    }
-
-    public MockParticipant(String nick, boolean useBundle)
-    {
         this.nick = nick;
-        this.useBundle = useBundle;
     }
 
     public MockRoomMember getChatMember()
@@ -154,7 +146,7 @@ public class MockParticipant
             throw new RuntimeException(e);
         }
 
-        user.setupFeatures(useBundle);
+        user.setupFeatures();
 
 
         try
@@ -326,11 +318,8 @@ public class MockParticipant
             IceUdpTransportPacketExtension transport
                 = new IceUdpTransportPacketExtension();
 
-            if (useBundle)
-            {
-                // Bundle uses RTCP mux
-                transport.addChildExtension(new RtcpmuxPacketExtension());
-            }
+            // Bundle uses RTCP mux
+            transport.addChildExtension(new RtcpmuxPacketExtension());
 
             DtlsFingerprintPacketExtension dtlsFingerprint
                 = new DtlsFingerprintPacketExtension();

--- a/src/test/java/mock/muc/MockRoomMember.java
+++ b/src/test/java/mock/muc/MockRoomMember.java
@@ -51,7 +51,7 @@ public class MockRoomMember
         this.room = chatRoom;
     }
 
-    public void setupFeatures(boolean useBundle)
+    public void setupFeatures()
     {
         OperationSetSimpleCaps caps
                 = room.getParentProvider()
@@ -60,11 +60,6 @@ public class MockRoomMember
         MockSetSimpleCapsOpSet mockCaps = (MockSetSimpleCapsOpSet) caps;
 
         List<String> features = DiscoveryUtil.getDefaultParticipantFeatureSet();
-        if (!useBundle)
-        {
-            features.remove(DiscoveryUtil.FEATURE_RTCP_MUX);
-            features.remove(DiscoveryUtil.FEATURE_RTP_BUNDLE);
-        }
 
         MockCapsNode myNode
             = new MockCapsNode(

--- a/src/test/java/org/jitsi/jicofo/BundleTest.java
+++ b/src/test/java/org/jitsi/jicofo/BundleTest.java
@@ -86,11 +86,11 @@ public class BundleTest
         MockMultiUserChat chat
             = (MockMultiUserChat) mucOpSet.findRoom(roomName.toString());
 
-        MockParticipant user1 = new MockParticipant("user1", true);
+        MockParticipant user1 = new MockParticipant("user1");
 
         user1.join(chat);
 
-        MockParticipant user2 = new MockParticipant("user2", true);
+        MockParticipant user2 = new MockParticipant("user2");
 
         user2.join(chat);
 

--- a/src/test/java/org/jitsi/jicofo/ColibriTest.java
+++ b/src/test/java/org/jitsi/jicofo/ColibriTest.java
@@ -105,20 +105,18 @@ public class ColibriTest
         contents.add(video);
         contents.add(data);
 
-        boolean peer1UseBundle = true;
         String peer1 = "endpoint1";
-        boolean peer2UseBundle = true;
         String peer2 = "endpoint2";
 
         ColibriConferenceIQ peer1Channels
             = colibriConf.createColibriChannels(
-                peer1UseBundle, peer1, null, true, contents);
+                peer1, null, true, contents);
 
         assertEquals(3 , mockBridge.getChannelsCount());
 
         ColibriConferenceIQ peer2Channels
             = colibriConf.createColibriChannels(
-                peer2UseBundle, peer2, null, true, contents);
+                peer2, null, true, contents);
 
         assertEquals(6 , mockBridge.getChannelsCount());
 

--- a/src/test/java/org/jitsi/jicofo/ColibriThreadingTest.java
+++ b/src/test/java/org/jitsi/jicofo/ColibriThreadingTest.java
@@ -355,7 +355,7 @@ public class ColibriThreadingTest
                     try
                     {
                         channels = colibriConference.createColibriChannels(
-                            true, endpointId, null, true, createContents());
+                            endpointId, null, true, createContents());
                     }
                     catch (ColibriException e)
                     {


### PR DESCRIPTION
Non-bundle support was deprecated in JVB 2, so we no longer support clients doing anything short of max-bundle.  These changes throw an exception if a participant does not list bundle among its advertised features, and assumes all clients are using bundle everywhere else (which meant removing many flags/conditionals to distinguish between bundle and non-bundle cases).