### PR TITLE
update the relays on the bridge in BridgeSession#setRelays

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -3083,6 +3083,7 @@ public class JitsiMeetConferenceImpl
 
             OctoParticipant octoParticipant = getOctoParticipant(remoteRelays);
             octoParticipant.setRelays(remoteRelays);
+            updateColibriOctoChannels(octoParticipant);
         }
 
         /**

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -3083,7 +3083,10 @@ public class JitsiMeetConferenceImpl
 
             OctoParticipant octoParticipant = getOctoParticipant(remoteRelays);
             octoParticipant.setRelays(remoteRelays);
-            updateColibriOctoChannels(octoParticipant);
+            if (octoParticipant.isSessionEstablished())
+            {
+                updateColibriOctoChannels(octoParticipant);
+            }
         }
 
         /**


### PR DESCRIPTION
We noticed an issue in the following scenario:

1. Bridges A and B have participants in the same conference
1. All the participants in that conference on bridge A leave
1. Bridge B is told that the remote participants are gone, but isn't told that relay (bridge A) is no longer in the call, so it continues forwarding packets there

Part of the reason the above flow fails, is that in `BridgeSession#removeSourcesFromOcto`, the relays we include in the colibri come from the `OctoParticipant`, but the 'removed' relay has not yet been removed from the participant at that point.

This PR adds a call to `updateColibriOctoChannels` to `BridgeSession#setRelays`.  This is where the relays in the `OctoParticipant` are updated, so doing an update at this point does include the proper set of relays.