### PR TITLE
fix: Fix deadlock in bridge selector.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/BridgeSelector.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/BridgeSelector.java
@@ -90,26 +90,31 @@ public class BridgeSelector
      * @param stats the last reported statistics
      * @return the {@link Bridge} instance for thee given JID.
      */
-    synchronized public Bridge addJvbAddress(
+    public Bridge addJvbAddress(
             Jid bridgeJid, ColibriStatsExtension stats)
     {
-        Bridge bridge = bridges.get(bridgeJid);
-        if (bridge != null)
+        Bridge newBridge;
+        synchronized(this)
         {
-            bridge.setStats(stats);
-            return bridge;
-        }
+            Bridge bridge = bridges.get(bridgeJid);
+            if (bridge != null)
+            {
+                bridge.setStats(stats);
+                return bridge;
+            }
 
-        Bridge newBridge = new Bridge(bridgeJid);
-        if (stats != null)
-        {
-            newBridge.setStats(stats);
+            newBridge = new Bridge(bridgeJid);
+            if (stats != null)
+            {
+                newBridge.setStats(stats);
+            }
+            logger.info("Added new videobridge: " + newBridge);
+            bridges.put(bridgeJid, newBridge);
         }
-        logger.info("Added new videobridge: " + newBridge);
-        bridges.put(bridgeJid, newBridge);
 
         notifyBridgeUp(newBridge);
         jvbDoctor.addBridge(newBridge.getJid());
+
         return newBridge;
     }
 
@@ -120,11 +125,15 @@ public class BridgeSelector
      * @param bridgeJid the JID of videobridge to be removed from this selector's
      *                  set of videobridges.
      */
-    synchronized public void removeJvbAddress(Jid bridgeJid)
+    public void removeJvbAddress(Jid bridgeJid)
     {
-        logger.info("Removing JVB: " + bridgeJid);
+        Bridge bridge;
+        synchronized(this)
+        {
+            logger.info("Removing JVB: " + bridgeJid);
 
-        Bridge bridge = bridges.remove(bridgeJid);
+            bridge = bridges.remove(bridgeJid);
+        }
 
         if (bridge != null)
         {
@@ -288,19 +297,6 @@ public class BridgeSelector
     public void dispose()
     {
         jvbDoctor.stop();
-    }
-
-    /**
-     * @return the {@link Bridge} for the bridge with a particular XMPP
-     * JID.
-     * @param jid the JID of the bridge.
-     */
-    public Bridge getBridge(Jid jid)
-    {
-        synchronized (bridges)
-        {
-            return bridges.get(jid);
-        }
     }
 
     public int getBridgeCount()


### PR DESCRIPTION
When participant joins and a bridge goes down at the same time we can get this:
Found one Java-level deadlock:
=============================
"Smack-Single Threaded Executor 1 (0)":
  waiting to lock monitor 0x00007f4a580f3538 (object 0x00000006c28d1af8, a java.util.LinkedList),
  which is held by "Smack-Single Threaded Executor 1 (1)"
"Smack-Single Threaded Executor 1 (1)":
  waiting to lock monitor 0x00007f4a3801c0a8 (object 0x00000006c01c4ae0, a org.jitsi.jicofo.bridge.BridgeSelector),
  which is held by "Smack-Single Threaded Executor 1 (0)"

Java stack information for the threads listed above:
===================================================
"Smack-Single Threaded Executor 1 (0)":
	at org.jitsi.jicofo.JitsiMeetConferenceImpl.onMultipleBridgesDown(JitsiMeetConferenceImpl.java:2372)
	- waiting to lock <0x00000006c28d1af8> (a java.util.LinkedList)
	at org.jitsi.jicofo.JitsiMeetConferenceImpl.onBridgeDown(JitsiMeetConferenceImpl.java:2359)
	at org.jitsi.jicofo.JitsiMeetConferenceImpl$BridgeSelectorEventHandler.bridgeRemoved(JitsiMeetConferenceImpl.java:3066)
	at org.jitsi.jicofo.bridge.BridgeSelector.lambda$notifyBridgeDown$2(BridgeSelector.java:271)
	at org.jitsi.jicofo.bridge.BridgeSelector$$Lambda$226/263140428.invoke(Unknown Source)
	at org.jitsi.utils.event.EventEmitter.fireEvent(EventEmitter.kt:25)
	at org.jitsi.jicofo.bridge.BridgeSelector.notifyBridgeDown(BridgeSelector.java:269)
	at org.jitsi.jicofo.bridge.BridgeSelector.removeJvbAddress(BridgeSelector.java:131)
	- locked <0x00000006c01c4ae0> (a org.jitsi.jicofo.bridge.BridgeSelector)
	at org.jitsi.jicofo.bridge.BridgeMucDetector.notifyInstanceOffline(BridgeMucDetector.java:89)
	at org.jitsi.jicofo.xmpp.BaseBrewery.removeInstance(BaseBrewery.java:409)
	at org.jitsi.jicofo.xmpp.BaseBrewery.memberPresenceChanged(BaseBrewery.java:248)
	- locked <0x00000006c01c6028> (a org.jitsi.jicofo.bridge.BridgeMucDetector)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.lambda$notifyMemberLeft$2(ChatRoomImpl.java:928)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl$$Lambda$221/735972004.accept(Unknown Source)
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:891)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.notifyMemberLeft(ChatRoomImpl.java:928)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.access$500(ChatRoomImpl.java:51)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl$MemberListener.left(ChatRoomImpl.java:1335)
	at org.jivesoftware.smackx.muc.MultiUserChat$3.processStanza(MultiUserChat.java:242)
	at org.jivesoftware.smack.AbstractXMPPConnection$6.run(AbstractXMPPConnection.java:1263)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
"Smack-Single Threaded Executor 1 (1)":
	at org.jitsi.jicofo.bridge.BridgeSelector.selectBridge(BridgeSelector.java:205)
	- waiting to lock <0x00000006c01c4ae0> (a org.jitsi.jicofo.bridge.BridgeSelector)
	at org.jitsi.jicofo.JitsiMeetConferenceImpl.selectBridge(JitsiMeetConferenceImpl.java:739)
	at org.jitsi.jicofo.JitsiMeetConferenceImpl.inviteParticipant(JitsiMeetConferenceImpl.java:811)
	- locked <0x00000006c28d1af8> (a java.util.LinkedList)
	at org.jitsi.jicofo.JitsiMeetConferenceImpl.inviteChatMember(JitsiMeetConferenceImpl.java:713)
	- locked <0x00000006c28d1a08> (a java.lang.Object)
	at org.jitsi.jicofo.JitsiMeetConferenceImpl.onMemberJoined(JitsiMeetConferenceImpl.java:660)
	- locked <0x00000006c28d1a08> (a java.lang.Object)
	at org.jitsi.jicofo.ChatRoomRoleAndPresence.memberPresenceChanged(ChatRoomRoleAndPresence.java:158)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.lambda$notifyMemberJoined$1(ChatRoomImpl.java:918)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl$$Lambda$216/1349166388.accept(Unknown Source)
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:891)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.notifyMemberJoined(ChatRoomImpl.java:918)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.processOtherPresence(ChatRoomImpl.java:1221)
	at org.jitsi.impl.protocol.xmpp.ChatRoomImpl.processPresence(ChatRoomImpl.java:1270)
	at org.jivesoftware.smackx.muc.MultiUserChat$3.processStanza(MultiUserChat.java:251)
	at org.jivesoftware.smack.AbstractXMPPConnection$6.run(AbstractXMPPConnection.java:1263)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

Found 1 deadlock.