### PR TITLE
feat(breakout-rooms): add breakout rooms support

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
@@ -192,4 +192,16 @@ public interface ChatRoom
      * @return <tt>true</tt> if the member is allowed to unmute, false otherwise.
      */
     boolean isMemberAllowedToUnmute(Jid jid, MediaType mediaType);
+
+    /**
+     * Checks whether this is a breakout room or not.
+     * @return <tt>true</tt> if it is, <tt>false</tt> otherwise.
+     */
+    boolean isBreakoutRoom();
+
+    /**
+     * Gets the main room name (JID) when in a breakout room.
+     * @return The main room JID as a string.
+     */
+    String getMainRoom();
 }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -113,6 +113,16 @@ public class ChatRoomImpl
     private String meetingId = null;
 
     /**
+     * The value of the "isbreakout" field from the MUC form, if present.
+     */
+    private boolean isBreakoutRoom = false;
+
+    /**
+     * The value of "breakout_main_room" field from the MUC form, if present.
+     */
+    private String mainRoom = null;
+
+    /**
      * Indicates whether A/V Moderation is enabled for this room.
      */
     private final Map<MediaType, Boolean> avModerationEnabled = Collections.synchronizedMap(new HashMap<>());
@@ -124,6 +134,13 @@ public class ChatRoomImpl
      * {@link #setEventExecutor(Executor)}
      */
     private EventEmitter<ChatRoomListener> eventEmitter = new SyncEventEmitter<>();
+
+    private static class MucConfigFields {
+        static final String IS_BREAKOUT_ROOM =  "muc#roominfo_isbreakout";
+        static final String MAIN_ROOM = "muc#roominfo_breakout_main_room";
+        static final String MEETING_ID = "muc#roominfo_meetingId";
+        static final String WHOIS = "muc#roomconfig_whois";
+    }
 
     /**
      * Creates new instance of <tt>ChatRoomImpl</tt>.
@@ -188,6 +205,16 @@ public class ChatRoomImpl
         joinAs(xmppProvider.getConfig().getUsername());
     }
 
+    @Override
+    public boolean isBreakoutRoom() {
+        return isBreakoutRoom;
+    }
+
+    @Override
+    public String getMainRoom() {
+        return mainRoom;
+    }
+
     private void joinAs(Resourcepart nickname) throws SmackException, XMPPException, InterruptedException
     {
         this.myOccupantJid = JidCreate.entityFullFrom(roomJid, nickname);
@@ -204,23 +231,37 @@ public class ChatRoomImpl
 
         muc.createOrJoin(nickname);
 
-        // Make the room non-anonymous, so that others can recognize focus JID
         Form config = muc.getConfigurationForm();
-        String meetingIdFieldName = "muc#roominfo_meetingId";
-        FormField meetingIdField = config.getField(meetingIdFieldName);
+
+        // Read breakout rooms options
+        FormField isBreakoutRoomField = config.getField(MucConfigFields.IS_BREAKOUT_ROOM);
+        if (isBreakoutRoomField != null)
+        {
+            isBreakoutRoom = Boolean.parseBoolean(isBreakoutRoomField.getFirstValue());
+            if (isBreakoutRoom)
+            {
+                FormField mainRoomField = config.getField(MucConfigFields.MAIN_ROOM);
+                if (mainRoomField != null)
+                {
+                    mainRoom = mainRoomField.getFirstValue();
+                }
+            }
+        }
+
+        // Read meetingId
+        FormField meetingIdField = config.getField(MucConfigFields.MEETING_ID);
         if (meetingIdField != null)
         {
-            meetingId = meetingIdField.getValuesAsString().stream().findFirst().orElse(null);
+            meetingId = meetingIdField.getFirstValue();
             if (meetingId != null)
             {
                 logger.addContext("meeting_id", meetingId);
             }
         }
 
+        // Make the room non-anonymous, so that others can recognize focus JID
         FillableForm answer = config.getFillableForm();
-        // Room non-anonymous
-        String whoisFieldName = "muc#roomconfig_whois";
-        answer.setAnswer(whoisFieldName, "anyone");
+        answer.setAnswer(MucConfigFields.WHOIS, "anyone");
 
         muc.sendConfigurationForm(answer);
     }

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import org.jitsi.impl.protocol.xmpp.RegistrationListener
+import org.jitsi.impl.protocol.xmpp.XmppProvider
 import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.auth.AuthenticationAuthority
@@ -24,31 +26,38 @@ import org.jitsi.jicofo.auth.ErrorFactory
 import org.jitsi.jicofo.reservation.ReservationSystem
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.jitsimeet.ConferenceIq
-import org.jivesoftware.smack.AbstractXMPPConnection
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler
 import org.jivesoftware.smack.iqrequest.IQRequestHandler
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.packet.StanzaError
+import org.jxmpp.jid.DomainBareJid
+import org.jxmpp.jid.impl.JidCreate
 
 /**
  * Handles XMPP requests for a new conference ([ConferenceIq]).
  */
 class ConferenceIqHandler(
-    val connection: AbstractXMPPConnection,
+    val xmppProvider: XmppProvider,
     val focusManager: FocusManager,
     val focusAuthJid: String,
     val isFocusAnonymous: Boolean,
     val authAuthority: AuthenticationAuthority?,
     val reservationSystem: ReservationSystem?,
     val jigasiEnabled: Boolean
-) : AbstractIqRequestHandler(
+) : RegistrationListener, AbstractIqRequestHandler(
     ConferenceIq.ELEMENT_NAME,
     ConferenceIq.NAMESPACE,
     IQ.Type.set,
     IQRequestHandler.Mode.sync
 ) {
-
+    private val connection = xmppProvider.xmppConnection
+    private var breakoutAddress: DomainBareJid? = null
     private val logger = createLogger()
+
+    init {
+        xmppProvider.addRegistrationListener(this)
+        registrationChanged(xmppProvider.isRegistered)
+    }
 
     private fun handleConferenceIq(query: ConferenceIq): IQ {
         val response = ConferenceIq()
@@ -104,9 +113,12 @@ class ConferenceIqHandler(
     private fun processExtensions(query: ConferenceIq, response: ConferenceIq?, roomExists: Boolean): IQ? {
         val peerJid = query.from
         var identity: String? = null
+        val room = query.room
+        val isBreakoutRoom = breakoutAddress != null && room.domain == breakoutAddress
 
-        // Authentication
-        if (authAuthority != null) {
+        // Authentication. We do not perform authentication for breakout rooms, expecting the breakout room prosody
+        // module to handle it.
+        if (!isBreakoutRoom && authAuthority != null) {
             val authErrorOrResponse = authAuthority.processAuthentication(query, response)
 
             // Checks if authentication module wants to cancel further
@@ -116,17 +128,26 @@ class ConferenceIqHandler(
             }
             // Only authenticated users are allowed to create new rooms
             if (!roomExists) {
-                identity = authAuthority.getUserIdentity(peerJid)
-                if (identity == null) {
-                    // Error not authorized
-                    return ErrorFactory.createNotAuthorizedError(query, "not authorized user domain")
+                var breakoutRoomExists: Boolean = false
+                for (conference in focusManager.getConferences()) {
+                    val name = conference.getRoomName()
+                    if (name.domain == breakoutAddress && name.localpart.startsWith("${room.localpart}_")) {
+                        breakoutRoomExists = true
+                        break
+                    }
+                }
+                if (!breakoutRoomExists) {
+                    identity = authAuthority.getUserIdentity(peerJid)
+                    if (identity == null) {
+                        // Error not authorized
+                        return ErrorFactory.createNotAuthorizedError(query, "not authorized user domain")
+                    }
                 }
             }
         }
 
         // Check room reservation?
         if (!roomExists && reservationSystem != null) {
-            val room = query.room
             val result: ReservationSystem.Result = reservationSystem.createConference(identity, room)
             logger.info("Create room result: $result for $room")
             if (result.code != ReservationSystem.RESULT_OK) {
@@ -160,5 +181,27 @@ class ConferenceIqHandler(
         }
 
         return null
+    }
+
+    override fun registrationChanged(registered: Boolean) {
+        if (!registered) {
+            breakoutAddress = null
+            return
+        }
+
+        try {
+            val info = xmppProvider.discoverInfo(JidCreate.bareFrom(XmppConfig.client.xmppDomain))
+            val breakoutAddressStr = info?.getIdentities("component", "breakout_rooms")?.firstOrNull()?.name
+
+            if (breakoutAddressStr == null) {
+                breakoutAddress = null
+                logger.info("No breakout room component address configured.")
+            } else {
+                breakoutAddress = JidCreate.domainBareFrom(breakoutAddressStr)
+                logger.info("Using breakout room component address: $breakoutAddress")
+            }
+        } catch (e: Exception) {
+            logger.error("Could not discover breakout rooms component address.", e)
+        }
     }
 }

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -128,10 +128,11 @@ class ConferenceIqHandler(
             }
             // Only authenticated users are allowed to create new rooms
             if (!roomExists) {
+                // If a breakout room exists and all members had left the main room, skip
+                // authentication for the main room so users can go back to it.
                 var breakoutRoomExists: Boolean = false
                 for (conference in focusManager.getConferences()) {
-                    val name = conference.getRoomName()
-                    if (name.domain == breakoutAddress && name.localpart.startsWith("${room.localpart}_")) {
+                    if (conference.chatRoom.isBreakoutRoom && room.toString() == conference.chatRoom.mainRoom) {
                         breakoutRoomExists = true
                         break
                     }

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
@@ -86,7 +86,7 @@ class XmppServices(
     private val videoMuteHandler = VideoMuteIqHandler(setOf(clientConnection.xmppConnection), conferenceStore)
 
     private val conferenceIqHandler = ConferenceIqHandler(
-        connection = clientConnection.xmppConnection,
+        xmppProvider = clientConnection,
         focusManager = focusManager,
         focusAuthJid = "${XmppConfig.client.username}@${XmppConfig.client.domain}",
         isFocusAnonymous = StringUtils.isBlank(XmppConfig.client.password),

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomRoleManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomRoleManager.kt
@@ -88,6 +88,11 @@ class AutoOwnerRoleManager(chatRoom: ChatRoom) : ChatRoomRoleManager(chatRoom) {
             return
         }
 
+        // Skip if this is a breakout room.
+        if (chatRoom.isBreakoutRoom) {
+            return
+        }
+
         owner = chatRoom.members.find { !it.isRobot && it.role.hasOwnerRights() }
         if (owner != null) {
             return

--- a/src/test/java/mock/muc/MockChatRoom.java
+++ b/src/test/java/mock/muc/MockChatRoom.java
@@ -132,6 +132,16 @@ public class MockChatRoom
     }
 
     @Override
+    public boolean isBreakoutRoom() {
+        return false;
+    }
+
+    @Override
+    public String getMainRoom() {
+        return null;
+    }
+
+    @Override
     public EntityBareJid getRoomJid()
     {
         return roomName;


### PR DESCRIPTION
This patch adds support for the breakout rooms feature. 

It allows participants to start breakout room conferences without authentication. Access to breakout rooms is assured by uuids. The prosody breakout_rooms_muc module only allows joining breakout rooms which were previously created by moderators.

Additionally it allows participants to join/start the main room when all participants are in breakout rooms.

This is a dependency of [this](https://github.com/jitsi/jitsi-meet/pull/9131) jitsi-meet pull request.