### PR TITLE
Revert "Integrate JVB API (#538)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,11 +198,6 @@
       <artifactId>jersey-media-json-jackson</artifactId>
       <version>${jersey.version}</version>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>jvb-api-client</artifactId>
-      <version>2.1-227-g3ce5bf97</version>
-    </dependency>
     <!-- jersey relies on this version of javassist or we get hk2
     errors, but other libs (Powermock, at this time) also rely on
     it but an older version, and that version is getting selected

--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -19,7 +19,6 @@ package org.jitsi.jicofo.bridge;
 
 import org.jitsi.jicofo.util.*;
 import org.jitsi.utils.stats.*;
-import org.jitsi.videobridge.api.types.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import static org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.*;
 
@@ -148,22 +147,6 @@ public class Bridge
      */
     private ColibriStatsExtension stats = EMPTY_STATS;
 
-    /**
-     * The base url of the HTTP API for this bridge, if it is supported.
-     */
-    private String jvbApiUrl = null;
-
-    /**
-     * The base port of the HTTP API for this bridge, if it is supported.
-     */
-    private Integer jvbApiPort = null;
-
-    /**
-     * The {@link SupportedApiVersions} of the HTTP API for this bridge,
-     * if it is supported.
-     */
-    private SupportedApiVersions supportedApiVersions = null;
-
     Bridge(Jid jid)
     {
         this(jid, BridgeSelector.DEFAULT_FAILURE_RESET_THRESHOLD);
@@ -224,17 +207,6 @@ public class Bridge
         if (newVersion != null)
         {
             version = newVersion;
-        }
-
-        jvbApiUrl = stats.getValueAsString("jvb-api-base-url");
-        jvbApiPort = stats.getValueAsInt("jvb-api-port");
-        String supportedVersions = stats.getValueAsString("jvb-api-version");
-        if (supportedVersions != null)
-        {
-            supportedApiVersions = SupportedApiVersionsKt.fromPresenceString(
-                SupportedApiVersions.Companion,
-                supportedVersions
-            );
         }
 
         Integer octoVersion = stats.getValueAsInt("octo_version");
@@ -383,29 +355,6 @@ public class Bridge
     public int getLastReportedPacketRatePps()
     {
         return lastReportedPacketRatePps;
-    }
-
-    /**
-     * Get the URL of the JVB API for this bridge
-     * @return
-     */
-    public String getJvbApiUrl()
-    {
-        return this.jvbApiUrl;
-    }
-
-    /**
-     * Get the port of the JVB API for this bridge
-     * @return
-     */
-    public Integer getJvbApiPort()
-    {
-        return this.jvbApiPort;
-    }
-
-    public SupportedApiVersions getSupportedApiVersions()
-    {
-        return this.supportedApiVersions;
     }
 
     public int getOctoVersion()

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -18,7 +18,6 @@
 package org.jitsi.protocol.xmpp.colibri;
 
 import org.jitsi.protocol.xmpp.colibri.exception.*;
-import org.jitsi.videobridge.api.client.v1.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 import net.java.sip.communicator.service.protocol.*;
@@ -286,11 +285,4 @@ public interface ColibriConference
      * Sets the "global" id of the conference.
      */
     void setGID(String gid) ;
-
-    /**
-     * Set a JVB API instance for this conference to use to control
-     * the JVB
-     * @param api
-     */
-    void setJvbApi(JvbApi api);
 }


### PR DESCRIPTION
This reverts commit c1ad0440affb12b09900a5dd97e536343d350123.

We've decided to go a different direction with the JVB API and postpone a transport change until later in the evolution of colibri. This PR removes the integration of the jvb-api-client code in jicofo. 