### PR TITLE
feat: Add an option to use presence instead of sending health checks.

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -137,6 +137,9 @@ public class Bridge
     @NonNull
     private final Clock clock;
 
+    @NonNull
+    private Instant lastPresenceReceived = Instant.MIN;
+
     Bridge(@NonNull Jid jid, @NonNull Clock clock)
     {
         this.jid = jid;
@@ -146,6 +149,12 @@ public class Bridge
     Bridge(@NonNull Jid jid)
     {
         this(jid, Clock.systemUTC());
+    }
+
+    @NonNull
+    public Instant getLastPresenceReceived()
+    {
+        return lastPresenceReceived;
     }
 
     /**
@@ -160,6 +169,7 @@ public class Bridge
         {
             return;
         }
+        lastPresenceReceived = clock.instant();
 
         Double stressLevel = UtilKt.getDouble(stats, "stress_level");
         if (stressLevel != null)

--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -84,6 +84,11 @@ public class Bridge
     private String version = null;
 
     /**
+     * Whether the last received presence indicated the bridge is healthy.
+     */
+    private boolean healthy = true;
+
+    /**
      * Holds bridge release ID, or null if not known.
      */
     private String releaseId = null;
@@ -222,6 +227,12 @@ public class Bridge
         if (relayId != null)
         {
             this.relayId = relayId;
+        }
+
+        String healthy = stats.getValueAsString("healthy");
+        if (healthy != null)
+        {
+            this.healthy = Boolean.parseBoolean(healthy);
         }
     }
 
@@ -442,6 +453,7 @@ public class Bridge
         o.put("graceful-shutdown", isInGracefulShutdown());
         o.put("overloaded", isOverloaded());
         o.put("relay-id", String.valueOf(relayId));
+        o.put("healthy", healthy);
 
         return o;
     }

--- a/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/Bridge.java
@@ -152,9 +152,14 @@ public class Bridge
     }
 
     @NonNull
-    public Instant getLastPresenceReceived()
+    public Duration getTimeSinceLastPresence()
     {
-        return lastPresenceReceived;
+        return Duration.between(lastPresenceReceived, clock.instant());
+    }
+
+    public boolean isHealthy()
+    {
+        return healthy;
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
@@ -108,6 +108,14 @@ class BridgeConfig private constructor() {
             .transformedBy { Duration.ofMillis(it.toMillis() / 2) }
     }
 
+    val usePresenceForHealth: Boolean by config {
+        "$BASE.health-checks.use-presence".from(JitsiConfig.newConfig)
+    }
+
+    val presenceHealthTimeout: Duration by config {
+        "$BASE.health-checks.presence-timeout".from(JitsiConfig.newConfig)
+    }
+
     val breweryJid: EntityBareJid? by optionalconfig {
         "org.jitsi.jicofo.BRIDGE_MUC".from(JitsiConfig.legacyConfig).convertFrom<String> {
             JidCreate.entityBareFrom(it)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -61,6 +61,12 @@ jicofo {
       // configures the delay between the original health check timing out and the second health check being sent.
       // It is a duration and defaults to half the [interval].
       # retry-delay = 5 seconds
+
+      // Use the lack of presence to infer unhealthy status instead of sending explicit health check requests.
+      use-presence = false
+
+      // A bridge will be consider unhealthy unless we've received its presence in that period.
+      presence-timeout = 45 seconds
     }
 
     // The JID of the MUC to be used as a brewery for bridge instances.


### PR DESCRIPTION
- Read bridge health from presence.
- Save the time presence was last received.
- feat: Add an option to use presence instead of sending health checks.
