### PR TITLE
fix(multi-stream): generate source name

### DIFF
--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1286,7 +1286,8 @@ public class JitsiMeetConferenceImpl
             // This is not necessary (and might trigger unexpected behavior) with colibri2.
             long ssrc = RANDOM.nextInt() & 0xffff_ffffL;
             logger.info(participant + " did not advertise any SSRCs. Injecting " + ssrc);
-            sourcesAdvertised = new EndpointSourceSet(new Source(ssrc, MediaType.AUDIO, null, null, true));
+            sourcesAdvertised = new EndpointSourceSet(
+                    new Source(ssrc, MediaType.AUDIO, participantId + "-injected0", null, true));
         }
         ConferenceSourceMap sourcesAccepted;
         try


### PR DESCRIPTION
...for injected audio sources.

It is required, because of this constraint:

https://github.com/jitsi/jitsi-videobridge/pull/1793/files#diff-9d9ade953a28940dd8dc6ad1a9378bacde2eab16400e03959d3bac1cb539f46fL295

I think it's okay to generate the source-name here, because it's Jicofo who's in charge of signaling this one and my understanding is that it's removed eventually.