### PR TITLE
feat: Adds conference property in the presence for terminate-restart.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-15-g813e4c4</version>
+      <version>1.0-18-gee3ce37</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProtocolProvider.java
@@ -152,6 +152,7 @@ public class XmppProtocolProvider
      * Initializes Jicofo's feature list.
      */
     private void initializeFeaturesList() {
+        // This can be removed once all clients are updated reading this from the presence conference property
         ServiceDiscoveryManager serviceDiscoveryManager = ServiceDiscoveryManager.getInstanceFor(connection);
         serviceDiscoveryManager.addFeature("https://jitsi.org/meet/jicofo/terminate-restart");
     }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -527,20 +527,32 @@ public class JitsiMeetConferenceImpl
 
         chatRoom.join();
 
+        Collection<ExtensionElement> presenceExtensions = new ArrayList<>();
+
         // Advertise shared Etherpad document
-        meetTools.sendPresenceExtension(chatRoom, EtherpadPacketExt.forDocumentName(etherpadName));
+        presenceExtensions.add(EtherpadPacketExt.forDocumentName(etherpadName));
 
         ComponentVersionsExtension versionsExtension = new ComponentVersionsExtension();
         versionsExtension.addComponentVersion(
                 ComponentVersionsExtension.COMPONENT_FOCUS,
                 CurrentVersionImpl.VERSION.toString());
-        meetTools.sendPresenceExtension(chatRoom, versionsExtension);
+        presenceExtensions.add(versionsExtension);
+
+        setConferenceProperty(
+            ConferenceProperties.KEY_SUPPORTS_SESSION_RESTART,
+            Boolean.TRUE.toString(),
+            false);
 
         // Advertise the conference creation time in presence
         setConferenceProperty(
             ConferenceProperties.KEY_CREATED_MS,
             Long.toString(System.currentTimeMillis()),
             false);
+
+        presenceExtensions.add(ConferenceProperties.clone(conferenceProperties));
+
+        // updates presence with presenceExtensions and sends it
+        chatRoom.modifyPresence(null, presenceExtensions);
     }
 
     /**

--- a/src/test/java/mock/muc/MockMultiUserChat.java
+++ b/src/test/java/mock/muc/MockMultiUserChat.java
@@ -105,7 +105,7 @@ public class MockMultiUserChat
         Collection<ExtensionElement> toRemove,
         Collection<ExtensionElement> toAdd)
     {
-        throw new RuntimeException("not implemented");
+        //FIXME: to be tested
     }
 
     @Override


### PR DESCRIPTION
Web and mobile clients can use that to quickly resolve features supported in the conference, rather than doing the expensive disco-info.