### PR TITLE
change jicofo tests to instantiate videobridge directly (not via bund…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-videobridge</artifactId>
-      <version>2.1-292-g3a51f0e0</version>
+      <version>2.1-300-gb0f2d1b5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/mock/jvb/MockVideobridge.java
+++ b/src/test/java/mock/jvb/MockVideobridge.java
@@ -57,8 +57,6 @@ public class MockVideobridge
 
     private boolean returnServerError = false;
 
-    private VideobridgeBundleActivator jvbActivator;
-
     private ColibriConferenceIqHandler confIqGetHandler
             = new ColibriConferenceIqHandler(IQ.Type.get);
 
@@ -76,13 +74,9 @@ public class MockVideobridge
     }
 
     public void start(BundleContext bc)
-        throws Exception
     {
-        this.jvbActivator = new VideobridgeBundleActivator();
-
-        jvbActivator.start(bc);
-
-        bridge = ServiceUtils2.getService(bc, Videobridge.class);
+        bridge = new Videobridge();
+        bridge.start(bc);
 
         connection.registerIQRequestHandler(confIqGetHandler);
         connection.registerIQRequestHandler(confIqSetHandler);
@@ -91,13 +85,12 @@ public class MockVideobridge
 
     @Override
     public void stop(BundleContext bundleContext)
-        throws Exception
     {
         connection.unregisterIQRequestHandler(confIqGetHandler);
         connection.unregisterIQRequestHandler(confIqSetHandler);
         connection.unregisterIQRequestHandler(healthCheckIqHandler);
 
-        jvbActivator.stop(bundleContext);
+        bridge.stop(bundleContext);
     }
 
     private class ColibriConferenceIqHandler extends AbstractIqRequestHandler


### PR DESCRIPTION
…le activator)

This adapts to the changes in https://github.com/jitsi/jitsi-videobridge/pull/1388, where the bridge instantiation is moved to a singleton and shimmed into OSGi.  This means that the instance survives across OSGi starts/stops, which isn't an issue in the bridge where we only start/stop things once (at startup/shutdown), but for tests which rely on re-instantiating videobridge it doesn't work.  The mock videobridge in Jicofo no longer needs to use OSGi to create the `Videobridge` instance, it can do so directly (like JVB now does)