### PR TITLE
fix: Increase the conference queue executor queue size.

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/util/QueueExecutor.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/util/QueueExecutor.kt
@@ -33,7 +33,7 @@ class QueueExecutor(
     id: String,
     parentLogger: Logger = createLogger()
 ) : Executor, PacketQueue<Runnable>(
-    50,
+    5000,
     true,
     id,
     object : PacketHandler<Runnable> {


### PR DESCRIPTION
This is a partial fix. Exposing queue stats, logging when items are dropped, and potentially using an unbounded queue will follow in a separate PR.