### PR TITLE
handles spaces around hostname

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -29,7 +29,7 @@ case "$1" in
             db_input critical jitsi-videobridge/jvb-hostname || true
             db_go
         fi
-        JVB_HOSTNAME="$RET"
+        JVB_HOSTNAME=$(echo "$RET" | xargs echo -n)
 
         # generate config on new install
         if [ "$OLDCONFIG" = "false" ] || [ "$JVB_HOSTNAME" != "$JICOFO_HOSTNAME" ]; then


### PR DESCRIPTION
((users doubleclick a host name and paste result in the installer)
how to reproduce ? install in a clean instance and add a space before the host name
Result:
https://community.jitsi.org/t/installation-problem-on-ubuntu-20-04-2-lts/94776
see also https://github.com/jitsi/jitsi-meet/pull/8728