### PR TITLE
 @bgrozev fix: Do not send source-add for injected SSRCs. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-20-g330a8f4</version>
+      <version>1.0-21-g3651d97</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1671,6 +1671,7 @@ public class JitsiMeetConferenceImpl
             long ssrc = RANDOM.nextInt() & 0xffff_ffffL;
             logger.info(participant + " did not advertise any SSRCs. Injecting " + ssrc);
             sourcePacketExtension.setSSRC(ssrc);
+            sourcePacketExtension.setInjected(true);
             sourcesAdvertised.addSource(MediaType.AUDIO.toString(), sourcePacketExtension);
         }
         MediaSourceMap sourcesAdded;

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -267,7 +267,7 @@ public abstract class AbstractOperationSetJingle
                         ssrcs.getSourcesForMedia("audio").stream().allMatch(SourcePacketExtension::isInjected);
         if (onlyInjected)
         {
-            logger.info("Suppressing source-remove for injected SSRC.");
+            logger.debug("Suppressing source-add for injected SSRC.");
             return;
         }
 
@@ -377,7 +377,7 @@ public abstract class AbstractOperationSetJingle
                         ssrcs.getSourcesForMedia("audio").stream().allMatch(SourcePacketExtension::isInjected);
         if (onlyInjected)
         {
-            logger.info("Suppressing source-remove for injected SSRC.");
+            logger.debug("Suppressing source-remove for injected SSRC.");
             return;
         }
 

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -262,21 +262,26 @@ public abstract class AbstractOperationSetJingle
                                 MediaSourceGroupMap ssrcGroupMap,
                                 JingleSession        session)
     {
-        JingleIQ addSourceIq
-            = new JingleIQ(JingleAction.SOURCEADD, session.getSessionID());
+        boolean onlyInjected =
+                ssrcs.getSourcesForMedia("video").isEmpty() &&
+                        ssrcs.getSourcesForMedia("audio").stream().allMatch(SourcePacketExtension::isInjected);
+        if (onlyInjected)
+        {
+            logger.info("Suppressing source-remove for injected SSRC.");
+            return;
+        }
 
+        JingleIQ addSourceIq = new JingleIQ(JingleAction.SOURCEADD, session.getSessionID());
         addSourceIq.setFrom(getOurJID());
         addSourceIq.setType(IQ.Type.set);
 
         for (String media : ssrcs.getMediaTypes())
         {
-            ContentPacketExtension content
-                = new ContentPacketExtension();
+            ContentPacketExtension content = new ContentPacketExtension();
 
             content.setName(media);
 
-            RtpDescriptionPacketExtension rtpDesc
-                = new RtpDescriptionPacketExtension();
+            RtpDescriptionPacketExtension rtpDesc = new RtpDescriptionPacketExtension();
 
             rtpDesc.setMedia(media);
 
@@ -365,10 +370,18 @@ public abstract class AbstractOperationSetJingle
     @Override
     public void sendRemoveSourceIQ(MediaSourceMap ssrcs,
                                    MediaSourceGroupMap ssrcGroupMap,
-                                   JingleSession        session)
+                                   JingleSession session)
     {
-        JingleIQ removeSourceIq = new JingleIQ(JingleAction.SOURCEREMOVE,
-                session.getSessionID());
+        boolean onlyInjected =
+                ssrcs.getSourcesForMedia("video").isEmpty() &&
+                        ssrcs.getSourcesForMedia("audio").stream().allMatch(SourcePacketExtension::isInjected);
+        if (onlyInjected)
+        {
+            logger.info("Suppressing source-remove for injected SSRC.");
+            return;
+        }
+
+        JingleIQ removeSourceIq = new JingleIQ(JingleAction.SOURCEREMOVE, session.getSessionID());
 
         removeSourceIq.setFrom(getOurJID());
         removeSourceIq.setType(IQ.Type.set);

--- a/src/main/kotlin/org/jitsi/impl/protocol/xmpp/JingleStats.kt
+++ b/src/main/kotlin/org/jitsi/impl/protocol/xmpp/JingleStats.kt
@@ -1,0 +1,41 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015-Present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.impl.protocol.xmpp
+
+import org.jitsi.xmpp.extensions.jingle.JingleAction
+import org.json.simple.JSONObject
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+class JingleStats {
+    private val stanzasReceivedByAction: MutableMap<JingleAction, AtomicInteger> = ConcurrentHashMap()
+    private val stanzasSentByAction: MutableMap<JingleAction, AtomicInteger> = ConcurrentHashMap()
+
+    fun stanzaReceived(action: JingleAction) {
+        stanzasReceivedByAction.computeIfAbsent(action) { AtomicInteger() }.incrementAndGet()
+    }
+    fun stanzaSent(action: JingleAction) {
+        stanzasSentByAction.computeIfAbsent(action) { AtomicInteger() }.incrementAndGet()
+    }
+
+    fun toJson() = JSONObject().apply {
+        this["sent"] = stanzasSentByAction.map { it.key to it.value.get() }.toMap()
+        this["received"] = stanzasReceivedByAction.map { it.key to it.value.get() }.toMap()
+    }
+}

--- a/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -46,6 +46,7 @@ import org.jitsi.jicofo.xmpp.XmppConnectionConfig
 import org.jitsi.jicofo.xmpp.XmppProviderFactory
 import org.jitsi.jicofo.xmpp.XmppServices
 import org.jitsi.jicofo.xmpp.initializeSmack
+import org.jitsi.protocol.xmpp.AbstractOperationSetJingle
 import org.jitsi.rest.JettyBundleActivatorConfig
 import org.jitsi.rest.createServer
 import org.jitsi.rest.isEnabled
@@ -247,6 +248,7 @@ open class JicofoServices {
         jigasiDetector?.let { put("jigasi_detector", it.stats) }
         putAll(ColibriConferenceImpl.stats.toJson())
         put("threads", ManagementFactory.getThreadMXBean().threadCount)
+        put("jingle", AbstractOperationSetJingle.getStats())
     }
 
     companion object {


### PR DESCRIPTION
Do not send source-add for injected SSRCs because Octo currently requires each endpoint to have at least one associated SSRC, jicofo injects a dummy audio SSRC for endpoints that do not advertise any SSRCs of their own. This makes sure that the dummy SSRCs are kept only for Octo and not propagated to other endpoints.