### PR TITLE
Fix jigasi iq handler

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/JigasiIqHandler.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/JigasiIqHandler.kt
@@ -18,7 +18,6 @@
 package org.jitsi.jicofo.xmpp
 
 import org.jitsi.jicofo.ConferenceStore
-import org.jitsi.jicofo.EmptyConferenceStore
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.jigasi.JigasiDetector
 import org.jitsi.jicofo.xmpp.IqProcessingResult.AcceptedWithNoResponse
@@ -37,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class JigasiIqHandler(
     connections: Set<AbstractXMPPConnection>,
+    private val conferenceStore: ConferenceStore,
     private val jigasiDetector: JigasiDetector
 ) : AbstractIqHandler<RayoIqProvider.DialIq>(
     connections,
@@ -44,8 +44,6 @@ class JigasiIqHandler(
     RayoIqProvider.NAMESPACE,
     setOf(IQ.Type.set)
 ) {
-    var conferenceStore: ConferenceStore = EmptyConferenceStore()
-
     private val logger = createLogger()
 
     private val stats = Stats()

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
@@ -66,6 +66,7 @@ class XmppServices(
     private val jigasiIqHandler = if (jigasiDetector != null) {
         JigasiIqHandler(
             setOf(clientConnection.xmppConnection, serviceConnection.xmppConnection),
+            conferenceStore,
             jigasiDetector
         )
     } else null


### PR DESCRIPTION
I don't know what I'm doing - all I know is that jigasi couldn't find any conference given it's using EmptyConferenceStore to do lookup (log shows "rejected ... non-existent conference").

The patch appears to work fine for me. Please advice.