### PR TITLE
Add Content-Type to Shibboleth handler response

### DIFF
--- a/src/main/java/org/jitsi/jicofo/auth/ShibbolethHandler.java
+++ b/src/main/java/org/jitsi/jicofo/auth/ShibbolethHandler.java
@@ -229,6 +229,7 @@ class ShibbolethHandler
             return;
         }
 
+        response.setContentType("text/html");
         PrintWriter responseWriter = response.getWriter();
 
         String displayName = getShibAttr(request, "displayName");


### PR DESCRIPTION
Currently, the Shibboleth handler (/login) does not set a Content-Type:

![image](https://user-images.githubusercontent.com/46450505/97598090-d88a4b80-1a06-11eb-8fea-378e9e3463a4.png)

This can cause issues with certain reverse proxies, certain default Content-Type configurations, and `X-Content-Type-Options: nosniff` that may cause the HTML source code to appear in the browser window instead of being rendered

This PR adds the missing Content-Type header