### PR TITLE
Fix granting ownership

### DIFF
--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoom.java
@@ -99,10 +99,9 @@ public interface ChatRoom
     * ownership privileges to other users. An owner is allowed to change
     * defining room features as well as perform all administrative functions.
     *
-    * @param address the user address of the user to grant ownership
-    * privileges (e.g. "user@host.org").
+    * @param member the member to grant ownershit to.
     */
-    void grantOwnership(String address);
+    void grantOwnership(@NotNull ChatRoomMember member);
 
     /**
      * Destroys the chat room.

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -447,9 +447,9 @@ public class ChatRoomImpl
     }
 
     @Override
-    public void grantOwnership(String address)
+    public void grantOwnership(@NotNull ChatRoomMember member)
     {
-        logger.debug("Grant owner to " + address);
+        logger.debug("Grant owner to " + member);
 
         // Have to construct the IQ manually as Smack version used here seems
         // to be using wrong namespace(muc#owner instead of muc#admin)
@@ -458,17 +458,7 @@ public class ChatRoomImpl
         admin.setType(IQ.Type.set);
         admin.setTo(roomJid);
 
-        Jid jidAddress;
-        try
-        {
-            jidAddress = JidCreate.from(address);
-        }
-        catch (XmppStringprepException e)
-        {
-            throw new RuntimeException(e);
-        }
-
-        MUCItem item = new MUCItem(MUCAffiliation.owner, jidAddress);
+        MUCItem item = new MUCItem(MUCAffiliation.owner, member.getJid());
         admin.addItem(item);
 
         AbstractXMPPConnection connection = xmppProvider.getXmppConnection();

--- a/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
+++ b/src/main/java/org/jitsi/impl/protocol/xmpp/ChatRoomImpl.java
@@ -458,7 +458,7 @@ public class ChatRoomImpl
         admin.setType(IQ.Type.set);
         admin.setTo(roomJid);
 
-        MUCItem item = new MUCItem(MUCAffiliation.owner, member.getJid());
+        MUCItem item = new MUCItem(MUCAffiliation.owner, member.getJid().asBareJid());
         admin.addItem(item);
 
         AbstractXMPPConnection connection = xmppProvider.getXmppConnection();

--- a/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomRoleManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomRoleManager.kt
@@ -40,7 +40,7 @@ sealed class ChatRoomRoleManager(
         }
 
         return try {
-            chatRoom.grantOwnership(member.jid.toString())
+            chatRoom.grantOwnership(member)
             true
         } catch (e: RuntimeException) {
             logger.error("Failed to grant owner status to ${member.jid}", e)


### PR DESCRIPTION
- ref: Pass a ChatRoomMember to grantOwnership().
- fix(#895): Use bare JID when granting priviledges.
