### PR TITLE
fix: Remove stale participant when the XMPP connection snaps.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/JitsiMeetConferenceImpl.java
@@ -1079,24 +1079,29 @@ public class JitsiMeetConferenceImpl
 
         synchronized (participantLock)
         {
-            if (participant.isSessionEstablished())
+            try
             {
-                JingleSession jingleSession = participant.getJingleSession();
+                if (participant.isSessionEstablished())
+                {
+                    JingleSession jingleSession = participant.getJingleSession();
 
-                jingle.terminateSession(jingleSession, reason, message, sendSessionTerminate);
+                    jingle.terminateSession(jingleSession, reason, message, sendSessionTerminate);
 
-                removeSources(
-                    jingleSession,
-                    participant.getSourcesCopy(),
-                    participant.getSourceGroupsCopy(),
-                    false /* no JVB update - will expire */,
-                    sendSourceRemove);
+                    removeSources(
+                        jingleSession,
+                        participant.getSourcesCopy(),
+                        participant.getSourceGroupsCopy(),
+                        false /* no JVB update - will expire */,
+                        sendSourceRemove);
 
-                participant.setJingleSession(null);
+                    participant.setJingleSession(null);
+                }
             }
-
-            boolean removed = participants.remove(participant);
-            logger.info("Removed participant " + participant.getChatMember().getName() + " removed=" + removed);
+            finally
+            {
+                boolean removed = participants.remove(participant);
+                logger.info("Removed participant " + participant.getChatMember().getName() + " removed=" + removed);
+            }
         }
 
         BridgeSession bridgeSession = terminateParticipantBridgeSession(participant);


### PR DESCRIPTION
This can cause double counting of stale participants, among other
things. Sample stack trace that can cause the issue:

Jicofo XXXX-XX-XX XX:XX:XX.XXX SEVERE: [XXXX] UtilKt.tryToSendStanza#73: No connection - unable to send packet: <iq>...</iq>
org.jivesoftware.smack.SmackException$NotConnectedException: The connection XMPPTCPConnection[focus@auth.jvb.example.com/focus] (1) is no longer connected. done=true smResumptionPossible=false
        at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter.throwNotConnectedExceptionIfDoneAndResumptionNotPossible(XMPPTCPConnection.java:1327)
        at org.jivesoftware.smack.tcp.XMPPTCPConnection.throwNotConnectedExceptionIfAppropriate(XMPPTCPConnection.java:358)
        at org.jivesoftware.smack.AbstractXMPPConnection.sendStanza(AbstractXMPPConnection.java:670)
        at org.jitsi.jicofo.xmpp.UtilKt.tryToSendStanza(Util.kt:71)
        at org.jitsi.impl.protocol.xmpp.colibri.ColibriConferenceImpl.updateChannelsInfo(ColibriConferenceImpl.java:821)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl$BridgeSession.updateColibriOctoChannels(JitsiMeetConferenceImpl.java:2731)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl$BridgeSession.removeSourcesFromOcto(JitsiMeetConferenceImpl.java:2823)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl$BridgeSession.access$2500(JitsiMeetConferenceImpl.java:2558)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl.lambda$removeSources$11(JitsiMeetConferenceImpl.java:1776)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
        at java.util.LinkedList$LLSpliterator.forEachRemaining(LinkedList.java:1235)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl.removeSources(JitsiMeetConferenceImpl.java:1776)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl.terminateParticipant(JitsiMeetConferenceImpl.java:1088)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl.onMemberLeft(JitsiMeetConferenceImpl.java:1043)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl.access$2400(JitsiMeetConferenceImpl.java:75)
        at org.jitsi.jicofo.JitsiMeetConferenceImpl$ChatRoomListenerImpl.memberLeft(JitsiMeetConferenceImpl.java:2983)
        at org.jitsi.impl.protocol.xmpp.ChatRoomImpl$MemberListener.lambda$left$0(ChatRoomImpl.java:885)
        at org.jitsi.utils.event.AsyncEventEmitter$fireEvent$$inlined$forEach$lambda$1$1.invoke(EventEmitter.kt:78)
        at org.jitsi.utils.event.AsyncEventEmitter$fireEvent$$inlined$forEach$lambda$1$1.invoke(EventEmitter.kt:69)
        at org.jitsi.utils.event.BaseEventEmitter.wrap(EventEmitter.kt:49)
        at org.jitsi.utils.event.AsyncEventEmitter$fireEvent$$inlined$forEach$lambda$1.run(EventEmitter.kt:78)
        at org.jitsi.jicofo.util.QueueExecutor$1.handlePacket(QueueExecutor.kt:45)
        at org.jitsi.jicofo.util.QueueExecutor$1.handlePacket(QueueExecutor.kt:39)
        at org.jitsi.utils.queue.PacketQueue$HandlerAdapter.handleItem(PacketQueue.java:380)
        at org.jitsi.utils.queue.AsyncQueueHandler$1.run(AsyncQueueHandler.java:133)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)