### PR TITLE
Colibri2 fixes

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
@@ -145,7 +145,15 @@ public class JvbDoctor
             }
             catch (Exception e)
             {
-                logger.error("Error when doing health-check on: " + bridge, e);
+                // If the task was canceled while running it will throw InterruptedException, ignore it.
+                if (taskInvalid() && e instanceof InterruptedException)
+                {
+                    logger.debug("The task has been canceled.");
+                }
+                else
+                {
+                    logger.error("Error when doing health-check on: " + bridge, e);
+                }
             }
         }
 
@@ -176,7 +184,7 @@ public class JvbDoctor
          * the task should terminate.
          */
         private void doHealthCheck()
-            throws SmackException.NotConnectedException
+            throws SmackException.NotConnectedException, InterruptedException
         {
             AbstractXMPPConnection connection = getConnection();
             // If XMPP is currently not connected skip the health-check

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
@@ -167,6 +167,8 @@ internal class Colibri2Session(
         if (create) {
             setCreate(true)
             setConferenceName(colibriSessionManager.conferenceName)
+            setCallstatsEnabled(colibriSessionManager.callstatsEnabled)
+            setRtcstatsEnabled(colibriSessionManager.rtcStatsEnabled)
         }
     }
 

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -425,7 +425,12 @@ class ColibriV2SessionManager(
         logger.info("Updating $participant with transport=$transport, sources=$sources")
 
         val participantInfo = participants[participant.endpointId]
-            ?: throw IllegalStateException("No participantInfo for $participant")
+            ?: run {
+                // This can happen after a colibri session is removed due to a failure to allocate, since we never
+                // notify the JitsiMeetConferenceImpl object of the failure.
+                logger.error("No ParticipantInfo for ${participant.endpointId}")
+                return
+            }
         if (!suppressLocalBridgeUpdate) {
             participantInfo.session.updateParticipant(participantInfo, transport, sources)
         }

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -104,6 +104,8 @@ class ColibriV2SessionManager(
     }
 
     internal val conferenceName = conference.roomName.toString()
+    internal val callstatsEnabled = conference.config.callStatsEnabled
+    internal val rtcStatsEnabled = conference.config.rtcStatsEnabled
 
     /**
      * Expire everything.


### PR DESCRIPTION
- fix: Just log a message when ParticipantInfo is missing.
- fix: Do not log exception when a JVB is removed while a health check is running.
- fix: Set the rtcstats/callstats flag for colibri2.
