### PR TITLE
chore: Remove the sentry and agafua-syslog runtime dependencies.

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -31,8 +31,8 @@ com.agafua.syslog.SyslogHandler.formatter = org.jitsi.utils.logging2.JitsiLogFor
 com.agafua.syslog.SyslogHandler.escapeNewlines = false
 com.agafua.syslog.SyslogHandler.filter = org.jitsi.impl.protocol.xmpp.log.ExcludeXmppPackets
 
-# Sentry (uncomment handler to use)
-io.sentry.jul.SentryHandler.level=WARNING
+# Sentry (also add the sentry handler to "handlers" to use)
+# io.sentry.jul.SentryHandler.level=WARNING
 
 # uncomment to see how Jicofo talks to the JVB
 #org.jitsi.impl.protocol.xmpp.colibri.level=ALL

--- a/pom.xml
+++ b/pom.xml
@@ -169,19 +169,6 @@
       <artifactId>spotbugs-annotations</artifactId>
       <version>${spotbugs.version}</version>
     </dependency>
-    <!-- runtime -->
-    <dependency>
-      <groupId>rusv</groupId>
-      <artifactId>agafua-syslog</artifactId>
-      <version>0.4</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.sentry</groupId>
-      <artifactId>sentry</artifactId>
-      <version>5.4.0</version>
-      <scope>runtime</scope>
-    </dependency>
     <!-- test -->
     <dependency>
       <groupId>org.xmlunit</groupId>


### PR DESCRIPTION
This is to stop shipping non-essential jars and reduce potential exposure to vulnerabilities. Setting up sentry requires setting an environment variable (and potentially more changes?), so it should be easy to adapt to also include the sentry jar in the classpath.

cc @saghul @sapkra
