### PR TITLE
Add mid signaling support

### DIFF
--- a/src/main/java/org/jitsi/jicofo/codec/JingleOfferFactory.java
+++ b/src/main/java/org/jitsi/jicofo/codec/JingleOfferFactory.java
@@ -157,6 +157,14 @@ public class JingleOfferFactory
             rtpDesc.addExtmap(toOffset);
         }
 
+        if (config.mid.enabled()) {
+            // a=extmap:10 rn:ietf:params:rtp-hdrext:sdes:mid
+            RTPHdrExtPacketExtension mid = new RTPHdrExtPacketExtension();
+            mid.setID(String.valueOf(config.mid.id()));
+            mid.setURI(URI.create("urn:ietf:params:rtp-hdrext:sdes:mid"));
+            rtpDesc.addExtmap(mid);
+        }
+
         if (config.absSendTime.enabled())
         {
             // a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
@@ -408,6 +416,14 @@ public class JingleOfferFactory
             ssrcAudioLevel.setID(String.valueOf(config.audioLevel.id()));
             ssrcAudioLevel.setURI(URI.create("urn:ietf:params:rtp-hdrext:ssrc-audio-level"));
             rtpDesc.addExtmap(ssrcAudioLevel);
+        }
+
+        if (config.mid.enabled()) {
+            // a=extmap:10 rn:ietf:params:rtp-hdrext:sdes:mid
+            RTPHdrExtPacketExtension mid = new RTPHdrExtPacketExtension();
+            mid.setID(String.valueOf(config.mid.id()));
+            mid.setURI(URI.create("urn:ietf:params:rtp-hdrext:sdes:mid"));
+            rtpDesc.addExtmap(mid);
         }
 
         if (config.opus.enabled())

--- a/src/main/kotlin/org/jitsi/jicofo/codec/CodecConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/codec/CodecConfig.kt
@@ -144,6 +144,8 @@ class Config {
     @JvmField
     val tcc = RtpExtensionConfig("jicofo.codec.rtp-extensions.tcc")
     @JvmField
+    val mid = RtpExtensionConfig("jicofo.codec.rtp-extensions.mid")
+    @JvmField
     val videoContentType: RtpExtensionConfig =
         RtpExtensionConfigWithLegacy(
             "$LEGACY_BASE.ENABLE_VIDEO_CONTENT_TYPE",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -146,6 +146,10 @@ jicofo {
         enabled = false
         id = 9
       }
+      mid {
+        enabled = false
+        id = 10
+      }
     }
   }
 

--- a/src/test/kotlin/org/jitsi/jicofo/CodecConfigTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/CodecConfigTest.kt
@@ -70,6 +70,9 @@ class CodecConfigTest : ConfigTest() {
 
             config.audioLevel.enabled shouldBe true
             config.audioLevel.id shouldBe 1
+
+            config.mid.enabled shouldBe false
+            config.mid.id shouldBe 10
         }
         context("Legacy config") {
             context("Disabling a codec") {
@@ -225,6 +228,12 @@ class CodecConfigTest : ConfigTest() {
                 }
                 withNewConfig("jicofo.codec.rtp-extensions.tcc.enabled=true") {
                     config.tcc.enabled shouldBe true
+                }
+                withNewConfig("jicofo.codec.rtp-extensions.mid.enabled=false") {
+                    config.mid.enabled shouldBe false
+                }
+                withNewConfig("jicofo.codec.rtp-extensions.mid.enabled=true") {
+                    config.mid.enabled shouldBe true
                 }
             }
             context("Changing extension IDs") {


### PR DESCRIPTION
This PR adds a config option to Jicofo for offering the RTP MID header extension in the negotiations with the browser.

Note: the feature itself (full support for MID header extension) is still work in progress and not functional yet.