### PR TITLE
Performance optimizations

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
@@ -127,7 +127,7 @@ public interface ChatRoom
      * @return an instance of <tt>XmppChatMember</tt> for given MUC jid or
      *         <tt>null</tt> if not found.
      */
-    ChatRoomMember findChatMember(Jid mucJid);
+    ChatRoomMember getChatMember(EntityFullJid mucJid);
 
     /**
      * @return the list of all our presence {@link ExtensionElement}s.

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -416,7 +416,7 @@ public class ChatRoomImpl
     }
 
     @Override
-    public ChatMemberImpl findChatMember(Jid occupantJid)
+    public ChatMemberImpl getChatMember(EntityFullJid occupantJid)
     {
         if (occupantJid == null)
         {
@@ -425,16 +425,8 @@ public class ChatRoomImpl
 
         synchronized (members)
         {
-            for (ChatMemberImpl member : members.values())
-            {
-                if (occupantJid.equals(member.getOccupantJid()))
-                {
-                    return member;
-                }
-            }
+            return members.get(occupantJid);
         }
-
-        return null;
     }
 
     @Override
@@ -793,7 +785,7 @@ public class ChatRoomImpl
 
         synchronized (members)
         {
-            chatMember = findChatMember(jid);
+            chatMember = getChatMember(jid);
             if (chatMember == null)
             {
                 if (presence.getType().equals(Presence.Type.available))

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
@@ -53,7 +53,7 @@ public interface JitsiMeetConference
      *
      * @return {@link Participant} instance or <tt>null</tt> if not found.
      */
-    Participant findParticipantForRoomJid(Jid mucJid);
+    Participant getParticipant(Jid mucJid);
 
     /**
      * @return the set of regions of the bridges currently in the conference.

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -256,8 +256,7 @@ public class JitsiMeetConferenceImpl
 
         this.jicofoServices = Objects.requireNonNull(JicofoServices.jicofoServicesSingleton);
         this.gid = gid;
-        ColibriConfig colibriConfig = new ColibriConfig();
-        if (colibriConfig.getEnableColibri2())
+        if (ColibriConfig.config.getEnableColibri2())
         {
             colibriSessionManager = new ColibriV2SessionManager(
                     jicofoServices.getXmppServices().getServiceConnection().getXmppConnection(),
@@ -1279,7 +1278,7 @@ public class JitsiMeetConferenceImpl
             logger.debug("Received initial sources from " + participantId + ": " + sourcesAdvertised);
         }
         if (sourcesAdvertised.isEmpty() && ConferenceConfig.config.injectSsrcForRecvOnlyEndpoints()
-            && !(new ColibriConfig().getEnableColibri2()))
+            && !(ColibriConfig.config.getEnableColibri2()))
         {
             // We inject an SSRC in order to ensure that the participant has
             // at least one SSRC advertised. Otherwise, non-local bridges in the

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1469,9 +1469,18 @@ public class JitsiMeetConferenceImpl
         return jicofoServices.getXmppServices().getClientConnection();
     }
 
-    public ChatRoomMember findMember(Jid from)
+    /**
+     * Checks if this conference has a member with a specific occupant JID. Note that we check for the existence of a
+     * member in the chat room instead of a {@link Participant} (it's not clear whether the distinction is important).
+     * @param jid the occupant JID of the member.
+     * @return
+     */
+    public boolean hasMember(Jid jid)
     {
-        return chatRoom == null ? null : chatRoom.findChatMember(from);
+        ChatRoom chatRoom = this.chatRoom;
+        return chatRoom != null
+                && (jid instanceof EntityFullJid)
+                && chatRoom.getChatMember((EntityFullJid) jid) != null;
     }
 
     /**

--- a/src/main/java/org/jitsi/jicofo/conference/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/conference/Participant.java
@@ -86,6 +86,7 @@ public class Participant
     /**
      * MUC chat member of this participant.
      */
+    @NotNull
     private final ChatRoomMember roomMember;
 
     /**
@@ -203,6 +204,7 @@ public class Participant
      * Returns {@link ChatRoomMember} that represents this participant in
      * conference multi-user chat room.
      */
+    @NotNull
     public ChatRoomMember getChatMember()
     {
         return roomMember;

--- a/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
+++ b/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
@@ -335,7 +335,7 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
 
             expireChannels = true;
         }
-        else if (meetConference.findMember(address) == null)
+        else if (!meetConference.hasMember(address))
         {
             // Participant has left the room
             logger.info("Expiring " + address + " channels - participant has left");

--- a/src/main/java/org/jitsi/jicofo/lipsynchack/LipSyncHack.java
+++ b/src/main/java/org/jitsi/jicofo/lipsynchack/LipSyncHack.java
@@ -161,7 +161,7 @@ public class LipSyncHack implements OperationSetJingle
 
     private boolean receiverSupportsLipSync(Jid receiverJid)
     {
-        Participant receiver = conference.findParticipantForRoomJid(receiverJid);
+        Participant receiver = conference.getParticipant(receiverJid);
         return receiver != null && receiver.hasLipSyncSupport();
     }
 
@@ -327,7 +327,7 @@ public class LipSyncHack implements OperationSetJingle
             Source existingAudioSource = null;
             if (!haveValidAudioSource)
             {
-                Participant owner = conference.findParticipantForRoomJid(ownerJid);
+                Participant owner = conference.getParticipant(ownerJid);
                 if (owner != null)
                 {
                     EndpointSourceSet existingOwnerSources = owner.getSources().get(ownerJid);

--- a/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
+++ b/src/main/java/org/jitsi/protocol/xmpp/AbstractOperationSetJingle.java
@@ -132,7 +132,7 @@ public abstract class AbstractOperationSetJingle
 
         JingleIQ inviteIQ = JingleUtilsKt.createSessionInitiate(getOurJID(), to, contents);
         String sid = inviteIQ.getSID();
-        JingleSession session = new JingleSession(sid, inviteIQ.getTo(), requestHandler);
+        JingleSession session = new JingleSession(sid, to, requestHandler);
 
         inviteIQ.addExtension(GroupPacketExtension.createBundleGroup(inviteIQ.getContentList()));
         additionalExtensions.forEach(inviteIQ::addExtension);

--- a/src/main/kotlin/org/jitsi/jicofo/ConferenceConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/ConferenceConfig.kt
@@ -26,7 +26,7 @@ import java.time.Duration
 import java.util.TreeMap
 
 @SuppressFBWarnings(value = ["BX_UNBOXING_IMMEDIATELY_REBOXED"], justification = "False positive.")
-class ConferenceConfig {
+class ConferenceConfig private constructor() {
     val conferenceStartTimeout: Duration by config {
         "org.jitsi.focus.IDLE_TIMEOUT".from(legacyConfig)
         "jicofo.conference.initial-timeout".from(newConfig)

--- a/src/main/kotlin/org/jitsi/jicofo/JicofoConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/JicofoConfig.kt
@@ -22,7 +22,7 @@ import org.jitsi.config.JitsiConfig.Companion.newConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.optionalconfig
 
-class JicofoConfig {
+class JicofoConfig private constructor() {
     val localRegion: String? by optionalconfig {
         "org.jitsi.jicofo.BridgeSelector.LOCAL_REGION".from(legacyConfig)
         "$BASE.local-region".from(newConfig)

--- a/src/main/kotlin/org/jitsi/jicofo/auth/AuthConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/auth/AuthConfig.kt
@@ -24,7 +24,7 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.optionalconfig
 import java.time.Duration
 
-class AuthConfig {
+class AuthConfig private constructor() {
     val enabled: Boolean by config {
         // Enabled if the URL is set to anything
         legacyLoginUrlPropertyName.from(legacyConfig).convertFrom<String> { true }

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
@@ -28,7 +28,7 @@ import java.time.Duration
 /**
  * Config for classes in the org.jicofo.bridge package.
  */
-class BridgeConfig {
+class BridgeConfig private constructor() {
     val maxBridgeParticipants: Int by config {
         "org.jitsi.jicofo.BridgeSelector.MAX_PARTICIPANTS_PER_BRIDGE".from(JitsiConfig.legacyConfig)
         "$BASE.max-bridge-participants".from(JitsiConfig.newConfig)

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -54,7 +54,7 @@ class BridgeSelector @JvmOverloads constructor(
     /**
      * The bridge selection strategy.
      */
-    private val bridgeSelectionStrategy = BridgeConfig().selectionStrategy.also {
+    private val bridgeSelectionStrategy = BridgeConfig.config.selectionStrategy.also {
         logger.info("Using ${it.javaClass.name}")
     }
 

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -185,7 +185,7 @@ class BridgeSelector @JvmOverloads constructor(
             return null
         }
 
-        if (ColibriConfig().enableColibri2) {
+        if (ColibriConfig.config.enableColibri2) {
             candidateBridges = candidateBridges.filter { it.supportsColibri2() }
             if (candidateBridges.isEmpty()) {
                 logger.warn("There are no bridges with colibri2 support.")

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/ColibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/ColibriConfig.kt
@@ -20,8 +20,13 @@ package org.jitsi.jicofo.conference.colibri
 import org.jitsi.config.JitsiConfig.Companion.newConfig
 import org.jitsi.metaconfig.config
 
-class ColibriConfig {
+class ColibriConfig private constructor() {
     val enableColibri2: Boolean by config {
         "jicofo.colibri.enable-colibri2".from(newConfig)
+    }
+
+    companion object {
+        @JvmField
+        val config = ColibriConfig()
     }
 }

--- a/src/main/kotlin/org/jitsi/jicofo/health/HealthConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/health/HealthConfig.kt
@@ -22,7 +22,7 @@ import org.jitsi.config.JitsiConfig.Companion.newConfig
 import org.jitsi.metaconfig.config
 import java.time.Duration
 
-class HealthConfig {
+class HealthConfig private constructor() {
     val enabled: Boolean by config {
         "org.jitsi.jicofo.health.ENABLE_HEALTH_CHECKS".from(legacyConfig)
         "jicofo.health.enabled".from(newConfig)

--- a/src/main/kotlin/org/jitsi/jicofo/jibri/BaseJibri.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/jibri/BaseJibri.kt
@@ -133,12 +133,9 @@ abstract class BaseJibri internal constructor(
         if (!conference.roomName.equals(roomName)) {
             return false
         }
-        val chatMember = conference.findMember(from)
-        if (chatMember == null) {
-            logger.warn("Chat member not found for: $from")
-            return false
+        return conference.hasMember(from).apply {
+            if (!this) logger.warn("No chat member found for: $from")
         }
-        return true
     }
 
     protected abstract fun acceptType(packet: JibriIq): Boolean

--- a/src/main/kotlin/org/jitsi/jicofo/jibri/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/jibri/JibriConfig.kt
@@ -26,7 +26,7 @@ import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
 import java.time.Duration
 
-class JibriConfig {
+class JibriConfig private constructor() {
     val breweryJid: EntityBareJid? by optionalconfig {
         "org.jitsi.jicofo.jibri.BREWERY".from(legacyConfig).convertFrom<String> {
             JidCreate.entityBareFrom(it)

--- a/src/main/kotlin/org/jitsi/jicofo/jigasi/JigasiConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/jigasi/JigasiConfig.kt
@@ -25,7 +25,7 @@ import org.jitsi.metaconfig.optionalconfig
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
 
-class JigasiConfig {
+class JigasiConfig private constructor() {
     val breweryJid: EntityBareJid? by optionalconfig {
         "org.jitsi.jicofo.jigasi.BREWERY".from(legacyConfig).convertFrom<String> {
             JidCreate.entityBareFrom(it)

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppConfig.kt
@@ -26,7 +26,7 @@ import org.jxmpp.jid.impl.JidCreate
 import org.jxmpp.jid.parts.Resourcepart
 import java.time.Duration
 
-class XmppConfig {
+class XmppConfig private constructor() {
     val trustedDomains: List<DomainBareJid> by config {
         "jicofo.xmpp.trusted-domains".from(newConfig)
             .convertFrom<List<String>> { l -> l.map { JidCreate.domainBareFrom(it) } }

--- a/src/test/java/mock/muc/MockChatRoom.java
+++ b/src/test/java/mock/muc/MockChatRoom.java
@@ -325,7 +325,7 @@ public class MockChatRoom
     }
 
     @Override
-    public ChatRoomMember findChatMember(Jid mucJid)
+    public ChatRoomMember getChatMember(EntityFullJid mucJid)
     {
         return findMember(mucJid.getResourceOrNull());
     }

--- a/src/test/java/mock/muc/MockMucShare.java
+++ b/src/test/java/mock/muc/MockMucShare.java
@@ -70,7 +70,7 @@ public class MockMucShare
             if (chatToNotify != chatRoom)
             {
                 MockRoomMember mockRoomMember
-                    = (MockRoomMember) chatToNotify.findChatMember(chatRoomMember.getOccupantJid());
+                    = (MockRoomMember) chatToNotify.getChatMember(chatRoomMember.getOccupantJid());
                 if (mockRoomMember != null)
                 {
                     chatToNotify.mockLeave(mockRoomMember.getName());

--- a/src/test/kotlin/org/jitsi/jicofo/ConferenceConfigTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/ConferenceConfigTest.kt
@@ -25,9 +25,8 @@ class ConferenceConfigTest : ShouldSpec() {
     init {
         context("source-signaling-delays") {
             context("With no delay configured") {
-                val config = ConferenceConfig()
                 for (i in 0..100) {
-                    config.getSourceSignalingDelayMs(i) shouldBe 0
+                    ConferenceConfig.config.getSourceSignalingDelayMs(i) shouldBe 0
                 }
             }
             context("With delay configured") {
@@ -41,16 +40,17 @@ class ConferenceConfigTest : ShouldSpec() {
                     }
                     """.trimIndent()
                 ) {
-                    val config = ConferenceConfig()
-                    config.getSourceSignalingDelayMs(0) shouldBe 0
-                    config.getSourceSignalingDelayMs(50) shouldBe 0
-                    config.getSourceSignalingDelayMs(99) shouldBe 0
-                    config.getSourceSignalingDelayMs(100) shouldBe 500
-                    config.getSourceSignalingDelayMs(199) shouldBe 500
-                    config.getSourceSignalingDelayMs(200) shouldBe 1000
-                    config.getSourceSignalingDelayMs(299) shouldBe 1000
-                    config.getSourceSignalingDelayMs(300) shouldBe 2000
-                    config.getSourceSignalingDelayMs(5000) shouldBe 2000
+                    ConferenceConfig.config.apply {
+                        getSourceSignalingDelayMs(0) shouldBe 0
+                        getSourceSignalingDelayMs(50) shouldBe 0
+                        getSourceSignalingDelayMs(99) shouldBe 0
+                        getSourceSignalingDelayMs(100) shouldBe 500
+                        getSourceSignalingDelayMs(199) shouldBe 500
+                        getSourceSignalingDelayMs(200) shouldBe 1000
+                        getSourceSignalingDelayMs(299) shouldBe 1000
+                        getSourceSignalingDelayMs(300) shouldBe 2000
+                        getSourceSignalingDelayMs(5000) shouldBe 2000
+                    }
                 }
             }
         }

--- a/src/test/kotlin/org/jitsi/jicofo/auth/AuthConfigTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/auth/AuthConfigTest.kt
@@ -28,15 +28,14 @@ class AuthConfigTest : ShouldSpec() {
 
     init {
         context("Default values") {
-            val config = AuthConfig()
-            config.enabled shouldBe false
-            config.enableAutoLogin shouldBe true
-            shouldThrow<Exception> {
-                config.loginUrl
+            AuthConfig.config.apply {
+                enabled shouldBe false
+                enableAutoLogin shouldBe true
+                shouldThrow<Exception> { loginUrl }
+                logoutUrl shouldBe null
+                type shouldBe AuthConfig.Type.SHIBBOLETH
+                authenticationLifetime shouldBe Duration.ofHours(24)
             }
-            config.logoutUrl shouldBe null
-            config.type shouldBe AuthConfig.Type.SHIBBOLETH
-            config.authenticationLifetime shouldBe Duration.ofHours(24)
         }
         context("With legacy config") {
             withLegacyConfig(
@@ -47,13 +46,14 @@ class AuthConfigTest : ShouldSpec() {
                 org.jitsi.jicofo.auth.AUTH_LIFETIME=60000
                 """
             ) {
-                val config = AuthConfig()
-                config.enabled shouldBe true
-                config.enableAutoLogin shouldBe false
-                config.loginUrl shouldBe "test@example.com"
-                config.logoutUrl shouldBe "logout"
-                config.type shouldBe AuthConfig.Type.XMPP
-                config.authenticationLifetime shouldBe Duration.ofMillis(60000)
+                AuthConfig.config.apply {
+                    enabled shouldBe true
+                    enableAutoLogin shouldBe false
+                    loginUrl shouldBe "test@example.com"
+                    logoutUrl shouldBe "logout"
+                    type shouldBe AuthConfig.Type.XMPP
+                    authenticationLifetime shouldBe Duration.ofMillis(60000)
+                }
             }
         }
         context("With new config") {
@@ -69,14 +69,14 @@ class AuthConfigTest : ShouldSpec() {
                 }
             """
             ) {
-                val config = AuthConfig()
-
-                config.enabled shouldBe false
-                config.enableAutoLogin shouldBe false
-                config.loginUrl shouldBe "login"
-                config.logoutUrl shouldBe "logout"
-                config.type shouldBe AuthConfig.Type.JWT
-                config.authenticationLifetime shouldBe Duration.ofMinutes(5)
+                AuthConfig.config.apply {
+                    enabled shouldBe false
+                    enableAutoLogin shouldBe false
+                    loginUrl shouldBe "login"
+                    logoutUrl shouldBe "logout"
+                    type shouldBe AuthConfig.Type.JWT
+                    authenticationLifetime shouldBe Duration.ofMinutes(5)
+                }
             }
         }
     }


### PR DESCRIPTION
- opt: Use a map for participants, linear search is slow for large conferences.
- opt: Do not search the members map linearly, cleanup
- ref: Use a static instance for colibri config.
- ref: Use a static instance for AuthConfig.
- ref: Use a static instance for BridgeConfig.
- ref: Make the HealthConfig constructor private.
- ref: Use a static instance for ConferenceConfig.
- ref: Make the JigasiConfig constructor private.
- ref: Make the XmppConfig constructor private.
- ref: Make the JicofoConfig constrructor private.
- ref: Make the JibriConfig constructor private.
