### PR TITLE
Fire ChatRoom events sync

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
@@ -25,7 +25,6 @@ import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.*;
 
 import java.util.*;
-import java.util.concurrent.*;
 
 /**
  * Represents a chat channel/room/rendez-vous point/ where multiple chat users
@@ -52,11 +51,6 @@ public interface ChatRoom
      * otherwise.
      */
     boolean isJoined();
-
-    /**
-     * Set the executor to use to fire events to {@link ChatRoomListener}s.
-     */
-    void setEventExecutor(@NotNull Executor executor);
 
     /**
      * Leave this chat room. Once this method is called, the user won't be

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -131,10 +131,9 @@ public class ChatRoomImpl
     private Map<String, List<String>> whitelists = new HashMap<>();
 
     /**
-     * The emitter used to fire events. By default we fire them synchronously, unless an executor is set via
-     * {@link #setEventExecutor(Executor)}
+     * The emitter used to fire events.
      */
-    private EventEmitter<ChatRoomListener> eventEmitter = new SyncEventEmitter<>();
+    private final EventEmitter<ChatRoomListener> eventEmitter = new SyncEventEmitter<>();
 
     private static class MucConfigFields {
         static final String IS_BREAKOUT_ROOM =  "muc#roominfo_isbreakout";
@@ -888,15 +887,6 @@ public class ChatRoomImpl
 
         List<String> whitelist = this.whitelists.get(mediaType.toString());
         return whitelist != null && whitelist.contains(jid.toString());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setEventExecutor(@NotNull Executor executor)
-    {
-        this.eventEmitter = new AsyncEventEmitter<>(executor, eventEmitter.getEventHandlers());
     }
 
     class MemberListener implements ParticipantStatusListener

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -17,14 +17,12 @@
  */
 package org.jitsi.jicofo.conference;
 
-import edu.umd.cs.findbugs.annotations.*;
 import org.jetbrains.annotations.*;
 import org.jetbrains.annotations.Nullable;
 import org.jitsi.impl.protocol.xmpp.*;
 import org.jitsi.jicofo.*;
 import org.jitsi.jicofo.auth.*;
 import org.jitsi.jicofo.bridge.*;
-import org.jitsi.jicofo.conference.colibri.*;
 import org.jitsi.jicofo.conference.source.*;
 import org.jitsi.jicofo.lipsynchack.*;
 import org.jitsi.jicofo.util.*;
@@ -396,7 +394,7 @@ public class JitsiMeetConferenceImpl
 
         try
         {
-            disposeConference();
+            expireBridgeSessions();
         }
         catch (Exception e)
         {
@@ -1004,12 +1002,9 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
-     * Disposes of this conference. Expires all allocated COLIBRI conferences.
-     *
-     * Does not terminate jingle sessions with its participants (why???).
-     *
+     * Expires all COLIBRI conferences.
      */
-    private void disposeConference()
+    private void expireBridgeSessions()
     {
         // If the conference is being disposed the timeout is not needed
         // anymore
@@ -1026,9 +1021,6 @@ public class JitsiMeetConferenceImpl
             }
             bridges.clear();
         }
-
-        // TODO: what about removing the participants and ending their jingle
-        // session?
     }
 
     private void onMemberKicked(ChatRoomMember chatRoomMember)
@@ -2415,7 +2407,7 @@ public class JitsiMeetConferenceImpl
                             /* send session-terminate */ true,
                             /* send source-remove */ false);
 
-                    disposeConference();
+                    expireBridgeSessions();
                 }
                 else
                 {

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1062,8 +1062,13 @@ public class JitsiMeetConferenceImpl
             }
             else if (participants.size() == 0)
             {
-                stop();
+                expireBridgeSessions();
             }
+        }
+
+        if (chatRoom == null || chatRoom.getMembersCount() == 0)
+        {
+            stop();
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -25,7 +25,6 @@ import org.jitsi.jicofo.auth.*;
 import org.jitsi.jicofo.bridge.*;
 import org.jitsi.jicofo.conference.source.*;
 import org.jitsi.jicofo.lipsynchack.*;
-import org.jitsi.jicofo.util.*;
 import org.jitsi.jicofo.version.*;
 import org.jitsi.jicofo.xmpp.*;
 import org.jitsi.jicofo.xmpp.muc.*;
@@ -98,11 +97,6 @@ public class JitsiMeetConferenceImpl
      * about conference events.
      */
     private final JitsiMeetConferenceImpl.ConferenceListener listener;
-
-    /**
-     * An executor to be used for tasks related to this conference, which need to execute in order and which may block.
-     */
-    private final QueueExecutor queueExecutor;
 
     @NotNull
     private final Logger logger;
@@ -261,7 +255,6 @@ public class JitsiMeetConferenceImpl
         this.includeInStatistics = includeInStatistics;
 
         this.jicofoServices = Objects.requireNonNull(JicofoServices.jicofoServicesSingleton);
-        queueExecutor = new QueueExecutor(TaskPools.getIoPool(), "JitsiMeetConference-queueExecutor", logger);
 
         logger.info("Created new conference.");
     }
@@ -449,7 +442,6 @@ public class JitsiMeetConferenceImpl
 
         chatRoom = getClientXmppProvider().findOrCreateRoom(roomName);
         chatRoom.addListener(chatRoomListener);
-        chatRoom.setEventExecutor(queueExecutor);
 
         AuthenticationAuthority authenticationAuthority = jicofoServices.getAuthenticationAuthority();
         if (authenticationAuthority != null)

--- a/src/test/java/mock/muc/MockChatRoom.java
+++ b/src/test/java/mock/muc/MockChatRoom.java
@@ -234,11 +234,6 @@ public class MockChatRoom
     }
 
     @Override
-    public void setEventExecutor(@NotNull Executor executor)
-    {
-    }
-
-    @Override
     public void leave()
     {
         if (!isJoined)


### PR DESCRIPTION
Emitting async was necessary in order to offload work from Smack's
single threaded executor. This is no longer necessary with Smack 4.4.4
as it uses a cached pool (segmented by MUC).

Processing presence from smack sync, but emitting async can lead to the
number of chat room members being out of sync.