### PR TITLE
fix: idle timeout if participants in the room

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -394,14 +394,14 @@ public class JitsiMeetConferenceImpl
             //    services.setSipGateway(config.getPreConfiguredSipGateway());
             //}
 
+            idleTimestamp = System.currentTimeMillis();
+
             if (protocolProviderHandler.isRegistered())
             {
                 joinTheRoom();
             }
 
             protocolProviderHandler.addRegistrationListener(this);
-
-            idleTimestamp = System.currentTimeMillis();
 
             // Register for bridge events
             eventHandlerRegistration


### PR DESCRIPTION
The idleTimestamp must be set before the call to 'joinTheRoom', because it triggers participants joined events and the timestamp is not set to -1.