### PR TITLE
Jibri send 'stopRequst' with session ID.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
+++ b/src/main/java/org/jitsi/jicofo/recording/jibri/JibriSession.java
@@ -401,6 +401,7 @@ public class JibriSession
         stopRequest.setType(IQ.Type.set);
         stopRequest.setTo(currentJibriJid);
         stopRequest.setAction(JibriIq.Action.STOP);
+        stopRequest.setSessionId(this.sessionId);
 
         logger.info("Trying to stop: " + stopRequest.toXML());
 


### PR DESCRIPTION
I'm working on Jibri to make it supporting recording multi rooms parallelly. The jibri need the session ID to decide which room recording should stop.