### PR TITLE
Cache Bridge instances, remove deprecated code.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -144,6 +144,25 @@ public class Bridge
     }
 
     /**
+     * Resets the state to the default values.
+     */
+    void reset()
+    {
+        lastReportedPacketRatePps = 0;
+        lastReportedStressLevel = 0.0;
+        usePacketRateStatForStress = true;
+        version = null;
+        releaseId = null;
+        colibri2 = false;
+        isOperational = true;
+        shutdownInProgress = false;
+        draining = true;
+        failureInstant = null;
+        region = null;
+        relayId = null;
+    }
+
+    /**
      * Notifies this instance that a new {@link ColibriStatsExtension} was
      * received for this instance.
      * @param stats the {@link ColibriStatsExtension} instance which was

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
@@ -38,19 +38,6 @@ class BridgeConfig private constructor() {
     }
     fun maxBridgeParticipants() = maxBridgeParticipants
 
-    val maxBridgePacketRatePps: Int by config {
-        "org.jitsi.jicofo.BridgeSelector.MAX_BRIDGE_PACKET_RATE".from(JitsiConfig.legacyConfig)
-        "$BASE.max-bridge-packet-rate".from(JitsiConfig.newConfig)
-    }
-    fun maxBridgePacketRatePps() = maxBridgePacketRatePps
-
-    val averageParticipantPacketRatePps: Int by config {
-        "org.jitsi.jicofo.BridgeSelector.AVG_PARTICIPANT_PACKET_RATE".from(JitsiConfig.legacyConfig)
-        "$BASE.average-participant-packet-rate-pps"
-            .from(JitsiConfig.newConfig).softDeprecated("use $BASE.average-participant-stress")
-    }
-    fun averageParticipantPacketRatePps() = averageParticipantPacketRatePps
-
     val averageParticipantStress: Double by config {
         "$BASE.average-participant-stress".from(JitsiConfig.newConfig)
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -17,10 +17,6 @@ jicofo {
   bridge {
     // The maximum number of participants in a single conference to put on one bridge (use -1 for no maximum).
     max-bridge-participants = -1
-    // The assumed maximum packet rate that a bridge can handle.
-    max-bridge-packet-rate = 50000
-    // The assumed average packet rate per participant.
-    average-participant-packet-rate-pps = 500
     // The default assumed average stress per participant. This value is only used when a bridge does not report its
     // own value.
     average-participant-stress = 0.01

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeConfigTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeConfigTest.kt
@@ -30,29 +30,21 @@ class BridgeConfigTest : ShouldSpec() {
     init {
         context("with no config the defaults from reference.conf should be used") {
             config.maxBridgeParticipants shouldBe -1
-            config.maxBridgePacketRatePps shouldBe 50000
-            config.averageParticipantPacketRatePps shouldBe 500
         }
         context("with legacy config") {
             withLegacyConfig(legacyConfig) {
                 config.maxBridgeParticipants shouldBe 111
-                config.maxBridgePacketRatePps shouldBe 111
-                config.averageParticipantPacketRatePps shouldBe 111
             }
         }
         context("with new config") {
             withNewConfig(newConfig) {
                 config.maxBridgeParticipants shouldBe 222
-                config.maxBridgePacketRatePps shouldBe 222
-                config.averageParticipantPacketRatePps shouldBe 222
             }
         }
         context("with both legacy and new config the legacy values should be used") {
             withLegacyConfig(legacyConfig) {
                 withNewConfig(newConfig) {
                     config.maxBridgeParticipants shouldBe 111
-                    config.maxBridgePacketRatePps shouldBe 111
-                    config.averageParticipantPacketRatePps shouldBe 111
                 }
             }
         }
@@ -97,16 +89,12 @@ class BridgeConfigTest : ShouldSpec() {
 }
 private val legacyConfig = """
 org.jitsi.jicofo.BridgeSelector.MAX_PARTICIPANTS_PER_BRIDGE=111
-org.jitsi.jicofo.BridgeSelector.MAX_BRIDGE_PACKET_RATE=111
-org.jitsi.jicofo.BridgeSelector.AVG_PARTICIPANT_PACKET_RATE=111
 """.trimIndent()
 
 private val newConfig = """
 jicofo {
     bridge {
         max-bridge-participants=222
-        max-bridge-packet-rate=222
-        average-participant-packet-rate-pps=222
     }
 }    
 """.trimIndent()


### PR DESCRIPTION
- fix: Re-use Bridge instances.
- ref: Remove support for calculating stress based on packet rate.
