### PR TITLE
Use drain mode flag in bridge selection.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -116,7 +116,7 @@ public class Bridge
     /**
      * Stores a boolean that indicates whether the bridge is in drain mode.
      */
-    private boolean draining = false;
+    private boolean draining = true; /* Default to true to prevent unwanted selection before reading actual state */
 
     /**
      * The time when this instance has failed.

--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -419,6 +419,14 @@ public class Bridge
         return shutdownInProgress;
     }
 
+    /**
+     * @return true if the bridge is currently in drain mode
+     */
+    public boolean isDraining()
+    {
+        return draining;
+    }
+
     @NonNull
     public OrderedJsonObject getDebugState()
     {

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -185,12 +185,12 @@ class BridgeSelector @JvmOverloads constructor(
             return null
         }
 
-        /* If there are active bridges, prefer those */
+        // If there are active bridges, prefer those.
         val activeBridges = candidateBridges.filter { !it.isDraining }.toList()
         if (!activeBridges.isEmpty())
             candidateBridges = activeBridges
 
-        /* If there are bridges not shutting down, prefer those */
+        // If there are bridges not shutting down, prefer those.
         val runningBridges = candidateBridges.filter { !it.isInGracefulShutdown }.toList()
         if (!runningBridges.isEmpty())
             candidateBridges = runningBridges

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -163,28 +163,37 @@ class BridgeSelector @JvmOverloads constructor(
          * */
         version: String? = null
     ): Bridge? {
+
+        var v = conferenceBridges.keys.firstOrNull()?.version
+        if (v == null) {
+            v = version
+        } else if (version != null && version != v) {
+            logger.warn("An inconsistent version was requested: $version. Conference is using version: $v")
+            return null
+        }
+
         // the list of all known videobridges JIDs ordered by load and *operational* status.
         val prioritizedBridges = synchronized(this) { ArrayList(bridges.values) }
         prioritizedBridges.sort()
 
-        var candidateBridges = prioritizedBridges
-            .filter { it.isOperational && !it.isInGracefulShutdown }
-            .toList()
-
-        // if there's no candidate bridge, we include bridges that are in graceful shutdown mode
-        // (the alternative is to crash the user)
-        if (candidateBridges.isEmpty()) {
-            candidateBridges = prioritizedBridges.filter { it.isOperational }.toList()
+        var candidateBridges = prioritizedBridges.filter { it.isOperational }.toList()
+        if (v != null) {
+            candidateBridges = candidateBridges.filter { it.version == v }
         }
-
-        if (candidateBridges.isEmpty()) return null
-
-        val v = version ?: conferenceBridges.keys.firstOrNull()?.version
-        candidateBridges = if (v == null) candidateBridges else candidateBridges.filter { it.version == v }
         if (candidateBridges.isEmpty()) {
             logger.warn("There are no bridges with the required version: $v")
             return null
         }
+
+        /* If there are active bridges, prefer those */
+        val activeBridges = candidateBridges.filter { !it.isDraining }.toList()
+        if (!activeBridges.isEmpty())
+            candidateBridges = activeBridges
+
+        /* If there are bridges not shutting down, prefer those */
+        val runningBridges = candidateBridges.filter { !it.isInGracefulShutdown }.toList()
+        if (!runningBridges.isEmpty())
+            candidateBridges = runningBridges
 
         if (ColibriConfig.config.enableColibri2) {
             candidateBridges = candidateBridges.filter { it.supportsColibri2() }

--- a/src/test/java/mock/util/TestConference.java
+++ b/src/test/java/mock/util/TestConference.java
@@ -74,7 +74,8 @@ public class TestConference
         mockBridge.start();
 
         Bridge bridge = harness.jicofoServices.getBridgeSelector().addJvbAddress(bridgeJid);
-        BridgeTestKt.setStats(bridge, 0.0, "region", "version", true /* colibri2 */, false);
+        BridgeTestKt.setStats(
+                bridge, 0.0, "region", "relay-id", "version", true /* colibri2 */, false, false /* drain */);
 
         createConferenceRoom(roomName);
     }

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeReleaseTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeReleaseTest.kt
@@ -17,7 +17,6 @@
  */
 package org.jitsi.jicofo.bridge
 
-import io.kotest.core.annotation.Ignored
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.ShouldSpec
@@ -30,7 +29,6 @@ import org.jxmpp.jid.impl.JidCreate
  * This test simulates the intended procedure to upgrade the set of bridges connected to a jicofo instance, and
  * verifies the selection logic.
  */
-@Ignored
 class BridgeReleaseTest : ShouldSpec() {
     override fun isolationMode() = IsolationMode.SingleInstance
 

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeReleaseTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeReleaseTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2022-Present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.bridge
+
+import io.kotest.core.annotation.Ignored
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.config.setNewConfig
+import org.jitsi.test.time.FakeClock
+import org.jxmpp.jid.impl.JidCreate
+
+/**
+ * This test simulates the intended procedure to upgrade the set of bridges connected to a jicofo instance, and
+ * verifies the selection logic.
+ */
+@Ignored
+class BridgeReleaseTest : ShouldSpec() {
+    override fun isolationMode() = IsolationMode.SingleInstance
+
+    val clock = FakeClock()
+
+    override fun afterSpec(spec: Spec) = super.afterSpec(spec).also {
+        setNewConfig("", true)
+    }
+    init {
+        context("Test") {
+            // This config is required for the whole test. Set it here instead of in [beforeSpec] because this executes
+            // earlier.
+            setNewConfig(
+                """
+                $regionBasedConfig
+                jicofo.bridge.max-bridge-participants=$maxBp
+                """.trimIndent(),
+                true
+            )
+
+            BridgeConfig.config.maxBridgeParticipants shouldBe maxBp
+
+            val selector = BridgeSelector(clock)
+            // We start with bridges from a single "old" release.
+            val old1 = selector.createBridge("old1", oldVersion, 0.1)
+            val old2 = selector.createBridge("old2", oldVersion, 0.2)
+            val old3 = selector.createBridge("old3", oldVersion, 0.3)
+
+            // Initially we only have bridges from the "old" release. Verify the basics.
+            // Select the least loaded bridge
+            selector.testSelect() shouldBe old1
+            selector.testSelect(version = oldVersion) shouldBe old1
+            selector.testSelect(mapOf(old1 to 1)) shouldBe old1
+            // Select an existing conference bridge
+            selector.testSelect(mapOf(old2 to 1)) shouldBe old2
+            selector.testSelect(mapOf(old3 to 1)) shouldBe old3
+            selector.testSelect(mapOf(old2 to 2, old3 to 1)) shouldBe old2
+            // Fail if the version doesn't match
+            selector.testSelect(version = "invalid-version") shouldBe null
+            // Fail with inconsistent version pinning
+            selector.testSelect(mapOf(old1 to 1), version = newVersion) shouldBe null
+            // Honor max-participants-per-bridge
+            selector.testSelect(mapOf(old1 to maxBp)) shouldBe old2
+            selector.testSelect(mapOf(old1 to maxBp, old3 to 1)) shouldBe old3
+            selector.testSelect(mapOf(old1 to maxBp, old3 to maxBp)) shouldBe old2
+            // Select the least loaded if all are full
+            selector.testSelect(mapOf(old1 to maxBp, old2 to maxBp, old3 to maxBp)) shouldBe old1
+
+            // We add a new bridge with a new release.
+            val new1 = selector.createBridge("new1", newVersion, 0.0, drain = true)
+            // An old one should be used even though the new one has stress 0, because the new one is drained.
+            selector.testSelect() shouldBe old1
+            selector.testSelect(version = newVersion) shouldBe new1
+            selector.testSelect(mapOf(new1 to 1)) shouldBe new1
+            new1.setStats(stress = 0.3, drain = true)
+            // And more bridges with a new release.
+            val new2 = selector.createBridge("new2", newVersion, 0.2, drain = true)
+            val new3 = selector.createBridge("new3", newVersion, 0.1, drain = true)
+            selector.testSelect(version = newVersion) shouldBe new3
+            selector.testSelect(mapOf(new2 to 1)) shouldBe new2
+            selector.testSelect(mapOf(new1 to 1)) shouldBe new1
+            selector.testSelect(mapOf(new1 to 1), version = newVersion) shouldBe new1
+            selector.testSelect(mapOf(new2 to 1)) shouldBe new2
+            selector.testSelect(mapOf(new2 to 1), version = newVersion) shouldBe new2
+            selector.testSelect(mapOf(new3 to 1)) shouldBe new3
+            selector.testSelect(mapOf(new3 to 1), version = newVersion) shouldBe new3
+            selector.testSelect(mapOf(new1 to 1), version = oldVersion) shouldBe null
+            // Honor max-participants-per-bridge, even though all new bridges are in drain.
+            selector.testSelect(mapOf(new1 to maxBp)) shouldBe new3
+            selector.testSelect(mapOf(new1 to maxBp, new2 to 1)) shouldBe new2
+            selector.testSelect(mapOf(new1 to maxBp, new2 to maxBp)) shouldBe new3
+            selector.testSelect(mapOf(new1 to maxBp, new2 to maxBp, new3 to maxBp)) shouldBe new3
+
+            // Everything should work the same unless a conference is pinned to the new version.
+            // Select the least loaded bridge
+            selector.testSelect() shouldBe old1
+            selector.testSelect(version = oldVersion) shouldBe old1
+            selector.testSelect(mapOf(old1 to 1)) shouldBe old1
+            // Select an existing conference bridge
+            selector.testSelect(mapOf(old2 to 1)) shouldBe old2
+            selector.testSelect(mapOf(old3 to 1)) shouldBe old3
+            selector.testSelect(mapOf(old2 to 2, old3 to 1)) shouldBe old2
+            // Fail if the version doesn't match
+            selector.testSelect(version = "invalid-version") shouldBe null
+            // Fail with inconsistent version pinning
+            selector.testSelect(mapOf(old1 to 1), version = newVersion) shouldBe null
+            // Honor max-participants-per-bridge
+            selector.testSelect(mapOf(old1 to maxBp)) shouldBe old2
+            selector.testSelect(mapOf(old1 to maxBp, old3 to 1)) shouldBe old3
+            selector.testSelect(mapOf(old1 to maxBp, old3 to maxBp)) shouldBe old2
+            selector.testSelect(mapOf(old1 to maxBp, old2 to maxBp, old3 to maxBp)) shouldBe old1
+
+            // Switch the releases
+            setOf(old1, old2, old3).forEach { it.setStats(drain = true) }
+            setOf(new1, new2, new3).forEach { it.setStats(drain = false) }
+
+            // Select the new version for new conferences
+            old1.setStats(stress = 0.0, drain = true)
+            // old1 should not be selected because it is in drain
+            selector.testSelect() shouldBe new3
+            selector.testSelect(mapOf(new3 to maxBp)) shouldBe new2
+            // Select the old version for existing conferences or pinned
+            selector.testSelect(mapOf(old1 to 1)) shouldBe old1
+            // Should select old2 even though all old bridges are in drain.
+            selector.testSelect(mapOf(old1 to maxBp)) shouldBe old2
+            selector.testSelect(version = oldVersion) shouldBe old1
+        }
+    }
+}
+
+private fun BridgeSelector.createBridge(jid: String, version: String, stress: Double, drain: Boolean = false) =
+    addJvbAddress(JidCreate.from(jid)).apply {
+        setStats(
+            version = version,
+            stress = stress,
+            drain = drain,
+            region = "region",
+            relayId = jid
+        )
+    }
+
+private val maxBp = 80
+private const val oldVersion = "old"
+private const val newVersion = "new"
+
+private fun BridgeSelector.testSelect(
+    conferenceBridges: Map<Bridge, Int> = emptyMap(),
+    version: String? = null
+) = selectBridge(conferenceBridges, participantRegion = "region", version = version)

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeSelectorTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeSelectorTest.kt
@@ -198,7 +198,7 @@ class BridgeSelectorTest : ShouldSpec() {
 }
 
 private const val enableOctoConfig = "jicofo.octo.enabled=true"
-private val regionBasedConfig = """
+val regionBasedConfig = """
     $enableOctoConfig
     jicofo.bridge.selection-strategy=RegionBasedBridgeSelectionStrategy
 """.trimIndent()

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeTest.kt
@@ -125,18 +125,23 @@ class BridgeTest : ShouldSpec({
 fun Bridge.setStats(
     stress: Double? = null,
     region: String? = null,
+    relayId: String? = region,
     version: String? = null,
     colibri2: Boolean = true,
-    gracefulShutdown: Boolean = false
+    gracefulShutdown: Boolean = false,
+    drain: Boolean = false
 ) = setStats(
     ColibriStatsExtension().apply {
         stress?.let { addStat(ColibriStatsExtension.Stat("stress_level", it)) }
         region?.let {
             addStat(ColibriStatsExtension.Stat(ColibriStatsExtension.REGION, it))
+        }
+        relayId?.let {
             addStat(ColibriStatsExtension.Stat(ColibriStatsExtension.RELAY_ID, it))
         }
         version?.let { addStat(ColibriStatsExtension.Stat("version", version)) }
         if (colibri2) addStat("colibri2", "true")
         if (gracefulShutdown) addStat(ColibriStatsExtension.SHUTDOWN_IN_PROGRESS, "true")
+        addStat(ColibriStatsExtension.DRAIN, if (drain) "true" else "false")
     }
 )

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/RegionBasedSelectionTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/RegionBasedSelectionTest.kt
@@ -158,7 +158,7 @@ class RegionBasedSelectionTest : ShouldSpec() {
     }
 }
 
-const val maxBp = 10
+private const val maxBp = 10
 const val maxBpConfig = "jicofo.bridge.max-bridge-participants=$maxBp"
 val regionGroupsConfig = """
     jicofo.bridge.selection-strategy=RegionBasedBridgeSelectionStrategy

--- a/src/test/kotlin/org/jitsi/jicofo/util/ConfigHelpers.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/util/ConfigHelpers.kt
@@ -23,9 +23,3 @@ fun ShouldSpec.context(config: String, name: String, block: () -> Unit) = contex
         block()
     }
 }
-
-fun ShouldSpec.xcontext(config: String, name: String, block: () -> Unit) = xcontext(name) {
-    withNewConfig(config) {
-        block()
-    }
-}

--- a/src/test/kotlin/org/jitsi/jicofo/util/ConfigHelpers.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/util/ConfigHelpers.kt
@@ -23,3 +23,9 @@ fun ShouldSpec.context(config: String, name: String, block: () -> Unit) = contex
         block()
     }
 }
+
+fun ShouldSpec.xcontext(config: String, name: String, block: () -> Unit) = xcontext(name) {
+    withNewConfig(config) {
+        block()
+    }
+}


### PR DESCRIPTION
Prefer active bridges to draining ones.
Fail selection if pinned to a version different than the
one the conference is already using.