### PR TITLE
fix deadlock in reservations

### DIFF
--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -1009,4 +1009,8 @@ public class FocusManager
             }
         }
     }
+
+    public final Object getLock(){
+        return conferencesSyncRoot;
+    }
 }


### PR DESCRIPTION
In jitsi-meet with reservations system,I found deadlock in FocusExpireTask & ConferenceExpireTask.


Lock sequence:
FocusExpireTask : conferencesSyncRoot -> RESTReservations object
ConferenceExpireTask : RESTReservations object-> conferencesSyncRoot

 
The proposed code is to fix at reservations side.
ConferenceExpireTask should lock manager.conferencesSyncRoot first  to ensure no deadlock happen.

More log evident at: https://community.jitsi.org/t/deadlock-between-focusexpiretask-and-conferenceexpiretask-in-jicofo/79445