### PR TITLE
Added mute video moderation feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-18-gee3ce37</version>
+      <version>1.0-19-g7f14fef</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -649,28 +649,29 @@ public class ColibriConferenceImpl
      * {@inheritDoc}
      */
     @Override
-    public boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute)
+    public boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute, @Nullable MediaType mediaType)
     {
         if (checkIfDisposed("muteParticipant"))
         {
             return false;
         }
+        MediaType muteMediaType = Optional.ofNullable(mediaType).orElse(MediaType.AUDIO);
 
         ColibriConferenceIQ request = new ColibriConferenceIQ();
         request.setID(conferenceState.getID());
         request.setName(conferenceState.getName());
 
-        ColibriConferenceIQ.Content audioContent = channelsInfo.getContent("audio");
+        ColibriConferenceIQ.Content content = channelsInfo.getContent((muteMediaType == MediaType.VIDEO) ? "video" : "audio");
 
-        if (audioContent == null || isBlank(request.getID()))
+        if (content == null || isBlank(request.getID()))
         {
-            logger.error("Failed to mute - no audio content." +
+            logger.error("Failed to mute - no " + muteMediaType.toString() + " content." +
                              " Conf ID: " + request.getID());
             return false;
         }
 
-        ColibriConferenceIQ.Content requestContent = new ColibriConferenceIQ.Content(audioContent.getName());
-        for (ColibriConferenceIQ.Channel channel : audioContent.getChannels())
+        ColibriConferenceIQ.Content requestContent = new ColibriConferenceIQ.Content(content.getName());
+        for (ColibriConferenceIQ.Channel channel : content.getChannels())
         {
             ColibriConferenceIQ.Channel requestChannel = new ColibriConferenceIQ.Channel();
             requestChannel.setID(channel.getID());

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/colibri/ColibriConferenceImpl.java
@@ -21,6 +21,7 @@ import org.jitsi.jicofo.xmpp.*;
 import org.jitsi.protocol.xmpp.colibri.*;
 import org.jitsi.protocol.xmpp.colibri.exception.*;
 import org.jitsi.protocol.xmpp.util.*;
+import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.stats.*;
 import org.jitsi.xmpp.extensions.colibri.*;
@@ -649,23 +650,22 @@ public class ColibriConferenceImpl
      * {@inheritDoc}
      */
     @Override
-    public boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute, @Nullable MediaType mediaType)
+    public boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute, MediaType mediaType)
     {
         if (checkIfDisposed("muteParticipant"))
         {
             return false;
         }
-        MediaType muteMediaType = Optional.ofNullable(mediaType).orElse(MediaType.AUDIO);
 
         ColibriConferenceIQ request = new ColibriConferenceIQ();
         request.setID(conferenceState.getID());
         request.setName(conferenceState.getName());
 
-        ColibriConferenceIQ.Content content = channelsInfo.getContent((muteMediaType == MediaType.VIDEO) ? "video" : "audio");
+        ColibriConferenceIQ.Content content = channelsInfo.getContent(mediaType.toString());
 
         if (content == null || isBlank(request.getID()))
         {
-            logger.error("Failed to mute - no " + muteMediaType.toString() + " content." +
+            logger.error("Failed to mute - no " + mediaType.toString() + " content." +
                              " Conf ID: " + request.getID());
             return false;
         }

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2083,10 +2083,12 @@ public class JitsiMeetConferenceImpl
      * @param fromJid MUC jid of the participant that requested mute status change.
      * @param toBeMutedJid MUC jid of the participant whose mute status will be changed (eventually).
      * @param doMute the new audio mute status to set.
+     * @param mediaType optional mediaType of the channel to mute, defaults to AUDIO.
      * @return <tt>true</tt> if status has been set successfully.
      */
-    public boolean handleMuteRequest(Jid fromJid, Jid toBeMutedJid, boolean doMute)
+    public boolean handleMuteRequest(Jid fromJid, Jid toBeMutedJid, boolean doMute, @Nullable MediaType mediaType)
     {
+        MediaType muteMediaType = Optional.ofNullable(mediaType).orElse(MediaType.AUDIO);
         Participant principal = findParticipantForRoomJid(fromJid);
         if (principal == null)
         {
@@ -2137,7 +2139,7 @@ public class JitsiMeetConferenceImpl
         boolean succeeded
             = bridgeSession != null
                     && participantChannels != null
-                    && bridgeSession.colibriConference.muteParticipant(participantChannels, doMute);
+                    && bridgeSession.colibriConference.muteParticipant(participantChannels, doMute, muteMediaType);
 
         if (succeeded)
         {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2142,7 +2142,11 @@ public class JitsiMeetConferenceImpl
 
         if (succeeded)
         {
-            participant.setMuted(doMute);
+            if (mediaType === MediaType.AUDIO) {
+                participant.setMuted(doMute);
+            } else if (mediaType === MediaType.VIDEO) {
+                participant.setVideoMuted(doMute);
+            }
         }
 
         return succeeded;

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2086,9 +2086,8 @@ public class JitsiMeetConferenceImpl
      * @param mediaType optional mediaType of the channel to mute, defaults to AUDIO.
      * @return <tt>true</tt> if status has been set successfully.
      */
-    public boolean handleMuteRequest(Jid fromJid, Jid toBeMutedJid, boolean doMute, @Nullable MediaType mediaType)
+    public boolean handleMuteRequest(Jid fromJid, Jid toBeMutedJid, boolean doMute, MediaType mediaType)
     {
-        MediaType muteMediaType = Optional.ofNullable(mediaType).orElse(MediaType.AUDIO);
         Participant principal = findParticipantForRoomJid(fromJid);
         if (principal == null)
         {
@@ -2139,7 +2138,7 @@ public class JitsiMeetConferenceImpl
         boolean succeeded
             = bridgeSession != null
                     && participantChannels != null
-                    && bridgeSession.colibriConference.muteParticipant(participantChannels, doMute, muteMediaType);
+                    && bridgeSession.colibriConference.muteParticipant(participantChannels, doMute, mediaType);
 
         if (succeeded)
         {

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -2142,9 +2142,9 @@ public class JitsiMeetConferenceImpl
 
         if (succeeded)
         {
-            if (mediaType === MediaType.AUDIO) {
+            if (mediaType == MediaType.AUDIO) {
                 participant.setMuted(doMute);
-            } else if (mediaType === MediaType.VIDEO) {
+            } else if (mediaType == MediaType.VIDEO) {
                 participant.setVideoMuted(doMute);
             }
         }

--- a/src/main/java/org/jitsi/jicofo/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/Participant.java
@@ -103,6 +103,11 @@ public class Participant
     private boolean mutedStatus;
 
     /**
+     * Remembers participant's video muted status.
+     */
+    private boolean videoMutedStatus;
+
+    /**
      * Creates new {@link Participant} for given chat room member.
      *
      * @param roomMember the {@link ChatRoomMember} that represent this
@@ -367,6 +372,25 @@ public class Participant
     public boolean isMuted()
     {
         return mutedStatus;
+    }
+
+    /**
+     * Sets video muted status of this participant.
+     * @param mutedStatus new muted status to set.
+     */
+    public void setVideoMuted(boolean mutedStatus)
+    {
+        this.videoMutedStatus = mutedStatus;
+    }
+
+    /**
+     * Return a <tt>Boolean</tt> which informs about this participant's video
+     * muted status. The <tt>null</tt> value stands for 'unknown'/not signalled,
+     * <tt>true</tt> for muted and <tt>false</tt> means unmuted.
+     */
+    public Boolean isVideoMuted()
+    {
+        return videoMutedStatus;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/xmpp/IqHandler.java
+++ b/src/main/java/org/jitsi/jicofo/xmpp/IqHandler.java
@@ -78,6 +78,7 @@ public class IqHandler
         this.authenticationIqHandler = authenticationIqHandler;
 
         MuteIqProvider.registerMuteIqProvider();
+        MuteVideoIqProvider.registerMuteVideoIqProvider();
         new RayoIqProvider().registerRayoIQs();
         StartMutedProvider.registerStartMutedProvider();
     }
@@ -251,7 +252,7 @@ public class IqHandler
 
             if (!muteVideoIq.getFrom().equals(jid))
             {
-                MuteIq muteStatusUpdate = new MuteIq();
+                MuteVideoIq muteStatusUpdate = new MuteVideoIq();
                 muteStatusUpdate.setActor(from);
                 muteStatusUpdate.setType(IQ.Type.set);
                 muteStatusUpdate.setTo(jid);

--- a/src/main/java/org/jitsi/jicofo/xmpp/IqHandler.java
+++ b/src/main/java/org/jitsi/jicofo/xmpp/IqHandler.java
@@ -25,6 +25,7 @@ import org.jitsi.xmpp.extensions.rayo.*;
 
 import org.jitsi.xmpp.extensions.jitsimeet.*;
 import org.jitsi.jicofo.jigasi.*;
+import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.iqrequest.*;
@@ -58,6 +59,7 @@ public class IqHandler
     private ExtendedXmppConnection connection;
 
     private final MuteIqHandler muteIqHandler = new MuteIqHandler();
+    private final MuteVideoIqHandler muteVideoIqHandler = new MuteVideoIqHandler();
     private final DialIqHandler dialIqHandler = new DialIqHandler();
     @NotNull
     private final ConferenceIqHandler conferenceIqHandler;
@@ -89,6 +91,7 @@ public class IqHandler
 
         logger.info("Registering IQ handlers with XmppConnection.");
         connection.registerIQRequestHandler(muteIqHandler);
+        connection.registerIQRequestHandler(muteVideoIqHandler);
         connection.registerIQRequestHandler(dialIqHandler);
         connection.registerIQRequestHandler(conferenceIqHandler);
         if (authenticationIqHandler != null)
@@ -113,6 +116,24 @@ public class IqHandler
         public IQ handleIQRequest(IQ iqRequest)
         {
             return handleMuteIq((MuteIq) iqRequest);
+        }
+    }
+
+    private class MuteVideoIqHandler extends AbstractIqRequestHandler
+    {
+        MuteVideoIqHandler()
+        {
+            super(
+                MuteVideoIq.ELEMENT_NAME,
+                MuteVideoIq.NAMESPACE,
+                IQ.Type.set,
+                Mode.sync);
+        }
+
+        @Override
+        public IQ handleIQRequest(IQ iqRequest)
+        {
+            return handleMuteVideoIq((MuteVideoIq) iqRequest);
         }
     }
 
@@ -144,6 +165,7 @@ public class IqHandler
         if (connection != null)
         {
             connection.unregisterIQRequestHandler(muteIqHandler);
+            connection.unregisterIQRequestHandler(muteVideoIqHandler);
             connection.unregisterIQRequestHandler(dialIqHandler);
             connection = null;
         }
@@ -179,7 +201,7 @@ public class IqHandler
 
         IQ result;
 
-        if (conference.handleMuteRequest(muteIq.getFrom(), jid, doMute))
+        if (conference.handleMuteRequest(muteIq.getFrom(), jid, doMute, MediaType.AUDIO))
         {
             result = IQ.createResultIQ(muteIq);
 
@@ -198,6 +220,50 @@ public class IqHandler
         else
         {
             result = IQ.createErrorResponse(muteIq, XMPPError.getBuilder(XMPPError.Condition.internal_server_error));
+        }
+
+        return result;
+    }
+
+    private IQ handleMuteVideoIq(MuteVideoIq muteVideoIq)
+    {
+        Boolean doMute = muteVideoIq.getMute();
+        Jid jid = muteVideoIq.getJid();
+
+        if (doMute == null || jid == null)
+        {
+            return IQ.createErrorResponse(muteVideoIq, XMPPError.getBuilder(XMPPError.Condition.item_not_found));
+        }
+
+        Jid from = muteVideoIq.getFrom();
+        JitsiMeetConferenceImpl conference = getConferenceForMucJid(from);
+        if (conference == null)
+        {
+            logger.debug("Mute error: room not found for JID: " + from);
+            return IQ.createErrorResponse(muteVideoIq, XMPPError.getBuilder(XMPPError.Condition.item_not_found));
+        }
+
+        IQ result;
+
+        if (conference.handleMuteRequest(muteVideoIq.getFrom(), jid, doMute, MediaType.VIDEO))
+        {
+            result = IQ.createResultIQ(muteVideoIq);
+
+            if (!muteVideoIq.getFrom().equals(jid))
+            {
+                MuteIq muteStatusUpdate = new MuteIq();
+                muteStatusUpdate.setActor(from);
+                muteStatusUpdate.setType(IQ.Type.set);
+                muteStatusUpdate.setTo(jid);
+
+                muteStatusUpdate.setMute(doMute);
+
+                connection.tryToSendStanza(muteStatusUpdate);
+            }
+        }
+        else
+        {
+            result = IQ.createErrorResponse(muteVideoIq, XMPPError.getBuilder(XMPPError.Condition.internal_server_error));
         }
 
         return result;

--- a/src/main/java/org/jitsi/jicofo/xmpp/IqHandler.java
+++ b/src/main/java/org/jitsi/jicofo/xmpp/IqHandler.java
@@ -263,7 +263,8 @@ public class IqHandler
         }
         else
         {
-            result = IQ.createErrorResponse(muteVideoIq, XMPPError.getBuilder(XMPPError.Condition.internal_server_error));
+            result = IQ.createErrorResponse(
+                muteVideoIq, XMPPError.getBuilder(XMPPError.Condition.internal_server_error));
         }
 
         return result;

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -256,11 +256,12 @@ public interface ColibriConference
      * direction to {@code sendonly}.
      * @param channelsInfo the IQ that describes the channels to be muted.
      * @param mute <tt>true</tt> to mute or <tt>false</tt> to unmute audio
+     * @param mediaType optional mediaType of the channel to mute, defaults to AUDIO.
      * channels described in <tt>channelsInfo</tt>.
      * @return <tt>true</tt> if the operation has succeeded or <tt>false</tt>
      * otherwise.
      */
-    boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute);
+    boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute, @Nullable MediaType mediaType);
 
     /**
      * Disposes of any resources allocated by this instance. Once disposed this

--- a/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/colibri/ColibriConference.java
@@ -18,6 +18,7 @@
 package org.jitsi.protocol.xmpp.colibri;
 
 import org.jitsi.protocol.xmpp.colibri.exception.*;
+import org.jitsi.utils.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 
@@ -252,17 +253,17 @@ public interface ColibriConference
     void expireConference();
 
     /**
-     * Mutes audio channels described in given IQ by changing their media
+     * Mutes audio  or video channels described in given IQ by changing their media
      * direction to {@code sendonly}.
      * @param channelsInfo the IQ that describes the channels to be muted.
-     * @param mute <tt>true</tt> to mute or <tt>false</tt> to unmute audio
-     * @param mediaType optional mediaType of the channel to mute, defaults to AUDIO.
-     * channels described in <tt>channelsInfo</tt>.
+     * @param mute <tt>true</tt> to mute or <tt>false</tt> to unmute channels 
+     * described in <tt>channelsInfo</tt>.
+     * @param mediaType optional mediaType of the channel to mute; defaults to audio.
      * @return <tt>true</tt> if the operation has succeeded or <tt>false</tt>
      * otherwise.
      */
-    boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute, @Nullable MediaType mediaType);
-
+    boolean muteParticipant(ColibriConferenceIQ channelsInfo, boolean mute, MediaType mediaType);
+    
     /**
      * Disposes of any resources allocated by this instance. Once disposed this
      * instance must not be used anymore.


### PR DESCRIPTION
This change adds the ability for a moderator to deactivate the camera of other participants. The implementation uses the same approach that was implemented to mute audio of other participants.

This feature consists of multiple PRs:
- https://github.com/jitsi/jitsi-media-transform/pull/329
- https://github.com/jitsi/jitsi-videobridge/pull/1570
- https://github.com/jitsi/jitsi-xmpp-extensions/pull/37
- https://github.com/jitsi/jicofo/pull/695
- https://github.com/jitsi/lib-jitsi-meet/pull/1496
- https://github.com/jitsi/jitsi-meet/pull/8630