### PR TITLE
track how long it takes to allocate channels on the jvb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <apache-http.version>4.4.1</apache-http.version>
     <jersey.version>2.30.1</jersey.version>
     <jicoco.version>1.1-29-g2e64779</jicoco.version>
-    <jitsi.utils.version>1.0-47-gdb30505</jitsi.utils.version>
+    <jitsi.utils.version>1.0-49-gef466fc</jitsi.utils.version>
   </properties>
 
   <dependencies>
@@ -125,6 +125,11 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
+      <version>${jitsi.utils.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jitsi-utils-kotlin</artifactId>
       <version>${jitsi.utils.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -970,11 +970,8 @@ public class ColibriConferenceImpl
          * An average of the time it takes to make allocate channel requests
          * to JVB.
          */
-        private final RateStatistics allocateChannelsReqTimes =
-            new RateStatistics((int)Duration.ofMinutes(1).toMillis());
-
-        private final RateStatistics healthCheckReqTimes =
-            new RateStatistics((int)Duration.ofMinutes(1).toMillis());
+        private final MovingAverage<Long> allocateChannelsReqTimes =
+            new MovingAverage<>(Duration.ofMinutes(1));
 
         /**
          * Notify the stats object how long an allocate channels request took
@@ -982,14 +979,14 @@ public class ColibriConferenceImpl
          * @param nanos the time, in nanoseconds
          */
         void allocateChannelsRequestTook(long nanos) {
-            allocateChannelsReqTimes.update((int)nanos, clock.millis());
+            allocateChannelsReqTimes.add(nanos);
         }
 
         @SuppressWarnings("unchecked")
         public JSONObject toJson()
         {
             JSONObject json = new JSONObject();
-            json.put("avg_allocate_channels_req_time_nanos", allocateChannelsReqTimes.getRate());
+            json.put("avg_allocate_channels_req_time_nanos", allocateChannelsReqTimes.get());
 
             return json;
         }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -25,13 +25,16 @@ import org.jitsi.protocol.xmpp.colibri.exception.*;
 import org.jitsi.protocol.xmpp.util.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.utils.logging.*;
+import org.jitsi.utils.stats.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 import org.jitsi.xmpp.util.*;
 import org.jivesoftware.smack.packet.*;
+import org.json.simple.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.parts.*;
 
+import java.time.*;
 import java.util.*;
 
 import static org.apache.commons.lang3.StringUtils.*;
@@ -47,6 +50,8 @@ import static org.apache.commons.lang3.StringUtils.*;
 public class ColibriConferenceImpl
     implements ColibriConference
 {
+    public final static Stats stats = new Stats();
+
     private final static Logger logger
         = Logger.getLogger(ColibriConferenceImpl.class);
 
@@ -442,7 +447,11 @@ public class ColibriConferenceImpl
     {
         try
         {
-            return connection.sendPacketAndGetReply(request);
+            long start = System.nanoTime();
+            Stanza reply = connection.sendPacketAndGetReply(request);
+            long end = System.nanoTime();
+            stats.allocateChannelsRequestTook(end - start);
+            return reply;
         }
         catch (OperationFailedException ofe)
         {
@@ -941,6 +950,48 @@ public class ColibriConferenceImpl
                     syncRoot.notifyAll();
                 }
             }
+        }
+    }
+
+    public static class Stats {
+        private final Clock clock;
+
+        public Stats(Clock clock)
+        {
+            this.clock = clock;
+        }
+
+        public Stats()
+        {
+            this(Clock.systemUTC());
+        }
+
+        /**
+         * An average of the time it takes to make allocate channel requests
+         * to JVB.
+         */
+        private final RateStatistics allocateChannelsReqTimes =
+            new RateStatistics((int)Duration.ofMinutes(1).toMillis());
+
+        private final RateStatistics healthCheckReqTimes =
+            new RateStatistics((int)Duration.ofMinutes(1).toMillis());
+
+        /**
+         * Notify the stats object how long an allocate channels request took
+         * to execute
+         * @param nanos the time, in nanoseconds
+         */
+        void allocateChannelsRequestTook(long nanos) {
+            allocateChannelsReqTimes.update((int)nanos, clock.millis());
+        }
+
+        @SuppressWarnings("unchecked")
+        public JSONObject toJson()
+        {
+            JSONObject json = new JSONObject();
+            json.put("avg_allocate_channels_req_time_nanos", allocateChannelsReqTimes.getRate());
+
+            return json;
         }
     }
 }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -954,18 +954,6 @@ public class ColibriConferenceImpl
     }
 
     public static class Stats {
-        private final Clock clock;
-
-        public Stats(Clock clock)
-        {
-            this.clock = clock;
-        }
-
-        public Stats()
-        {
-            this(Clock.systemUTC());
-        }
-
         /**
          * An average of the time it takes to make allocate channel requests
          * to JVB.

--- a/src/main/java/org/jitsi/jicofo/rest/Statistics.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Statistics.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.jicofo.rest;
 
+import org.jitsi.impl.protocol.xmpp.colibri.*;
 import org.jitsi.jicofo.util.*;
 import org.json.simple.*;
 
@@ -50,6 +51,7 @@ public class Statistics
         // so we merge the FocusManager and Jibri stats in the root object.
         stats.putAll(focusManagerProvider.get().getStats());
         stats.putAll(jibriStatsProvider.get().getStats());
+        stats.putAll(ColibriConferenceImpl.stats.toJson());
 
         stats.put(
             "threads", ManagementFactory.getThreadMXBean().getThreadCount());


### PR DESCRIPTION
We want to track how long it takes for the allocate request to complete, as we're looking at a new transport for this path and want to have some data to compare.

@bgrozev I know we talked about doing this for health checks as well, but we have some logic there that [retries](https://github.com/jitsi/jicofo/blob/master/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java#L453-L483) and I wasn't sure what we want to do there, so thought I'd at least start with this bit.