### PR TITLE
Fixes blocking receiver thread

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1307,7 +1307,7 @@ public class JitsiMeetConferenceImpl
 
         if (!"failed".equalsIgnoreCase(iceState))
         {
-            logger.info(String.format("Ignored ice-state %s from %s state: %s", iceState, address));
+            logger.info(String.format("Ignored ice-state %s from %s", iceState, address));
 
             return null;
         }

--- a/src/main/java/org/jitsi/jicofo/xmpp/IqHandler.java
+++ b/src/main/java/org/jitsi/jicofo/xmpp/IqHandler.java
@@ -309,8 +309,6 @@ public class IqHandler
             return IQ.createErrorResponse(dialIq, XMPPError.getBuilder(XMPPError.Condition.not_allowed));
         }
 
-        final List<Jid> excludeList = exclude == null ? new ArrayList<>() : exclude;
-
         Set<String> bridgeRegions = conference.getBridges().keySet().stream()
             .map(Bridge::getRegion)
             .filter(Objects::nonNull)
@@ -319,7 +317,7 @@ public class IqHandler
         // Check if Jigasi is available
         JicofoServices jicofoServices = Objects.requireNonNull(JicofoServices.jicofoServicesSingleton);
         JigasiDetector detector = jicofoServices.getJigasiDetector();
-        Jid jigasiJid = detector == null ? null : detector.selectSipJigasi(excludeList, bridgeRegions);
+        Jid jigasiJid = detector == null ? null : detector.selectSipJigasi(exclude, bridgeRegions);
 
         if (jigasiJid == null)
         {
@@ -355,10 +353,10 @@ public class IqHandler
                     {
                         if (retryCount > 0)
                         {
-                            excludeList.add(jigasiJid);
+                            exclude.add(jigasiJid);
 
                             // let's retry lowering the number of attempts
-                            IQ result = this.handleRayoIQ(dialIq, retryCount - 1, excludeList);
+                            IQ result = this.handleRayoIQ(dialIq, retryCount - 1, exclude);
                             if (result != null)
                             {
                                 connection.sendStanza(result);


### PR DESCRIPTION
I started doing it, but then I found that there are 3 more places like this that will need similar changes and those are the grantOwner, start Jibri and start transcriber.

Or we can change so that we have a pool of threads executing these tasks ... WDYT?

People were asking whether recording started taking a little bit longer, I guess the same is happening ... 