### PR TITLE
Fix: bump jitsi-xmpp-extensions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-26-g67e8beb</version>
+      <version>1.0-29-g3c269f8</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Work around bug in jxmpp 1.0.1 parsing a JID localpart containing an @ character.