### PR TITLE
Logging adjustments

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProviderImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProviderImpl.java
@@ -139,8 +139,11 @@ public class XmppProviderImpl
                 .setPort(config.getPort())
                 .setXmppDomain(config.getDomain());
 
-        // Required for PacketDebugger and XMPP stats to work
-        connConfig.setDebuggerFactory(PacketDebugger::new);
+        if (PacketDebugger.isEnabled())
+        {
+            // If XMPP debug logging is enabled, insert our debugger.
+            connConfig.setDebuggerFactory(PacketDebugger::new);
+        }
 
         if (!config.getUseTls())
         {

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProviderImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProviderImpl.java
@@ -142,7 +142,7 @@ public class XmppProviderImpl
         if (PacketDebugger.isEnabled())
         {
             // If XMPP debug logging is enabled, insert our debugger.
-            connConfig.setDebuggerFactory(PacketDebugger::new);
+            connConfig.setDebuggerFactory((connection) -> new PacketDebugger(connection, config.getName()));
         }
 
         if (!config.getUseTls())

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProviderImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/XmppProviderImpl.java
@@ -290,26 +290,6 @@ public class XmppProviderImpl
         return jingleOpSet;
     }
 
-    /**
-     * Generates a {@link JSONObject} with statistics for this {@link XmppProviderImpl}.
-     * @return JSON stats
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    public @NotNull JSONObject getStats()
-    {
-        JSONObject stats = new JSONObject();
-
-        PacketDebugger debugger = PacketDebugger.forConnection(connection);
-        if (debugger != null)
-        {
-            stats.put("total_sent", debugger.getTotalPacketsSent());
-            stats.put("total_recv", debugger.getTotalPacketsRecv());
-        }
-
-        return stats;
-    }
-
     @Override
     public @NotNull ChatRoom createRoom(@NotNull EntityBareJid name) throws RoomExistsException
     {

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/log/PacketDebugger.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/log/PacketDebugger.java
@@ -21,10 +21,7 @@ import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.debugger.*;
 import org.jivesoftware.smack.packet.*;
 
-import java.io.*;
 import java.lang.*;
-import java.util.*;
-import java.util.concurrent.atomic.*;
 
 /**
  * Implements {@link SmackDebugger} in order to get info about XMPP traffic.
@@ -33,13 +30,6 @@ public class PacketDebugger
     extends AbstractDebugger
 {
     /**
-     * Weak mapping between {@link XMPPConnection} and {@link PacketDebugger}
-     * for convenient access(XMPP connection doesn't have a getter for
-     * the debugger field).
-     */
-    private static final WeakHashMap<XMPPConnection, PacketDebugger> debuggerMap = new WeakHashMap<>();
-
-    /**
      * The logger used by this class.
      */
     private final static Logger logger = new LoggerImpl(PacketDebugger.class.getName());
@@ -47,33 +37,11 @@ public class PacketDebugger
     /**
      * Whether XMPP logging is enabled. We don't want to insert a debugger into Smack when it's not going to actually
      * log anything.
-     * Note that the "packets" received/sent stats are only available when debug logging is enabled.
      */
     public static boolean isEnabled()
     {
         return logger.isDebugEnabled();
     }
-
-    /**
-     * Finds {@link PacketDebugger} for given connection.
-     * @param connection - the connection for which {@link PacketDebugger} will
-     * be retrieved.
-     * @return debugger instance for given connection.
-     */
-    static public PacketDebugger forConnection(XMPPConnection connection)
-    {
-        return debuggerMap.get(connection);
-    }
-
-    /**
-     * Total XMPP packets  received.
-     */
-    private AtomicLong totalPacketsRecv = new AtomicLong();
-
-    /**
-     * Total XMPP packets sent.
-     */
-    private AtomicLong totalPacketsSent = new AtomicLong();
 
     /**
      * Creates new {@link PacketDebugger}
@@ -86,37 +54,15 @@ public class PacketDebugger
 
         // Change the static value only if an instance is created.
         AbstractDebugger.printInterpreted = true;
-
-        debuggerMap.put(connection, this);
-    }
-
-    /**
-     * @return total XMPP packets received for the lifetime of the tracked
-     * {@link XMPPConnection} instance.
-     */
-    public long getTotalPacketsRecv()
-    {
-        return totalPacketsRecv.get();
-    }
-
-    /**
-     * @return total XMPP packets sent for the lifetime of the tracked
-     * {@link XMPPConnection} instance.
-     */
-    public long getTotalPacketsSent()
-    {
-        return totalPacketsSent.get();
     }
 
     @Override
     public void onIncomingStreamElement(TopLevelStreamElement streamElement) {
-        totalPacketsRecv.incrementAndGet();
         logger.debug(() -> "RCV PKT (" + connection.getConnectionCounter() + "): " + streamElement.toXML());
     }
 
     @Override
     public void onOutgoingStreamElement(TopLevelStreamElement streamElement) {
-        totalPacketsSent.incrementAndGet();
         logger.debug(() -> "SENT PKT (" + connection.getConnectionCounter() + "): " + streamElement.toXML());
     }
 

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/log/PacketDebugger.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/log/PacketDebugger.java
@@ -45,6 +45,16 @@ public class PacketDebugger
     private final static Logger logger = new LoggerImpl(PacketDebugger.class.getName());
 
     /**
+     * Whether XMPP logging is enabled. We don't want to insert a debugger into Smack when it's not going to actually
+     * log anything.
+     * Note that the "packets" received/sent stats are only available when debug logging is enabled.
+     */
+    public static boolean isEnabled()
+    {
+        return logger.isDebugEnabled();
+    }
+
+    /**
      * Finds {@link PacketDebugger} for given connection.
      * @param connection - the connection for which {@link PacketDebugger} will
      * be retrieved.

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/log/PacketDebugger.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/log/PacketDebugger.java
@@ -44,13 +44,20 @@ public class PacketDebugger
     }
 
     /**
+     * An ID to log to identify the connection.
+     */
+    @NonNull
+    private final String id;
+
+    /**
      * Creates new {@link PacketDebugger}
      * {@inheritDoc}
      */
     @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
-    public PacketDebugger(XMPPConnection connection)
+    public PacketDebugger(XMPPConnection connection, @NonNull String id)
     {
         super(connection);
+        this.id = id;
 
         // Change the static value only if an instance is created.
         AbstractDebugger.printInterpreted = true;
@@ -58,12 +65,12 @@ public class PacketDebugger
 
     @Override
     public void onIncomingStreamElement(TopLevelStreamElement streamElement) {
-        logger.debug(() -> "RCV PKT (" + connection.getConnectionCounter() + "): " + streamElement.toXML());
+        logger.debug(() -> "RCV PKT (" + id + "): " + streamElement.toXML());
     }
 
     @Override
     public void onOutgoingStreamElement(TopLevelStreamElement streamElement) {
-        logger.debug(() -> "SENT PKT (" + connection.getConnectionCounter() + "): " + streamElement.toXML());
+        logger.debug(() -> "SENT PKT (" + id + "): " + streamElement.toXML());
     }
 
     // It's fine to do non-atomic as it's only 1 thread doing write operation

--- a/src/main/kotlin/org/jitsi/impl/protocol/xmpp/XmppProvider.kt
+++ b/src/main/kotlin/org/jitsi/impl/protocol/xmpp/XmppProvider.kt
@@ -21,7 +21,6 @@ import org.jitsi.jicofo.xmpp.XmppConnectionConfig
 import org.jitsi.protocol.xmpp.OperationSetJingle
 import org.jivesoftware.smack.AbstractXMPPConnection
 import org.jivesoftware.smackx.disco.packet.DiscoverInfo
-import org.json.simple.JSONObject
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.EntityFullJid
 import org.jxmpp.jid.Jid

--- a/src/main/kotlin/org/jitsi/impl/protocol/xmpp/XmppProvider.kt
+++ b/src/main/kotlin/org/jitsi/impl/protocol/xmpp/XmppProvider.kt
@@ -62,7 +62,6 @@ interface XmppProvider {
 
     fun discoverFeatures(jid: EntityFullJid): List<String>
     fun discoverInfo(jid: Jid): DiscoverInfo?
-    fun getStats(): JSONObject
 
     class RoomExistsException(message: String) : Exception(message)
 }

--- a/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -205,10 +205,6 @@ open class JicofoServices {
         putAll(focusManager.stats)
         putAll(ColibriConferenceImpl.stats.toJson())
 
-        // XMPP traffic stats
-        put("xmpp", xmppServices.clientConnection.getStats())
-        put("xmpp_service", xmppServices.serviceConnection.getStats())
-
         put("bridge_selector", bridgeSelector.stats)
         jibriDetector?.let { put("jibri_detector", it.stats) }
         sipJibriDetector?.let { put("sip_jibri_detector", it.stats) }

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
@@ -417,7 +417,7 @@ internal class Colibri2Session(
             relay.setEndpoints(endpoints.build())
             request.addRelay(relay.build())
 
-            logger.info("Expiring ${participants.map { it.id }}")
+            logger.debug { "Expiring ${participants.map { it.id }}" }
             logger.trace { "Sending ${request.build().toXML()}" }
             xmppConnection.sendIqAndLogResponse(request.build(), logger)
         }

--- a/src/test/java/mock/MockXmppProvider.java
+++ b/src/test/java/mock/MockXmppProvider.java
@@ -25,7 +25,6 @@ import org.jitsi.jicofo.discovery.*;
 import org.jitsi.jicofo.xmpp.*;
 import org.jitsi.protocol.xmpp.*;
 import org.jivesoftware.smackx.disco.packet.*;
-import org.json.simple.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
 import org.jxmpp.stringprep.*;
@@ -152,12 +151,5 @@ public class MockXmppProvider
     public DiscoverInfo discoverInfo(@NotNull Jid jid)
     {
         return null;
-    }
-
-    @NotNull
-    @Override
-    public JSONObject getStats()
-    {
-        return new JSONObject();
     }
 }


### PR DESCRIPTION
- log: Log expiring relayed endpoints at debug.
- fix: Only insert a debugger into smack when debug logging is enabled.
- feat: Remove xmpp "packet stats".
- feat: Use the connection name when logging XMPP traffic
