### PR TITLE
Clarify and enhance bridge selection log.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/BridgeSelectionStrategy.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/BridgeSelectionStrategy.java
@@ -102,8 +102,9 @@ public abstract class BridgeSelectionStrategy
             if (bridge != null)
             {
                 logger.info("Selected initial bridge " + bridge
-                        + " with stress=" + bridge.getLastReportedStressLevel()
-                        + " for participantRegion=" + participantRegion);
+                        + " with reported stress=" + bridge.getLastReportedStressLevel()
+                        + " for participantRegion=" + participantRegion
+                        + " using strategy " + this.getClass().getSimpleName());
             }
             else
             {


### PR DESCRIPTION
Note that the adjusted stress (taking new endpoints into account) is printed by the bridge's `toString()` method so this clarifies why the two values are different.