### PR TITLE
Fix removing sources for octo

### DIFF
--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1394,8 +1394,8 @@ public class JitsiMeetConferenceImpl
      *
      * @param participant the participant that owns the sources to be removed.
      * @param sourcesRequestedToBeRemoved the sources that an endpoint requested to be removed from the conference.
-     * @param sendSourceRemove Whether to send source-remove IQs to the remaining participants.
      * @param removeColibriSourcesFromLocalBridge whether to signal the source removal to the local bridge (we use
+     * @param sendSourceRemove Whether to send source-remove IQs to the remaining participants.
      * "false" to avoid sending an unnecessary "remove source" message just prior to the "expire" message).
      */
     private StanzaError removeSources(

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1395,6 +1395,8 @@ public class JitsiMeetConferenceImpl
      * @param participant the participant that owns the sources to be removed.
      * @param sourcesRequestedToBeRemoved the sources that an endpoint requested to be removed from the conference.
      * @param sendSourceRemove Whether to send source-remove IQs to the remaining participants.
+     * @param removeColibriSourcesFromLocalBridge whether to signal the source removal to the local bridge (we use
+     * "false" to avoid sending an unnecessary "remove source" message just prior to the "expire" message).
      */
     private StanzaError removeSources(
             @NotNull Participant participant,

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -851,9 +851,6 @@ public class JitsiMeetConferenceImpl
             EndpointSourceSet participantSources = participant.getSources().get(participant.getMucJid());
             if (participantSources != null)
             {
-                // This is inefficient because it sends one colibri request to remove the sources and another one
-                // to expire the channels/endpoint.
-                // TODO: clean-up when colibri1 is removed.
                 removeSources(participant, participantSources, false, sendSourceRemove);
             }
 

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -854,7 +854,7 @@ public class JitsiMeetConferenceImpl
                 // This is inefficient because it sends one colibri request to remove the sources and another one
                 // to expire the channels/endpoint.
                 // TODO: clean-up when colibri1 is removed.
-                removeSources(participant, participantSources, sendSourceRemove);
+                removeSources(participant, participantSources, false, sendSourceRemove);
             }
 
             participant.setJingleSession(null);
@@ -1265,7 +1265,7 @@ public class JitsiMeetConferenceImpl
         }
         else
         {
-            return removeSources(participant, sourcesRequestedToBeRemoved, true);
+            return removeSources(participant, sourcesRequestedToBeRemoved, true, true);
         }
     }
 
@@ -1402,6 +1402,7 @@ public class JitsiMeetConferenceImpl
     private StanzaError removeSources(
             @NotNull Participant participant,
             EndpointSourceSet sourcesRequestedToBeRemoved,
+            boolean removeColibriSourcesFromLocalBridge,
             boolean sendSourceRemove)
     {
         Jid participantJid = participant.getMucJid();
@@ -1429,7 +1430,10 @@ public class JitsiMeetConferenceImpl
             return null;
         }
 
-        colibriSessionManager.removeSources(participant, sourcesAcceptedToBeRemoved);
+        colibriSessionManager.removeSources(
+                participant,
+                sourcesAcceptedToBeRemoved,
+                removeColibriSourcesFromLocalBridge);
 
         if (sendSourceRemove)
         {

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1395,8 +1395,8 @@ public class JitsiMeetConferenceImpl
      * @param participant the participant that owns the sources to be removed.
      * @param sourcesRequestedToBeRemoved the sources that an endpoint requested to be removed from the conference.
      * @param removeColibriSourcesFromLocalBridge whether to signal the source removal to the local bridge (we use
-     * @param sendSourceRemove Whether to send source-remove IQs to the remaining participants.
      * "false" to avoid sending an unnecessary "remove source" message just prior to the "expire" message).
+     * @param sendSourceRemove Whether to send source-remove IQs to the remaining participants.
      */
     private StanzaError removeSources(
             @NotNull Participant participant,

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -845,21 +845,20 @@ public class JitsiMeetConferenceImpl
             JingleSession jingleSession = participant.getJingleSession();
             if (jingleSession != null)
             {
-
                 jingle.terminateSession(jingleSession, reason, message, sendSessionTerminate);
-
-                EndpointSourceSet participantSources = participant.getSources().get(participant.getMucJid());
-                if (participantSources != null)
-                {
-                    removeSources(
-                            participant,
-                            participantSources,
-                            false /* no JVB update - will expire */,
-                            sendSourceRemove);
-                }
-
-                participant.setJingleSession(null);
             }
+
+            EndpointSourceSet participantSources = participant.getSources().get(participant.getMucJid());
+            if (participantSources != null)
+            {
+                removeSources(
+                        participant,
+                        participantSources,
+                        false /* no JVB update - will expire */,
+                        sendSourceRemove);
+            }
+
+            participant.setJingleSession(null);
 
             boolean removed = participants.remove(participant);
             logger.info("Removed participant " + participant.getChatMember().getName() + " removed=" + removed);

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/ColibriSessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/ColibriSessionManager.kt
@@ -53,7 +53,16 @@ interface ColibriSessionManager {
      *  Note at the time this is called [participant.sources] have already been updated.
      * TODO: remove in favor of updateParticipant
      */
-    fun removeSources(participant: Participant, sources: ConferenceSourceMap)
+    fun removeSources(
+        participant: Participant,
+        sources: ConferenceSourceMap,
+        /**
+         * If this is `false`, the source removal will only be signaled to remote bridges. This is used to avoid sending
+         * an unnecessary "remove sources" message prior to the endpoint itself being expired (the "remove sources"
+         * message for remote bridges is always necessary).
+         */
+        removeSourcesFromLocalBridge: Boolean
+    )
     fun mute(participant: Participant, doMute: Boolean, mediaType: MediaType): Boolean
     val bridgeCount: Int
     val bridgeRegions: Set<String>

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v1/ColibriV1SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v1/ColibriV1SessionManager.kt
@@ -299,14 +299,20 @@ class ColibriV1SessionManager(
     }
 
     /** Remove sources for a [participant] */
-    override fun removeSources(participant: Participant, sources: ConferenceSourceMap) {
+    override fun removeSources(
+        participant: Participant,
+        sources: ConferenceSourceMap,
+        removeSourcesFromLocalBridge: Boolean
+    ) {
         // TODO error handling
         val bridgeSession = findBridgeSession(participant)
         if (bridgeSession != null) {
-            bridgeSession.colibriConference.updateSourcesInfo(
-                participant.sources,
-                participantInfoMap[participant]?.colibriChannels
-            )
+            if (removeSourcesFromLocalBridge) {
+                bridgeSession.colibriConference.updateSourcesInfo(
+                    participant.sources,
+                    participantInfoMap[participant]?.colibriChannels
+                )
+            }
             removeSourcesFromOcto(sources, bridgeSession)
         }
     }

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
@@ -105,7 +105,7 @@ internal class Colibri2Session(
         /** The transport info to set for the colibri2 endpoint, or null if it is not to be modified. */
         transport: IceUdpTransportPacketExtension?,
         /** The sources to set for the colibri2 endpoint, or null if the sources are not to be modified. */
-        sources: ConferenceSourceMap?,
+        sources: ConferenceSourceMap?
     ) {
         if (transport == null && sources == null) {
             logger.info("Nothing to update.")

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
@@ -105,7 +105,7 @@ internal class Colibri2Session(
         /** The transport info to set for the colibri2 endpoint, or null if it is not to be modified. */
         transport: IceUdpTransportPacketExtension?,
         /** The sources to set for the colibri2 endpoint, or null if the sources are not to be modified. */
-        sources: ConferenceSourceMap?
+        sources: ConferenceSourceMap?,
     ) {
         if (transport == null && sources == null) {
             logger.info("Nothing to update.")

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -421,7 +421,9 @@ class ColibriV2SessionManager(
 
         val participantInfo = participants[participant.endpointId]
             ?: throw IllegalStateException("No participantInfo for $participant")
-        participantInfo.session.updateParticipant(participantInfo, transport, sources)
+        if (!suppressLocalBridgeUpdate) {
+            participantInfo.session.updateParticipant(participantInfo, transport, sources)
+        }
         if (sources != null) {
             // We don't need to make a copy, because we're already passed an unmodifiable copy.
             // TODO: refactor to make that clear (explicit use of UnmodifiableConferenceSourceMap).


### PR DESCRIPTION
- fix: Remove sources when a participant leaved regardless of the presense of a jingle session.
- fix: Remove sources from octo  when a participant leaves.
