### PR TITLE
feat: add support for session-terminate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,8 +156,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <!-- FIXME update and squash before merging -->
-      <version>1.0.1-SNAPSHOT</version>
+      <version>1.0-13-ga40f9c3</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,8 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-6-g009420d</version>
+      <!-- FIXME update and squash before merging -->
+      <version>1.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/DefaultJingleRequestHandler.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/DefaultJingleRequestHandler.java
@@ -67,6 +67,14 @@ public class DefaultJingleRequestHandler
     }
 
     @Override
+    public XMPPError onSessionTerminate(JingleSession jingleSession, JingleIQ iq)
+    {
+        logger.warn("Ignored Jingle 'session-terminate'");
+
+        return null;
+    }
+
+    @Override
     public XMPPError onSessionInfo(JingleSession session, JingleIQ iq)
     {
         logger.warn("Ignored Jingle 'session-info'");

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1319,7 +1319,7 @@ public class JitsiMeetConferenceImpl
                 JingleSession jingleSession = participant.getJingleSession();
                 logger.info("Terminating: " + contactAddress);
 
-                jingle.terminateSession(jingleSession, reason, message, true);
+                jingle.terminateSession(jingleSession, reason, message, reason != null);
 
                 removeSources(
                     jingleSession,

--- a/src/main/java/org/jitsi/jicofo/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/LipSyncHack.java
@@ -366,9 +366,10 @@ public class LipSyncHack implements OperationSetJingle
     @Override
     public void terminateSession(JingleSession    session,
                                  Reason           reason,
-                                 String           msg)
+                                 String           msg,
+                                 boolean          sendTerminate)
     {
-        jingleImpl.terminateSession(session, reason, msg);
+        jingleImpl.terminateSession(session, reason, msg, sendTerminate);
     }
 
     /**

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -307,6 +307,9 @@ public abstract class AbstractOperationSetJingle
         case SESSION_INFO:
             error = requestHandler.onSessionInfo(session, iq);
             break;
+        case SESSION_TERMINATE:
+            error = requestHandler.onSessionTerminate(session, iq);
+            break;
         case TRANSPORT_ACCEPT:
             error = requestHandler.onTransportAccept(session, iq.getContentList());
             break;
@@ -558,39 +561,43 @@ public abstract class AbstractOperationSetJingle
         {
             if (session.getRequestHandler() == requestHandler)
             {
-                terminateSession(session, Reason.GONE, null);
+                terminateSession(session, Reason.GONE, null, true);
             }
         }
     }
 
     /**
-     * Terminates given Jingle session by sending 'session-terminate' with some
-     * {@link Reason} if provided.
+     * Terminates given Jingle session. This method is to be called either to send 'session-terminate' or to inform
+     * this operation set that the session has been terminated as a result of 'session-terminate' received from
+     * the other peer in which case {@code sendTerminate} should be set to {@code false}.
      *
      * @param session the <tt>JingleSession</tt> to terminate.
      * @param reason one of {@link Reason} enum that indicates why the session
      *               is being ended or <tt>null</tt> to omit.
+     * @param sendTerminate when {@code true} it means that a 'session-terminate' is to be sent, otherwise it means
+     * the session is being ended on the remote peer's request.
      * {@inheritDoc}
      */
     @Override
     public void terminateSession(JingleSession    session,
                                  Reason           reason,
-                                 String           message)
+                                 String           message,
+                                 boolean          sendTerminate)
     {
-        logger.info("Terminate session: " + session.getAddress());
+        logger.info("Terminate session: " + session.getAddress() + ", reason: " + reason);
 
-        // we do not send session-terminate as muc addresses are invalid at this
-        // point
-        // FIXME: but there is also connection address available
-        JingleIQ terminate
-            = JinglePacketFactory.createSessionTerminate(
+        if (sendTerminate)
+        {
+            JingleIQ terminate
+                    = JinglePacketFactory.createSessionTerminate(
                     getOurJID(),
                     session.getAddress(),
                     session.getSessionID(),
                     reason,
                     message);
 
-        getConnection().sendStanza(terminate);
+            getConnection().sendStanza(terminate);
+        }
 
         sessions.remove(session.getSessionID());
     }

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -584,7 +584,11 @@ public abstract class AbstractOperationSetJingle
                                  String           message,
                                  boolean          sendTerminate)
     {
-        logger.info("Terminate session: " + session.getAddress() + ", reason: " + reason);
+        logger.info(String.format(
+                "Terminate session: %s, reason: %s, send terminate: %s",
+                session.getAddress(),
+                reason,
+                sendTerminate));
 
         if (sendTerminate)
         {

--- a/src/main/java/org/jitsi/protocol/xmpp/JingleRequestHandler.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/JingleRequestHandler.java
@@ -88,6 +88,17 @@ public interface JingleRequestHandler
     XMPPError onSessionInfo(JingleSession jingleSession, JingleIQ iq);
 
     /**
+     * Callback fired when 'session-terminate' is received from the client.
+     *
+     * @param jingleSession the session that has received the notification.
+     * @param iq the full message sent by the client.
+     *
+     * @return <tt>XMPPError</tt> if an error should be returned as response to the original request or <tt>null</tt>
+     * to reply with RESULT.
+     */
+    XMPPError onSessionTerminate(JingleSession jingleSession, JingleIQ iq);
+
+    /**
      * Callback fired when 'transport-info' is received from the client.
      *
      * @param jingleSession the session that has received the notification.

--- a/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/OperationSetJingle.java
@@ -125,16 +125,17 @@ public interface OperationSetJingle
                             JingleSession session);
 
     /**
-     * Terminates given session by sending 'session-terminate' IQ which will
-     * optionally include the <tt>Reason</tt> supplied.
+     * Terminates given Jingle session. This method is to be called either to send 'session-terminate' or to inform
+     * this operation set that the session has been terminated as a result of 'session-terminate' received from
+     * the other peer in which case {@code sendTerminate} should be set to {@code false}.
      *
-     * @param session the <tt>JingleSession</tt> to be terminated.
-     * @param reason optional <tt>Reason</tt> specifying the reason of session
-     *               termination.
-     * @param message optional text message providing more details about
-     *                the reason for terminating the session.
+     * @param session the <tt>JingleSession</tt> to terminate.
+     * @param reason one of {@link Reason} enum that indicates why the session
+     *               is being ended or <tt>null</tt> to omit.
+     * @param sendTerminate when {@code true} it means that a 'session-terminate' is to be sent, otherwise it means
+     * the session is being ended on the remote peer's request.
      */
-    void terminateSession(JingleSession session, Reason reason, String message);
+    void terminateSession(JingleSession session, Reason reason, String message, boolean sendTerminate);
 
     /**
      * Terminates all active Jingle Sessions associated with given

--- a/src/test/java/mock/muc/MockRoomMember.java
+++ b/src/test/java/mock/muc/MockRoomMember.java
@@ -44,7 +44,7 @@ public class MockRoomMember
 
     private ChatRoomMemberRole role = ChatRoomMemberRole.MEMBER;
 
-    MockRoomMember(EntityFullJid address, MockMultiUserChat chatRoom)
+    public MockRoomMember(EntityFullJid address, MockMultiUserChat chatRoom)
     {
         this.address = address;
         this.name = address.getResourceOrThrow();

--- a/src/test/java/org/jitsi/jicofo/ParticipantTest.java
+++ b/src/test/java/org/jitsi/jicofo/ParticipantTest.java
@@ -1,0 +1,75 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo;
+
+import mock.muc.*;
+import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+import org.jxmpp.jid.impl.*;
+import org.jxmpp.stringprep.*;
+
+import java.time.*;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnit4.class)
+public class ParticipantTest
+{
+    @Test
+    public void testRestartReqRateLimiting()
+            throws XmppStringprepException
+    {
+        Participant p = new Participant(
+                new MockJitsiMeetConference(),
+                new MockRoomMember(JidCreate.entityFullFrom("something@server.com/1234"), null),
+                0);
+
+        p.setClock(Clock.fixed(Instant.now(), ZoneId.systemDefault()));
+
+        assertTrue("should allow 1st request", p.incrementAndCheckRestartRequests());
+        assertFalse("should not allow next request immediately", p.incrementAndCheckRestartRequests());
+
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(5)));
+        assertFalse("should not allow next request after 5 seconds", p.incrementAndCheckRestartRequests());
+
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(6)));
+        assertTrue("should allow 2nd request after 11 seconds", p.incrementAndCheckRestartRequests());
+
+        assertFalse("should not allow 3rd request after 11 seconds", p.incrementAndCheckRestartRequests());
+
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(10)));
+        assertTrue("should allow 3rd request after 21 seconds", p.incrementAndCheckRestartRequests());
+
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(11)));
+        assertFalse("should not allow more than 3 request within the last minute (31 second)", p.incrementAndCheckRestartRequests());
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(10)));
+        assertFalse("should not allow more than 3 request within the last minute (41 second)", p.incrementAndCheckRestartRequests());
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(10)));
+        assertFalse("should not allow more than 3 request within the last minute (51 second)", p.incrementAndCheckRestartRequests());
+
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(10)));
+        assertTrue("should allow the 4th request after 60 seconds have passed since the 1st (61 second)", p.incrementAndCheckRestartRequests());
+
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(5)));
+        assertFalse("should not allow the 5th request in 66th second", p.incrementAndCheckRestartRequests());
+
+        p.setClock(Clock.offset(p.getClock(), Duration.ofSeconds(5)));
+        assertTrue("should allow the 5th request in 71st second", p.incrementAndCheckRestartRequests());
+    }
+}


### PR DESCRIPTION
Implements 'session-terminate' which allows the clients to end the session. If there's the restart attribute set to true in the <bridge-session> extension, then Jicofo will start a new session after tearing down the existing one.

Adds rate limiting on the restart requests to prevent abuse and/or client bugs. There must be at least 10 second gap between the requests and no more than 3 requests are allowed in the last minute.

Depends on https://github.com/jitsi/jitsi-xmpp-extensions/pull/30