### PR TITLE
fix(JvbDoctor): connection null on bad timing

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/OpSetSimpleCapsImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/OpSetSimpleCapsImpl.java
@@ -140,7 +140,7 @@ public class OpSetSimpleCapsImpl
         }
         catch (Exception e)
         {
-            logger.error(
+            logger.warn(
                     String.format(
                             "Failed to discover features for %s: %s", node, e.getMessage()));
         }


### PR DESCRIPTION
Use getter to fetch the current XMPP connection. This fixes
an issue where the connection is always null if it wasn't
available on bundle startup.

Also reduces logging level on discovery error to warning.