### PR TITLE
Add option to improve audio quality

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConfig.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConfig.java
@@ -132,6 +132,11 @@ public class JitsiMeetConfig
     public static final String PNAME_STEREO = "stereo";
 
     /**
+     * The name of the "maxaveragebitrate" property.
+     */
+    public static final String PNAME_OPUS_MAX_AVG_BITRATE = "opusMaxAverageBitrate";
+
+    /**
      * The name of the "octo" property.
      */
     public static final String PNAME_OCTO = "octo";
@@ -366,6 +371,15 @@ public class JitsiMeetConfig
     {
         Boolean stereo = getBoolean(PNAME_STEREO);
         return stereo != null && stereo;
+    }
+
+    /**
+     * @return the "maxaveragebitrate" which should be included in offers or -1 if not specified.
+     */
+    public int getOpusMaxAverageBitrate()
+    {
+        Integer maxAvgBitrate = getInt(PNAME_OPUS_MAX_AVG_BITRATE);
+        return maxAvgBitrate == null ? -1 : maxAvgBitrate;
     }
 
     public boolean isOctoEnabled()

--- a/src/main/java/org/jitsi/jicofo/OctoChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/OctoChannelAllocator.java
@@ -93,7 +93,7 @@ public class OctoChannelAllocator extends AbstractChannelAllocator
         contents.add(
             jingleOfferFactory.createAudioContent(
                     !useIce, useDtls, config.stereoEnabled(),
-                    enableRemb, enableTcc));
+                    config.getOpusMaxAverageBitrate(), enableRemb, enableTcc));
 
         contents.add(
             jingleOfferFactory.createVideoContent(

--- a/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
+++ b/src/main/java/org/jitsi/jicofo/ParticipantChannelAllocator.java
@@ -111,7 +111,7 @@ public class ParticipantChannelAllocator extends AbstractChannelAllocator
             contents.add(
                 jingleOfferFactory.createAudioContent(
                     disableIce, useDtls, config.stereoEnabled(),
-                    enableRemb, enableTcc));
+                    config.getOpusMaxAverageBitrate(), enableRemb, enableTcc));
         }
 
         if (participant.hasVideoSupport())

--- a/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/util/JingleOfferFactory.java
@@ -247,13 +247,13 @@ public class JingleOfferFactory
      */
     public ContentPacketExtension createAudioContent(
         boolean disableIce, boolean useDtls, boolean stereo,
-        boolean enableRemb, boolean enableTcc)
+        int maxAvgBitrate, boolean enableRemb, boolean enableTcc)
     {
         ContentPacketExtension content
             = createContentPacketExtension(
                     "audio", disableIce, useDtls);
 
-        addAudioToContent(content, stereo, enableRemb, enableTcc);
+        addAudioToContent(content, stereo, maxAvgBitrate, enableRemb, enableTcc);
 
         return content;
     }
@@ -640,12 +640,14 @@ public class JingleOfferFactory
      * {@link ContentPacketExtension}.
      * @param content the {@link ContentPacketExtension} to add extensions to.
      * @param stereo Whether to enable stereo for opus.
+     * @param maxAvgBitrate The {@code maxaveragebitrate} to be set for opus.
      * @param enableRemb Whether to enable REMB.
      * @param enableTcc Whether to enable transport-cc.
      */
     private static void addAudioToContent(
             ContentPacketExtension content,
             boolean stereo,
+            int maxAvgBitrate,
             boolean enableRemb,
             boolean enableTcc)
     {
@@ -672,6 +674,11 @@ public class JingleOfferFactory
         {
             // fmtp: 111 stereo=1
             addParameterExtension(opus, "stereo", "1");
+        }
+
+        if (maxAvgBitrate != -1)
+        {
+            addParameterExtension(opus, "maxaveragebitrate", String.valueOf(maxAvgBitrate));
         }
 
         // fmtp:111 useinbandfec=1

--- a/src/test/java/org/jitsi/jicofo/ColibriTest.java
+++ b/src/test/java/org/jitsi/jicofo/ColibriTest.java
@@ -94,7 +94,7 @@ public class ColibriTest
             = FocusBundleActivator.getJingleOfferFactory();
         ContentPacketExtension audio
             = jingleOfferFactory.createAudioContent(
-                    false, true, false, false, false);
+                    false, true, false, -1, false, false);
         ContentPacketExtension video
             = jingleOfferFactory.createVideoContent(
                     false, true, false, false, false, -1, -1);

--- a/src/test/java/org/jitsi/jicofo/ColibriThreadingTest.java
+++ b/src/test/java/org/jitsi/jicofo/ColibriThreadingTest.java
@@ -313,7 +313,7 @@ public class ColibriThreadingTest
             = FocusBundleActivator.getJingleOfferFactory();
 
         contents.add(jingleOfferFactory.createAudioContent(
-                    false, true, false, false, false));
+                    false, true, false, -1, false, false));
 
         contents.add(jingleOfferFactory.createVideoContent(
                     false, true, false, false, false, -1, -1));


### PR DESCRIPTION
A setting to improve the audio quality is frequently requested in the community forum. While it is already possible to disable audio processing and to enable stereo through `config.js` options, there is currently no way to adjust the actual bitrate thats produced by the Opus encoder. This PR provides a way to influence the audio bitrate through a `config.js` option.

### Intention
While this PR provides a workaround that allows to control the used audio bitrate to some degree, I am by no means certain that this is the way to go. There may be more efficient ways to achieve this and there could even be ways unknown to me that provide more fine grained control over the mode used by the Opus encoder. The main intention behind this PR is therefore to start a discussion about how an option for improved audio resolution could be implemented in future Jitsi releases.

### Background
After digging through the relevant Opus [1] and Opus RTP [2] RFCs, I believe that in contrast to the audio processing which can be controlled through audio constraints passed to `GetUserMedia`, the encoding behavior of Opus can only be influenced through the RTP payload in the SDP? Even though Opus appears to provide various modes including for speech and for fullbandwidth encoding, the RFCs did not really help me to understand how to control the mode that is actually used for encoding an audio stream. A StackOverflow post [3] mentioned the `maxaveragebitrate` parameter and a test confirmed that adding this parameter to the SDP gives some control over the used audio bitrates. The maxaveragebitrate parameter is explained in the Opus RTP RFC as follows ([2], Section 3.1.1):

>    maxaveragebitrate:  specifies the maximum average receive bitrate of
>       a session in bits per second (bit/s).  The actual value of the
>       bitrate can vary, as it is dependent on the characteristics of the
>       media in a packet.  Note that the maximum average bitrate MAY be
>       modified dynamically during a session.  Any positive integer is
>       allowed, but values outside the range 6000 to 510000 SHOULD be
>       ignored.  If no value is specified, the maximum value specified in
>       Section 3.1.1 for the corresponding mode of Opus and corresponding
>       maxplaybackrate is the default.

### Implementation
To make use of the `config.js` option introduced by this PR, additional changes in `jitsi-meet` and `lib-jitsi-meet` are required as detailed below. Should you consider to merge this PR, I'd be happy to open the related PR's in the respectiver repositories.

1. In `jitsi-meet/react/features/base/config/configWhitelist.js`, add the new option to the config whitelist:
```
diff --git a/react/features/base/config/configWhitelist.js b/react/features/base/config/configWhitelist.js
index 757049932..404592dcd 100644
--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -125,6 +125,7 @@ export default [
     'minParticipants',
     'nick',
     'openBridgeChannel',
+    'opusMaxAverageBitrate',
     'p2p',
     'pcStatsInterval',
     'preferH264',
```

2. In `lib-jitsi-meet/modules/xmpp/moderator.js'

```
diff --git a/modules/xmpp/moderator.js b/modules/xmpp/moderator.js
index 50097909..78604ac1 100644
--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -237,6 +237,13 @@ Moderator.prototype.createConferenceIq = function() {
                 value: config.minBitrate
             }).up();
     }
+    if (config.opusMaxAverageBitrate) {
+        elem.c(
+            'property', {
+                name: 'opusMaxAverageBitrate',
+                value: config.opusMaxAverageBitrate
+            }).up();
+    }
     if (config.testing && config.testing.octo
         && typeof config.testing.octo.probability === 'number') {
         if (Math.random() < config.testing.octo.probability) {
```

3. Remember to adjust `jitsi-meet/package.json` to use the local `lib-jitsi-meet` as described [here](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-web#working-with-the-library-sources-lib-jitsi-meet).

4. Once deployed, one can add `opusMaxAverageBitrate: 310000,` to `config.js` or as override in the URL fragment `#config.opusMaxAverageBitrate=310000`.

### Open Questions
- Works for Chromium based browsers; does not work with Firefox; I could not test Safari: While the effect of the increased audio bitrate can be observed in `chrome://webrtc-internals`, checking in Firefox's `about:webrtc` one can see that the `maxaveragebitrate` parameter is completely missing from the parsed SDP. It is unclear to me if this is a Firefox issue or if this is related to the conversion from Plan B to Unified Plan.
- I am currently unsure whether this works in p2p mode as well as in calls routed through the videobridge. I also did not test this with mobile clients. 
- Even after going through the Opus related RFCs, it is still unclear to me, whether or not the used encoding parameters can be influenced *on the fly*. Ideally, a button in the UI should be available to toggle a higher audio resolution than the current default.

---

[1] [RFC6716 - Definition of the Opus Audio Codec](https://tools.ietf.org/html/rfc6716)
[2] [RFC7587 - RTP Payload Format for the Opus Speech and Audio Codec](https://tools.ietf.org/html/rfc7587)
[3] https://stackoverflow.com/a/58898298