### PR TITLE
Handle Jibri errors on initial request

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
@@ -373,8 +373,14 @@ public class JibriSession
         {
             logger.error("Failed to send start Jibri IQ: " + e, e);
             jibriDetector.memberHadTransientError(jibriJid);
-
-            throw new StartException(StartException.INTERNAL_SERVER_ERROR);
+            if (!maxRetriesExceeded())
+            {
+                retryRequestWithAnotherJibri();
+            }
+            else
+            {
+                throw new StartException(StartException.INTERNAL_SERVER_ERROR);
+            }
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
@@ -372,6 +372,7 @@ public class JibriSession
         catch (Exception e)
         {
             logger.error("Failed to send start Jibri IQ: " + e, e);
+            jibriDetector.memberHadTransientError(jibriJid);
 
             throw new StartException(StartException.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
+++ b/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
@@ -266,6 +266,25 @@ public abstract class BaseBrewery<T extends ExtensionElement>
     }
 
     /**
+     * Notify this {@link BaseBrewery} that the member with jid {@code member} experienced
+     * an error which is expected to be transient.
+     *
+     * @param member the {@link Jid} of the member who experienced the error
+     */
+    synchronized public void memberHadTransientError(Jid member)
+    {
+        BrewInstance instance = find(member);
+        if (instance != null)
+        {
+            logger.info("Jid member " + member + " had a transient error, moving to the back" +
+                "of the queue");
+            // Move the instance to the back of the list
+            removeInstance(instance);
+            addInstance(instance);
+        }
+    }
+
+    /**
      * Process chat room member status changed. Extract the appropriate
      * presence extension and use it to process it further.
      * @param member the chat member to process

--- a/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
+++ b/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
@@ -325,9 +325,7 @@ public abstract class BaseBrewery<T extends ExtensionElement>
         if (instance == null)
         {
             instance = new BrewInstance(jid, extension);
-            instances.add(instance);
-
-            logger.info("Added brewery instance: " + jid);
+            addInstance(instance);
         }
         else
         {
@@ -371,6 +369,13 @@ public abstract class BaseBrewery<T extends ExtensionElement>
             .filter(i -> i.jid.equals(jid))
             .findFirst()
             .orElse(null);
+    }
+
+    private void addInstance(BrewInstance i)
+    {
+        instances.add(i);
+
+        logger.info("Added brewery instance: " + i.jid);
     }
 
     /**

--- a/src/test/kotlin/org/jitsi/jicofo/recording/jibri/JibriDetectorTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/recording/jibri/JibriDetectorTest.kt
@@ -1,0 +1,68 @@
+package org.jitsi.jicofo.recording.jibri
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import net.java.sip.communicator.service.protocol.event.ChatRoomMemberPresenceChangeEvent
+import org.jitsi.protocol.xmpp.XmppChatMember
+import org.jitsi.xmpp.extensions.health.HealthStatusPacketExt
+import org.jitsi.xmpp.extensions.jibri.JibriBusyStatusPacketExt
+import org.jitsi.xmpp.extensions.jibri.JibriStatusPacketExt
+import org.jivesoftware.smack.packet.ExtensionElement
+import org.jivesoftware.smack.packet.Presence
+import org.jxmpp.jid.EntityFullJid
+import org.jxmpp.jid.impl.JidCreate
+
+class JibriDetectorTest : ShouldSpec({
+    val detector = JibriDetector(mockk(), "brewery_name", false)
+    val jibriJids = listOf(
+        JidCreate.entityFullFrom("jibri1@bar.com/nick"),
+        JidCreate.entityFullFrom("jibri2@bar.com/nick")
+    )
+
+    jibriJids
+        .map { createJibriMember(it) }
+        .forEach {
+            detector.memberPresenceChanged(ChatRoomMemberPresenceChangeEvent(
+                mockk(),
+                it,
+                ChatRoomMemberPresenceChangeEvent.MEMBER_JOINED,
+                "reason"
+            ))
+        }
+
+    context("When selecting a Jibri, JibriDetector") {
+        should("pick the first one from the list") {
+            detector.selectJibri() shouldBe jibriJids[0]
+        }
+        context("and a jibri has had a transient error") {
+            detector.memberHadTransientError(jibriJids[0])
+            should("pick the next one") {
+                detector.selectJibri() shouldBe jibriJids[1]
+            }
+            context("and the next member has a transient error") {
+                detector.memberHadTransientError(jibriJids[1])
+                should("pick the next one") {
+                    // We will have rolled around to the first Jibri again here
+                    detector.selectJibri() shouldBe jibriJids[0]
+                }
+            }
+        }
+    }
+
+})
+
+private fun createJibriMember(jid: EntityFullJid): XmppChatMember {
+    return mockk {
+        every { occupantJid } returns jid
+        every { presence } returns mockk<Presence> {
+            every { getExtension<ExtensionElement>(JibriStatusPacketExt.ELEMENT_NAME, JibriStatusPacketExt.NAMESPACE)} answers {
+                JibriStatusPacketExt().apply {
+                    healthStatus = HealthStatusPacketExt().apply { status = HealthStatusPacketExt.Health.HEALTHY }
+                    busyStatus = JibriBusyStatusPacketExt().apply { setAttribute("status", "idle") }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/jitsi/jicofo/recording/jibri/JibriSessionTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/recording/jibri/JibriSessionTest.kt
@@ -1,0 +1,112 @@
+package org.jitsi.jicofo.recording.jibri
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
+import org.jitsi.eventadmin.EventAdmin
+import org.jitsi.impl.osgi.framework.BundleContextImpl
+import org.jitsi.jicofo.FocusBundleActivator
+import org.jitsi.osgi.ServiceUtils2
+import org.jitsi.protocol.xmpp.XmppConnection
+import org.jitsi.test.concurrent.FakeScheduledExecutorService
+import org.jitsi.utils.logging.Logger
+import org.jitsi.xmpp.extensions.jibri.JibriIq
+import org.jivesoftware.smack.packet.IQ
+import org.jivesoftware.smack.packet.XMPPError
+import org.jxmpp.jid.impl.JidCreate
+
+class JibriSessionTest : ShouldSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    mockkStatic(ServiceUtils2::class)
+    every { ServiceUtils2.getService(any(), EventAdmin::class.java)} returns mockk(relaxed = true)
+    val bundleContext: BundleContextImpl = mockk(relaxed = true)
+    val owner: JibriSession.Owner = mockk(relaxed = true)
+    val roomName = JidCreate.entityBareFrom("room@bar.com/baz")
+    val initiator = JidCreate.bareFrom("foo@bar.com/baz")
+    val pendingTimeout = 60L
+    val maxNumRetries = 2
+    val xmppConnection: XmppConnection = mockk()
+    val executor: FakeScheduledExecutorService = spyk()
+    val jibriList = mutableListOf(
+        JidCreate.bareFrom("jibri1@bar.com"),
+        JidCreate.bareFrom("jibri2@bar.com"),
+        JidCreate.bareFrom("jibri3@bar.com")
+    )
+    val detector: JibriDetector = mockk {
+        every { selectJibri() } returnsMany(jibriList)
+        every { isAnyInstanceConnected } returns true
+        every { memberHadTransientError(any()) } answers {
+            // Simulate the real JibriDetector logic and put the Jibri at the back of the list
+            jibriList.remove(arg(0))
+            jibriList.add(arg(0))
+        }
+    }
+    val logger: Logger = mockk(relaxed = true)
+
+    val jibriSession = JibriSession(
+        bundleContext,
+        owner,
+        roomName,
+        initiator,
+        pendingTimeout,
+        maxNumRetries,
+        xmppConnection,
+        executor,
+        detector,
+        false /* isSIP */,
+        null /* sipAddress */,
+        "displayName",
+        "streamID",
+        "youTubeBroadcastId",
+        "sessionId",
+        "applicationData",
+        logger
+    )
+
+    FocusBundleActivator.bundleContext = bundleContext
+
+    context("When sending a request to a Jibri to start a session throws an error") {
+        val iqRequests = mutableListOf<IQ>()
+        every { xmppConnection.sendPacketAndGetReply(capture(iqRequests)) } answers {
+            // First return error
+            IQ.createErrorResponse(arg(0), XMPPError.Condition.service_unavailable)
+        } andThen {
+            // Then return a successful response
+            JibriIq().apply {
+                status = JibriIq.Status.PENDING
+                from = (arg(0) as IQ).to
+            }
+        }
+        context("Trying to start a Jibri session") {
+            should("retry with another jibri") {
+                jibriSession.start()
+                verify(exactly = 2) { xmppConnection.sendPacketAndGetReply(any()) }
+                iqRequests shouldHaveSize 2
+                iqRequests[0].to shouldNotBe iqRequests[1].to
+            }
+        }
+        context("and that's the only Jibri") {
+            every { detector.selectJibri() } returns JidCreate.bareFrom("solo@bar.com")
+            every { xmppConnection.sendPacketAndGetReply(capture(iqRequests)) } answers {
+                // First return error
+                IQ.createErrorResponse(arg(0), XMPPError.Condition.service_unavailable)
+            }
+            context("trying to start a jibri session") {
+                should("give up after exceeding the retry count") {
+                    shouldThrow<JibriSession.StartException> {
+                        jibriSession.start()
+                    }
+                    verify(exactly = maxNumRetries + 1) { xmppConnection.sendPacketAndGetReply(any())}
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
If Jicofo encounters a Jibri error on the initial request, it throws and fails immediately because the assumption was that anything in the instances list should be present.  We've recently run into errors where a Jibri in a strange state is at the front of the queue and fails repeatedly: this means Jicofo fails each time but, for the next request, tries the same Jibri again.  Because we don't know how permanent the error state is for this Jibri, this PR adds an API to denote that a JibriSession encountered a transient error with the Jibri, which moves it to the back of the line.  It also retries in this case, similar to the retries we perform when getting an error response back from Jibri.