### PR TITLE
Limit video senders

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatMemberImpl.java
@@ -94,6 +94,11 @@ public class ChatMemberImpl
      */
     private String statsId;
 
+    /**
+     * Indicates whether the member's video sources are currently muted.
+     */
+    private boolean isVideoMuted = true;
+
     public ChatMemberImpl(EntityFullJid fullJid, ChatRoomImpl chatRoom,
                           int joinOrderNumber)
     {
@@ -199,6 +204,9 @@ public class ChatMemberImpl
         return isJibri;
     }
 
+    @Override
+    public boolean isVideoMuted() { return isVideoMuted; }
+
     /**
      * Does presence processing.
      *
@@ -286,6 +294,19 @@ public class ChatMemberImpl
         if (statsIdPacketExt != null)
         {
             statsId = statsIdPacketExt.getStatsId();
+        }
+
+        boolean wasVideoMuted = isVideoMuted;
+        StandardExtensionElement videoMutedExt = presence.getExtension("videomuted", "jabber:client");
+        isVideoMuted = videoMutedExt == null || Boolean.valueOf(videoMutedExt.getText()); /* defaults to true */
+
+        if (isVideoMuted != wasVideoMuted)
+        {
+            logger.debug(() -> toString() + ". isMuted = " + isVideoMuted + ".");
+            if (isVideoMuted)
+                chatRoom.removeVideoSender();
+            else
+                chatRoom.addVideoSender();
         }
     }
 

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
@@ -90,6 +90,11 @@ public interface ChatRoom
     int getMembersCount();
 
     /**
+     * Returns the number of members that currently have their video sources unmuted.
+     */
+    int getVideoSendersCount();
+
+    /**
     * Grants ownership privileges to another user. Room owners may grant
     * ownership privileges. Some room implementations will not allow to grant
     * ownership privileges to other users. An owner is allowed to change

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -890,9 +890,10 @@ public class ChatRoomImpl
                 {
                     logger.error(occupantJid + " not in " + roomJid);
                 }
-
-                if (!removed.isVideoMuted())
+                else if (!removed.isVideoMuted())
+                {
                     removeVideoSender();
+                }
 
                 return removed;
             }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -127,6 +127,11 @@ public class ChatRoomImpl
     private EventEmitter<ChatRoomListener> eventEmitter = new SyncEventEmitter<>();
 
     /**
+     * The number of members that currently have their video sources unmuted.
+     */
+    private int numVideoSenders;
+
+    /**
      * Creates new instance of <tt>ChatRoomImpl</tt>.
      *
      * @param roomJid the room JID (e.g. "room@service").
@@ -577,6 +582,21 @@ public class ChatRoomImpl
         UtilKt.tryToSendStanza(xmppProvider.getXmppConnection(), lastPresenceSent);
     }
 
+    @Override
+    public int getVideoSendersCount() { return numVideoSenders; }
+
+    public void addVideoSender()
+    {
+        ++numVideoSenders;
+        logger.debug(() -> "The number of video senders has increased to " + numVideoSenders + ".");
+    }
+
+    public void removeVideoSender()
+    {
+        --numVideoSenders;
+        logger.debug(() -> "The number of video senders has decreased to " + numVideoSenders + ".");
+    }
+
     /**
      * Adds a new {@link ChatMemberImpl} with the given JID to {@link #members}.
      * If a member with the given JID already exists, it returns the existing
@@ -596,6 +616,9 @@ public class ChatRoomImpl
             ChatMemberImpl newMember = new ChatMemberImpl(jid, ChatRoomImpl.this, members.size() + 1);
 
             members.put(jid, newMember);
+
+            if (!newMember.isVideoMuted())
+                addVideoSender();
 
             return newMember;
         }
@@ -857,6 +880,9 @@ public class ChatRoomImpl
                 {
                     logger.error(occupantJid + " not in " + roomJid);
                 }
+
+                if (!removed.isVideoMuted())
+                    removeVideoSender();
 
                 return removed;
             }

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -589,12 +589,22 @@ public class ChatRoomImpl
     {
         ++numVideoSenders;
         logger.debug(() -> "The number of video senders has increased to " + numVideoSenders + ".");
+
+        eventEmitter.fireEvent(handler -> {
+            handler.numVideoSendersChanged(numVideoSenders);
+            return Unit.INSTANCE;
+        });
     }
 
     public void removeVideoSender()
     {
         --numVideoSenders;
         logger.debug(() -> "The number of video senders has decreased to " + numVideoSenders + ".");
+
+        eventEmitter.fireEvent(handler -> {
+            handler.numVideoSendersChanged(numVideoSenders);
+            return Unit.INSTANCE;
+        });
     }
 
     /**

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomMember.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomMember.java
@@ -97,6 +97,11 @@ public interface ChatRoomMember
     boolean isJibri();
 
     /**
+     * Returns whether the room member has its video sources muted.
+     */
+    boolean isVideoMuted();
+
+    /**
      * Gets the region (e.g. "us-east") of this {@link ChatRoomMember}.
      */
     String getRegion();

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1504,6 +1504,16 @@ public class JitsiMeetConferenceImpl
             return StanzaError.from(StanzaError.Condition.bad_request, e.getMessage()).build();
         }
 
+        // $ optimize. add methods to EndpointSourceSet that don't need to copy ssrcs.
+        boolean hasVideo = !sourcesAdvertised.getVideoSsrcs().isEmpty();
+
+        if (hasVideo && chatRoom.getVideoSendersCount() >= ConferenceConfig.config.getMaxVideoSenders())
+        {
+            String errorMsg = "Source add rejected. Maximum number of video senders reached.";
+            logger.warn(() -> participantId + ": " + errorMsg);
+            return StanzaError.from(StanzaError.Condition.resource_constraint, errorMsg).build();
+        }
+
         logger.debug(() -> "Received source-add from " + participantId + ": " + sourcesAdvertised);
         logger.debug(() -> "Accepted sources from " + participantId + ": " + sourcesAccepted);
 

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -115,7 +115,7 @@ public class JitsiMeetConferenceImpl
     @NotNull
     private final JitsiMeetConfig config;
 
-    private final ChatRoomListener chatRoomListener = new ChatRoomListenerImpl(this);
+    private final ChatRoomListener chatRoomListener = new ChatRoomListenerImpl();
 
     /**
      * Conference room chat instance.
@@ -534,7 +534,7 @@ public class JitsiMeetConferenceImpl
     /**
      * Process the new number of video senders reported by the chat room.
      */
-    private void numVideoSendersChanged(int numVideoSenders)
+    private void onNumVideoSendersChanged(int numVideoSenders)
     {
         boolean newValue = numVideoSenders >= ConferenceConfig.config.getMaxVideoSenders();
         if (videoLimitReached != newValue)
@@ -1522,7 +1522,7 @@ public class JitsiMeetConferenceImpl
             return StanzaError.from(StanzaError.Condition.bad_request, e.getMessage()).build();
         }
 
-        if (sourcesAdvertised.hasVideo() &&
+        if (sourcesAdvertised.getHasVideo() &&
             chatRoom.getVideoSendersCount() >= ConferenceConfig.config.getMaxVideoSenders())
         {
             String errorMsg = "Source add rejected. Maximum number of video senders reached.";
@@ -2443,12 +2443,6 @@ public class JitsiMeetConferenceImpl
 
     private class ChatRoomListenerImpl implements ChatRoomListener
     {
-        private final JitsiMeetConferenceImpl conference;
-        private ChatRoomListenerImpl(JitsiMeetConferenceImpl conference)
-        {
-            this.conference = conference;
-        }
-
         @Override
         public void roomDestroyed(@NotNull String reason)
         {
@@ -2499,7 +2493,7 @@ public class JitsiMeetConferenceImpl
         @Override
         public void numVideoSendersChanged(int numVideoSenders)
         {
-            conference.numVideoSendersChanged(numVideoSenders);
+            onNumVideoSendersChanged(numVideoSenders);
         }
     }
 }

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1504,10 +1504,8 @@ public class JitsiMeetConferenceImpl
             return StanzaError.from(StanzaError.Condition.bad_request, e.getMessage()).build();
         }
 
-        // $ optimize. add methods to EndpointSourceSet that don't need to copy ssrcs.
-        boolean hasVideo = !sourcesAdvertised.getVideoSsrcs().isEmpty();
-
-        if (hasVideo && chatRoom.getVideoSendersCount() >= ConferenceConfig.config.getMaxVideoSenders())
+        if (sourcesAdvertised.hasVideo() &&
+            chatRoom.getVideoSendersCount() >= ConferenceConfig.config.getMaxVideoSenders())
         {
             String errorMsg = "Source add rejected. Maximum number of video senders reached.";
             logger.warn(() -> participantId + ": " + errorMsg);

--- a/src/main/kotlin/org/jitsi/jicofo/ConferenceConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/ConferenceConfig.kt
@@ -62,6 +62,10 @@ class ConferenceConfig {
         "jicofo.conference.min-participants".from(newConfig)
     }
 
+    val maxVideoSenders: Int by config {
+        "jicofo.conference.max-video-senders".from(newConfig)
+    }
+
     val enableLipSync: Boolean by config {
         "jicofo.conference.enable-lip-sync".from(newConfig)
     }

--- a/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
@@ -44,12 +44,12 @@ data class EndpointSourceSet(
     /**
      * Whether there are any audio sources in this set.
      */
-    fun hasAudio() = sources.any { it.mediaType == AUDIO }
+    val hasAudio: Boolean by lazy { sources.any { it.mediaType == AUDIO } }
 
     /**
      * Whether there are any video sources in this set.
      */
-    fun hasVideo() = sources.any { it.mediaType == VIDEO }
+    val hasVideo: Boolean by lazy { sources.any { it.mediaType == VIDEO } }
 
     /**
      * Creates a list of Jingle [ContentPacketExtension]s that describe the sources in this [EndpointSourceSet].

--- a/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
@@ -42,6 +42,16 @@ data class EndpointSourceSet(
     fun isEmpty() = sources.isEmpty() && ssrcGroups.isEmpty()
 
     /**
+     * Whether there are any audio sources in this set.
+     */
+    fun hasAudio() = sources.any { it.mediaType == AUDIO }
+
+    /**
+     * Whether there are any video sources in this set.
+     */
+    fun hasVideo() = sources.any { it.mediaType == VIDEO }
+
+    /**
      * Creates a list of Jingle [ContentPacketExtension]s that describe the sources in this [EndpointSourceSet].
      */
     fun toJingle(owner: Jid? = null): List<ContentPacketExtension> = toJingle(mutableMapOf(), owner)

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomListener.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomListener.kt
@@ -29,6 +29,7 @@ interface ChatRoomListener {
     fun roomDestroyed(reason: String) {}
     fun startMutedChanged(startAudioMuted: Boolean, startVideoMuted: Boolean) {}
     fun localRoleChanged(newRole: MemberRole, oldRole: MemberRole? = null) {}
+    fun numVideoSendersChanged(numVideoSenders: Int) {}
 }
 
 /** A class with the default kotlin method implementations (to avoid using @JvmDefault) **/

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -177,6 +177,9 @@ jicofo {
     // The minimum number of participants required for the conference to be started.
     min-participants = 2
 
+    // The maximum number of participants that can send their video at the same time.
+    max-video-senders = 50
+
     // Experimental.
     enable-lip-sync = false
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -178,7 +178,7 @@ jicofo {
     min-participants = 2
 
     // The maximum number of participants that can send their video at the same time.
-    max-video-senders = 50
+    max-video-senders = 999999
 
     // Experimental.
     enable-lip-sync = false

--- a/src/test/java/mock/muc/MockChatRoom.java
+++ b/src/test/java/mock/muc/MockChatRoom.java
@@ -255,6 +255,12 @@ public class MockChatRoom
         return members.size();
     }
 
+    @Override
+    public int getVideoSendersCount()
+    {
+        return 0; /* implement */
+    }
+
     private void grantRole(EntityFullJid address, MemberRole newRole)
     {
         MockRoomMember member = findMember(address.getResourceOrNull());

--- a/src/test/java/mock/muc/MockRoomMember.java
+++ b/src/test/java/mock/muc/MockRoomMember.java
@@ -111,6 +111,12 @@ public class MockRoomMember
     }
 
     @Override
+    public boolean isVideoMuted()
+    {
+        return false;
+    }
+
+    @Override
     public Presence getPresence()
     {
         // FIXME: not implemented


### PR DESCRIPTION
Keep track of the number of video senders in a conference, that is, the number of participants who have unmuted their video source. When the limit is reached, return an error if another participant attempts to unmute their video.

This is an attempt to avoid issues that may arise from the storm of signaling that may occur when a large number of participants unmute at the same time.