### PR TITLE
feat: Remove limitations for MSID signaled by an endpoint.

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/conference/source/ValidatingConferenceSourceMap.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/source/ValidatingConferenceSourceMap.kt
@@ -18,7 +18,6 @@
 package org.jitsi.jicofo.conference.source
 
 import org.jitsi.jicofo.ConferenceConfig
-import org.jitsi.utils.MediaType
 import org.jitsi.utils.logging2.createLogger
 import org.jxmpp.jid.Jid
 import java.lang.IllegalStateException
@@ -280,62 +279,6 @@ class ValidatingConferenceSourceMap(
                     }
                 }
             }
-
-            // Audio and video sources can have the same MSID.
-            listOf(MediaType.AUDIO, MediaType.VIDEO).forEach { mediaType ->
-                // This groups all sources according to the extended group that they belong to, i.e. a SIM group gets
-                // associated with all of its sources plus the sources in FID groups associated with the SIM group's
-                // sources. For example given these groups:
-                // SIM(1, 2, 3)
-                // FID(1, 4)
-                // FID(2, 5)
-                // FID(3, 6)
-                // FID(111, 222)
-                // And non-grouped source 333 this will associate the SIM group with sources 1..6, the lonely FID group
-                // with sources 111 and 222, and a dummy single-source group with source 333.
-                //
-                // This is technically O(s*g^2) where s is the number of sources and g is the number of groups. But in
-                // practice both s and g are very small (at most 20 and 4 respectively).
-                val grouped: Map<SsrcGroup, List<Source>> =
-                    endpointSourceSet.sources
-                        .filter { it.mediaType == mediaType && it.msid != null }
-                        .groupBy { groupBySimulcastGroup(it.ssrc, endpointSourceSet.ssrcGroups) }
-
-                // Here we check for MSID conflicts, i.e. we make sure that each group has a unique MSID.
-                val msidsSeen = mutableSetOf<String?>()
-                grouped.values.map { it[0] }.forEach { source ->
-                    if (msidsSeen.contains(source.msid)) throw MsidConflictException(source.msid ?: "NONE")
-                    msidsSeen.add(source.msid)
-                }
-            }
-        }
-
-        /** Returns the extended group to which an SSRC belongs. See [validateEndpointSourceSet]. */
-        private fun groupBySimulcastGroup(ssrc: Long, ssrcGroups: Set<SsrcGroup>): SsrcGroup {
-            val simGroup = ssrcGroups.find {
-                it.semantics == SsrcGroupSemantics.Sim && it.ssrcs.contains(ssrc)
-            }
-            if (simGroup != null) {
-                return simGroup
-            }
-
-            val fidGroup = ssrcGroups.find {
-                it.semantics == SsrcGroupSemantics.Fid && it.ssrcs.contains(ssrc)
-            }
-            if (fidGroup != null) {
-                if (ssrc == fidGroup.ssrcs[1]) {
-                    val simGroup2 = ssrcGroups.find {
-                        it.semantics == SsrcGroupSemantics.Sim && it.ssrcs.contains(fidGroup.ssrcs[0])
-                    }
-                    if (simGroup2 != null) {
-                        return simGroup2
-                    }
-                }
-                return fidGroup
-            }
-
-            // Dummy group just for this source.
-            return SsrcGroup(SsrcGroupSemantics.Sim, listOf(ssrc))
         }
     }
 }


### PR DESCRIPTION
SSRCValidator used to put all SSRCs and groups in a conference in one place and run checks on the whole sett. In #768 I changed that to check for conflicts between endpoints and then check for consistency whithin the sources singaled from a single endpoint. To preserve the existing behavior I added the same check that, grouped into "simulcast groups", MSIDs need to be unique. This means that an endpoint is not allowed to use the same MSID for more than one of its sources. I don't think this was intended by SSRCValidator (@paweldomas perhaps you remember?), and the limitation seems unnecessary, so this PR removes it.

In effect this PR allows an endpoint to use whatever MSIDs it likes, as long as they don't conflict with another endpoint, and the groups have a consistent MSID value.