### PR TITLE
debian: don't depend on a specific JRE version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,12 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>, Pawel Domas <pawel.domas@jitsi.org>
-Build-Depends: debhelper, openjdk-8-jre-headless | openjdk-11-jre-headless, maven
+Build-Depends: debhelper, java8-runtime-headless | java8-runtime | java11-runtime-headless | java11-runtime, maven
 Standards-Version: 3.9.3
 Homepage: https://jitsi.org/meet
 
 Package: jicofo
 Architecture: all
-Depends: ${misc:Depends}, openjdk-8-jre-headless | openjdk-11-jre-headless
+Depends: ${misc:Depends}, java8-runtime-headless | java8-runtime | java11-runtime-headless | java11-runtime
 Description: JItsi Meet COnference FOcus
  Jicofo is a conference focus for Jitsi Meet application.


### PR DESCRIPTION
This makes it possible to use AdoptOpenJDK builds. This is useful for
running Java 8 on Debian Buster, for example.