### PR TITLE
Use the service connection (if configured) for the Jigasi detector

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -439,7 +439,9 @@ public class JitsiMeetConferenceImpl
         rolesAndPresence.init();
 
         transcriberManager = new TranscriberManager(
-            getClientXmppProvider(),
+            jicofoServices.getXmppServices().getXmppConnectionByName(
+                JigasiConfig.config.xmppConnectionName()
+            ),
             this,
             jicofoServices.getXmppServices().getJigasiDetector(),
             logger);

--- a/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -102,15 +102,10 @@ open class JicofoServices {
         reservationSystem = reservationSystem
     )
 
-    private fun getXmppConnectionByName(name: XmppConnectionEnum) = when (name) {
-        XmppConnectionEnum.Client -> xmppServices.clientConnection
-        XmppConnectionEnum.Service -> xmppServices.serviceConnection
-    }
-
     val bridgeSelector = BridgeSelector()
     private val bridgeDetector: BridgeMucDetector? = BridgeConfig.config.breweryJid?.let { breweryJid ->
         BridgeMucDetector(
-            getXmppConnectionByName(BridgeConfig.config.xmppConnectionName),
+            xmppServices.getXmppConnectionByName(BridgeConfig.config.xmppConnectionName),
             bridgeSelector,
             breweryJid
         ).apply { init() }
@@ -119,7 +114,11 @@ open class JicofoServices {
         null
     }
     val jibriDetector = JibriConfig.config.breweryJid?.let { breweryJid ->
-        JibriDetector(getXmppConnectionByName(JibriConfig.config.xmppConnectionName), breweryJid, false).apply {
+        JibriDetector(
+            xmppServices.getXmppConnectionByName(JibriConfig.config.xmppConnectionName),
+            breweryJid,
+            false
+        ).apply {
             init()
         }
     } ?: run {

--- a/src/main/kotlin/org/jitsi/jicofo/jigasi/JigasiConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/jigasi/JigasiConfig.kt
@@ -39,6 +39,8 @@ class JigasiConfig {
         "jicofo.jigasi.xmpp-connection-name".from(newConfig)
     }
 
+    fun xmppConnectionName() = xmppConnectionName
+
     companion object {
         @JvmField
         val config = JigasiConfig()

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
@@ -51,8 +51,16 @@ class XmppServices(
         clientConnection
     }
 
+    fun getXmppConnectionByName(name: XmppConnectionEnum) = when (name) {
+        XmppConnectionEnum.Client -> clientConnection
+        XmppConnectionEnum.Service -> serviceConnection
+    }
+    
     val jigasiDetector = JigasiConfig.config.breweryJid?.let { breweryJid ->
-        JigasiDetector(clientConnection, breweryJid).apply { init() }
+        JigasiDetector(
+            getXmppConnectionByName(JigasiConfig.config.xmppConnectionName),
+            breweryJid
+        ).apply { init() }
     } ?: run {
         logger.info("No Jigasi detector configured.")
         null


### PR DESCRIPTION
When Jicofo is configured to use the service XMPP connection for Jigasi, it still accesses the Jigasi brewery MUC using the client connection. This patch fixes it to use the connection selected in jicofo.conf for jigasi.