### PR TITLE
Send the HEX GID to JVB

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -724,7 +724,8 @@ public class JitsiMeetConferenceImpl
     {
         ColibriConferenceImpl colibriConference
             = (ColibriConferenceImpl) colibri.createNewConference();
-        colibriConference.setGID(String.valueOf(gid));
+        // JVB expects the hex string
+        colibriConference.setGID(Long.toHexString(gid));
 
         colibriConference.setConfig(config);
 


### PR DESCRIPTION
JVB parses the GID using `gid = Long.parseLong(gidStr, 16);` (VideobridgeShim.java)

https://github.com/jitsi/jicofo/issues/606