### PR TITLE
Octo user migration fixes

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2823,9 +2823,12 @@ public class JitsiMeetConferenceImpl
         }
 
         /**
-         * Expires the COLIBRI channels for all participants.
-         * @return the list of participants which were removed from {@link #participants} as a result of this call
-         * (does not include the Octo participant).
+         * Expires the COLIBRI channels (via
+         * {@link Participant#terminateBridgeSession()}) for all
+         * participants.
+         * @return the list of participants which were removed from
+         * {@link #participants} as a result of this call (does not include
+         * the Octo participant).
          */
         private List<Participant> terminateAll()
         {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -912,6 +912,12 @@ public class JitsiMeetConferenceImpl
 
             participant.setChannelAllocator(channelAllocator);
             FocusBundleActivator.getSharedThreadPool().submit(channelAllocator);
+
+            if (reInvite)
+            {
+                propagateNewSourcesToOcto(
+                    participant.getBridgeSession(), participant.getSourcesCopy(), participant.getSourceGroupsCopy());
+            }
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo;
 
+import org.jetbrains.annotations.*;
 import org.jitsi.jicofo.bridge.*;
 import org.jitsi.osgi.*;
 import org.jitsi.utils.*;
@@ -1289,7 +1290,6 @@ public class JitsiMeetConferenceImpl
                 reason,
                 sendSessionTerminate));
 
-        BridgeSession bridgeSession;
         synchronized (participantLock)
         {
             Jid contactAddress = participant.getMucJid();
@@ -1308,26 +1308,13 @@ public class JitsiMeetConferenceImpl
                 participant.setJingleSession(null);
             }
 
-            bridgeSession = participant.terminateBridgeSession();
-
             boolean removed = participants.remove(participant);
             logger.info("Removed participant: " + removed + ", " + contactAddress);
         }
 
+        BridgeSession bridgeSession = terminateParticipantBridgeSession(participant);
         if (bridgeSession != null)
         {
-            MediaSourceMap removedSources = participant.getSourcesCopy();
-            MediaSourceGroupMap removedGroups = participant.getSourceGroupsCopy();
-
-            synchronized (bridges)
-            {
-                operationalBridges()
-                    .filter(bridge -> !bridge.equals(bridgeSession))
-                    .forEach(
-                        bridge -> bridge.removeSourcesFromOcto(
-                            removedSources, removedGroups));
-            }
-
             maybeExpireBridgeSession(bridgeSession);
         }
     }
@@ -2576,26 +2563,7 @@ public class JitsiMeetConferenceImpl
         {
             for (Participant participant : participants)
             {
-                BridgeSession session = participant.getBridgeSession();
-                participant.terminateBridgeSession();
-
-                // Expire the OctoEndpoints for this participant on other
-                // bridges.
-                if (session != null)
-                {
-                    MediaSourceMap removedSources = participant.getSourcesCopy();
-                    MediaSourceGroupMap removedGroups = participant.getSourceGroupsCopy();
-
-                    // Locking participantLock and the bridges is okay (or at
-                    // least used elsewhere).
-                    synchronized (bridges)
-                    {
-                        operationalBridges()
-                                .filter(bridge -> !bridge.equals(session))
-                                .forEach(
-                                    bridge -> bridge.removeSourcesFromOcto(removedSources, removedGroups));
-                    }
-                }
+                terminateParticipantBridgeSession(participant);
             }
             for (Participant participant : participants)
             {
@@ -2605,6 +2573,33 @@ public class JitsiMeetConferenceImpl
                         hasToStartMuted(participant, false));
             }
         }
+    }
+
+    private BridgeSession terminateParticipantBridgeSession(@NotNull Participant participant)
+    {
+        BridgeSession session = participant.getBridgeSession();
+        participant.terminateBridgeSession();
+
+        // Expire the OctoEndpoints for this participant on other
+        // bridges.
+        if (session != null)
+        {
+            MediaSourceMap removedSources = participant.getSourcesCopy();
+            MediaSourceGroupMap removedGroups = participant.getSourceGroupsCopy();
+
+            // Locking participantLock and the bridges is okay (or at
+            // least used elsewhere).
+            synchronized (bridges)
+            {
+                operationalBridges()
+                    .filter(bridge -> !bridge.equals(session))
+                    .forEach(
+                        bridge -> bridge.removeSourcesFromOcto(
+                            removedSources, removedGroups));
+            }
+        }
+
+        return session;
     }
 
     /**


### PR DESCRIPTION
This attempts to fix is the following case of moving participants to another bridge after a failure:

Endpoints A and B on jvb1, endpoints C and D on jvb2. Kill jvb1. Endpoints A and B are moved to jvb3. The following happens:
- Video between C and D continues to work, but not for any other endpoints.
- The jicofo logs seem normal — it sees jvb1 go away, allocates channels on a new bridge, sends transport-replace, receives transport-accept.
- On jvb2 things seem normal — remove relay for jvb1, add relay for jvb3.
- jvb3 receives a conference request and creates OctoEndpoint-s for endpoints A and B. Then it replaces that with local Endpoint instances and gathers candidates. While in that state, jvb3 spams the logs with `Received a message with an unexpected type: EndpointConnectivityStatusChangeEvent.` (still investigating)

This PR fixes several issues:

* The first problem is the weird transition from octo endpoints to local endpoint again on jvb3. This is fixed in a888ec72a86518eebb511b86358455e418105ed1. The fix prevents the inclusion of the endpoints of the crashed bridge (jvb1) in the octo channel allocation on the bridge that was chosen to replace the crashed bridge (jvb3).
* The second problem is that after a re-invite, there's no source/source group propagation, preventing media to flow back to the local participants of the old healthy bridge. This is fixed in https://github.com/jitsi/jicofo/pull/617/commits/e9f1c3bf3257fd8d3c88343fb9b76a520f50b313