### PR TITLE
fix: Adds a nullcheck fixes NPE.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/health/JicofoHealthChecker.java
+++ b/src/main/java/org/jitsi/jicofo/health/JicofoHealthChecker.java
@@ -201,7 +201,7 @@ public class JicofoHealthChecker implements HealthCheckService
         try
         {
             connection.addSyncStanzaListener(
-                listener, stanza -> stanza.getStanzaId().equals(p.getStanzaId())
+                listener, stanza -> stanza.getStanzaId() != null && stanza.getStanzaId().equals(p.getStanzaId())
             );
             connection.sendStanza(p);
 


### PR DESCRIPTION
WARNING: [15] org.jivesoftware.smack.AbstractXMPPConnection.callConnectionClosedOnErrorListener: Connection XMPPTCPConnection[focus@auth.jitsi.net/focus] (0) clos
ed with error
java.lang.NullPointerException
        at org.jitsi.jicofo.health.JicofoHealthChecker.lambda$pingClientConnection$1(JicofoHealthChecker.java:204)