### PR TITLE
Integrate JVB API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,11 @@
       <artifactId>jersey-media-json-jackson</artifactId>
       <version>${jersey.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jvb-api-client</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
     <!-- jersey relies on this version of javassist or we get hk2
     errors, but other libs (Powermock, at this time) also rely on
     it but an older version, and that version is getting selected

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jvb-api-client</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>2.1-227-g3ce5bf97</version>
     </dependency>
     <!-- jersey relies on this version of javassist or we get hk2
     errors, but other libs (Powermock, at this time) also rely on

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -472,20 +472,12 @@ public class ColibriConferenceImpl
         Stanza reply;
         if (jvbApi != null)
         {
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Using JVB API for request");
-            }
             reply = jvbApi.sendIqAndGetReply(iq);
         }
         else
         {
             try
             {
-                if (logger.isDebugEnabled())
-                {
-                    logger.debug("Using XMPP connection for request");
-                }
                 reply = connection.sendPacketAndGetReply(iq);
             }
             catch (OperationFailedException ofe)
@@ -908,6 +900,10 @@ public class ColibriConferenceImpl
     public void setJvbApi(JvbApi jvbApi)
     {
         this.jvbApi = jvbApi;
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("Using JVB API for requests");
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -26,6 +26,7 @@ import org.jitsi.protocol.xmpp.util.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.utils.logging.*;
 import org.jitsi.utils.stats.*;
+import org.jitsi.videobridge.api.client.v1.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 import org.jitsi.xmpp.util.*;
@@ -75,6 +76,8 @@ public class ColibriConferenceImpl
      * {@link #conferenceState}.
      */
     private final Object syncRoot = new Object();
+
+    private JvbApi jvbApi = new JvbApi("localhost", 9099);
 
     /**
      * Custom type of semaphore that allows only 1 thread to send initial
@@ -445,18 +448,11 @@ public class ColibriConferenceImpl
                                       ColibriConferenceIQ request)
         throws ColibriException
     {
-        try
-        {
-            long start = System.nanoTime();
-            Stanza reply = connection.sendPacketAndGetReply(request);
-            long end = System.nanoTime();
-            stats.allocateChannelsRequestTook(end - start);
-            return reply;
-        }
-        catch (OperationFailedException ofe)
-        {
-            throw new ColibriException(ofe.getMessage());
-        }
+        long start = System.nanoTime();
+        Stanza reply = jvbApi.sendIqAndGetReply(request); //connection.sendPacketAndGetReply(request);
+        long end = System.nanoTime();
+        stats.allocateChannelsRequestTook(end - start);
+        return reply;
     }
 
     /**

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -472,17 +472,11 @@ public class ColibriConferenceImpl
         Stanza reply;
         if (jvbApi != null)
         {
-            try
+            if (logger.isDebugEnabled())
             {
-                if (logger.isDebugEnabled())
-                {
-                    logger.debug("Using JVB API for request");
-                }
-                reply = jvbApi.sendIqAndGetReply(iq);
-            } catch (JvbApiException e)
-            {
-                throw new ColibriException(e.getMessage());
+                logger.debug("Using JVB API for request");
             }
+            reply = jvbApi.sendIqAndGetReply(iq);
         }
         else
         {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -767,10 +767,10 @@ public class JitsiMeetConferenceImpl
             bridge.getSupportedApiVersions() != null)
         {
             logger.info("Bridge advertised a JVB API address.  JVB API " +
-                "client supports " + VersionKt.SUPPORTED_API_VERSIONS +
+                "client supports " + JvbApiClientInfo.SUPPORTED_API_VERSIONS +
                 ", bridge supports " + bridge.getSupportedApiVersions());
             ApiVersion maxApiVersion =
-                VersionKt.SUPPORTED_API_VERSIONS.intersect(
+                JvbApiClientInfo.SUPPORTED_API_VERSIONS.intersect(
                     bridge.getSupportedApiVersions())
                     .maxSupported(implementedJvbApiVersions);
             if (maxApiVersion == null)

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -759,22 +759,32 @@ public class JitsiMeetConferenceImpl
             logger.info("Bridge advertised a JVB API address.  JVB API " +
                 "client supports " + VersionKt.SUPPORTED_API_VERSIONS +
                 ", bridge supports " + bridge.getSupportedApiVersions());
-            ApiVersion maxApiVersion = VersionKt.SUPPORTED_API_VERSIONS.maxSupported(bridge.getSupportedApiVersions());
+            ApiVersion maxApiVersion =
+                VersionKt.SUPPORTED_API_VERSIONS.maxSupported(
+                    bridge.getSupportedApiVersions());
             if (maxApiVersion == null)
             {
-                logger.info("No JVB API version compatibility found between " +
-                    "client and server");
+                logger.info("No JVB API version compatibility found " +
+                    "between client and server");
             }
             else
             {
                 logger.info("Got common api version " + maxApiVersion);
-                switch (maxApiVersion) {
-                    case V1: {
-                        conf.setJvbApi(new org.jitsi.videobridge.api.client.v1.JvbApi(bridge.getJvbApiUrl(), bridge.getJvbApiPort()));
+                switch (maxApiVersion)
+                {
+                    case V1:
+                    {
+                        conf.setJvbApi(
+                            new org.jitsi.videobridge.api.client.v1.JvbApi(
+                                bridge.getJvbApiUrl(),
+                                bridge.getJvbApiPort()
+                            )
+                        );
                         break;
                     }
-                    default: throw new RuntimeException("Found common JVB API version " +
-                        maxApiVersion + " but logic to instantiate client missing");
+                    default: throw new RuntimeException("Found common JVB " +
+                        "API version " + maxApiVersion + " but logic to " +
+                        "instantiate client missing");
                 }
             }
         }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -737,6 +737,16 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
+     * The versions of the JVB API for which support has been implemented.
+     *
+     * NOTE: this is defined here because it should be as close as possible
+     * to the switch statement below which instantiates the proper API client
+     * instance.  BOTH the switch statement AND this member must be updated
+     * when adding support for a new JVB API version.
+     */
+    private static SupportedApiVersions implementedJvbApiVersions =
+        new SupportedApiVersions(ApiVersion.V1);
+    /**
      * Creates a new {@link ColibriConference} and creates a {@link JvbApi}
      * instance for it to use to control the JVB
      * @param bridgeJid see
@@ -760,8 +770,9 @@ public class JitsiMeetConferenceImpl
                 "client supports " + VersionKt.SUPPORTED_API_VERSIONS +
                 ", bridge supports " + bridge.getSupportedApiVersions());
             ApiVersion maxApiVersion =
-                VersionKt.SUPPORTED_API_VERSIONS.maxSupported(
-                    bridge.getSupportedApiVersions());
+                VersionKt.SUPPORTED_API_VERSIONS.intersect(
+                    bridge.getSupportedApiVersions())
+                    .maxSupported(implementedJvbApiVersions);
             if (maxApiVersion == null)
             {
                 logger.info("No JVB API version compatibility found " +
@@ -770,6 +781,11 @@ public class JitsiMeetConferenceImpl
             else
             {
                 logger.info("Got common api version " + maxApiVersion);
+                /**
+                 * NOTE: when adding or removing versions to this switch
+                 * statement, the changes must also be made to
+                 * {@link implementedJvbApiVersions} member.
+                 */
                 switch (maxApiVersion)
                 {
                     case V1:

--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -143,6 +143,9 @@ public class Bridge
      */
     private ColibriStatsExtension stats = EMPTY_STATS;
 
+    private String jvbApiUrl = null;
+    private Integer jvbApiPort = null;
+
     /**
      * Notifies this instance that a new {@link ColibriStatsExtension} was
      * received for this instance.
@@ -193,6 +196,9 @@ public class Bridge
         {
             version = newVersion;
         }
+
+        jvbApiUrl = stats.getValueAsString("jvb-api-base-url");
+        jvbApiPort = stats.getValueAsInt("jvb-api-port");
     }
 
     Bridge(BridgeSelector bridgeSelector,
@@ -346,6 +352,24 @@ public class Bridge
     public int getLastReportedPacketRatePps()
     {
         return lastReportedPacketRatePps;
+    }
+
+    /**
+     * Get the URL of the JVB API for this bridge
+     * @return
+     */
+    public String getJvbApiUrl()
+    {
+        return this.jvbApiUrl;
+    }
+
+    /**
+     * Get the port of the JVB API for this bridge
+     * @return
+     */
+    public Integer getJvbApiPort()
+    {
+        return this.jvbApiPort;
     }
 
 }

--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -19,6 +19,7 @@ package org.jitsi.jicofo.bridge;
 
 import org.jitsi.jicofo.util.*;
 import org.jitsi.utils.stats.*;
+import org.jitsi.videobridge.api.types.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import static org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.*;
 
@@ -143,8 +144,21 @@ public class Bridge
      */
     private ColibriStatsExtension stats = EMPTY_STATS;
 
+    /**
+     * The base url of the HTTP API for this bridge, if it is supported.
+     */
     private String jvbApiUrl = null;
+
+    /**
+     * The base port of the HTTP API for this bridge, if it is supported.
+     */
     private Integer jvbApiPort = null;
+
+    /**
+     * The {@link SupportedApiVersions} of the HTTP API for this bridge,
+     * if it is supported.
+     */
+    private SupportedApiVersions supportedApiVersions = null;
 
     /**
      * Notifies this instance that a new {@link ColibriStatsExtension} was
@@ -199,6 +213,10 @@ public class Bridge
 
         jvbApiUrl = stats.getValueAsString("jvb-api-base-url");
         jvbApiPort = stats.getValueAsInt("jvb-api-port");
+        supportedApiVersions = SupportedApiVersionsKt.fromPresenceString(
+            SupportedApiVersions.Companion,
+            stats.getValueAsString("jvb-api-version")
+        );
     }
 
     Bridge(BridgeSelector bridgeSelector,
@@ -372,4 +390,8 @@ public class Bridge
         return this.jvbApiPort;
     }
 
+    public SupportedApiVersions getSupportedApiVersions()
+    {
+        return this.supportedApiVersions;
+    }
 }

--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -213,10 +213,14 @@ public class Bridge
 
         jvbApiUrl = stats.getValueAsString("jvb-api-base-url");
         jvbApiPort = stats.getValueAsInt("jvb-api-port");
-        supportedApiVersions = SupportedApiVersionsKt.fromPresenceString(
-            SupportedApiVersions.Companion,
-            stats.getValueAsString("jvb-api-version")
-        );
+        String supportedVersions = stats.getValueAsString("jvb-api-version");
+        if (supportedVersions != null)
+        {
+            supportedApiVersions = SupportedApiVersionsKt.fromPresenceString(
+                SupportedApiVersions.Companion,
+                supportedVersions
+            );
+        }
     }
 
     Bridge(BridgeSelector bridgeSelector,

--- a/src/main/java/org/jitsi/jicofo/bridge/BridgeMucDetector.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/BridgeMucDetector.java
@@ -171,9 +171,9 @@ public class BridgeMucDetector
         Jid jid,
         ColibriStatsExtension stats)
     {
-//        if (logger.isDebugEnabled())
+        if (logger.isDebugEnabled())
         {
-            logger.info(
+            logger.debug(
                 "Received updated status for " + jid + ": " + stats.toXML());
         }
 

--- a/src/main/java/org/jitsi/jicofo/bridge/BridgeMucDetector.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/BridgeMucDetector.java
@@ -171,9 +171,9 @@ public class BridgeMucDetector
         Jid jid,
         ColibriStatsExtension stats)
     {
-        if (logger.isDebugEnabled())
+//        if (logger.isDebugEnabled())
         {
-            logger.debug(
+            logger.info(
                 "Received updated status for " + jid + ": " + stats.toXML());
         }
 

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -18,6 +18,7 @@
 package org.jitsi.protocol.xmpp.colibri;
 
 import org.jitsi.protocol.xmpp.colibri.exception.*;
+import org.jitsi.videobridge.api.client.v1.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 import net.java.sip.communicator.service.protocol.*;
@@ -285,4 +286,11 @@ public interface ColibriConference
      * Sets the "global" id of the conference.
      */
     void setGID(String gid) ;
+
+    /**
+     * Set a JVB API instance for this conference to use to control
+     * the JVB
+     * @param api
+     */
+    void setJvbApi(JvbApi api);
 }


### PR DESCRIPTION
This relies on the work in https://github.com/jitsi/jitsi-videobridge/pull/1268 and integrates the JVB API with Jicofo.

In this first version, Jicofo looks for values present in JVB's presence that advertise support for the new JVB API.  If those are present, all requests are sent via the JVB API, if not then it falls back to the existing XMPP connection.

Still considering this a WIP, as we may want some other tweaks before merging this (even if we didn't enable it in JVB yet).