### PR TITLE
Mute fixes

### DIFF
--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1597,15 +1597,9 @@ public class JitsiMeetConferenceImpl
      */
     public void muteParticipant(Participant participant, MediaType mediaType)
     {
-        if (participant.getChatMember().isJigasi() && !participant.hasAudioMuteSupport())
+        if (participant.shouldSuppressForceMute())
         {
-            logger.warn("Will not mute jigasi with not audioMute support: " + participant);
-            return;
-        }
-
-        if (participant.getChatMember().isJibri())
-        {
-            logger.warn("Will not mute jibri: " + participant);
+            logger.info("Will not mute a trusted participant without unmute support (jibri, jigasi): " + participant);
             return;
         }
 

--- a/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -48,6 +48,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+import java.util.stream.*;
 
 import static org.jitsi.jicofo.xmpp.IqProcessingResult.*;
 
@@ -1511,25 +1512,17 @@ public class JitsiMeetConferenceImpl
             }
         }
 
-        if (doMute
-            && participant.getChatMember().isJigasi()
-            && !participant.hasAudioMuteSupport())
+        if (participant.shouldSuppressForceMute())
         {
-            logger.warn("Mute not allowed, toBeMuted is jigasi.");
-            return MuteResult.NOT_ALLOWED;
-        }
-
-
-        if (doMute && participant.getChatMember().isJibri())
-        {
-            logger.warn("Mute not allowed, toBeMuted is jibri.");
+            logger.warn("Force mute suppressed, returning NOT_ALLOWED:" + participant);
             return MuteResult.NOT_ALLOWED;
         }
 
         logger.info("Will " + (doMute ? "mute" : "unmute") + " " + toBeMutedJid + " on behalf of " + muterJid
             + " for " + mediaType);
 
-        return colibriSessionManager.mute(participant, doMute, mediaType) ? MuteResult.SUCCESS : MuteResult.ERROR;
+        colibriSessionManager.mute(participant.getEndpointId(), doMute, mediaType);
+        return MuteResult.SUCCESS;
     }
 
     @Override
@@ -1577,63 +1570,58 @@ public class JitsiMeetConferenceImpl
      */
     public void muteAllParticipants(MediaType mediaType)
     {
-        Iterable<Participant> participantsToMute;
+        Set<Participant> participantsToMute = new HashSet<>();
         synchronized (participantLock)
         {
-            participantsToMute = new ArrayList<>(participants.values());
+            for (Participant participant : participants.values())
+            {
+                if (participant.shouldSuppressForceMute())
+                {
+                    logger.info("Will not mute a trusted participant without unmute support (jibri, jigasi): "
+                            + participant);
+                    continue;
+                }
+
+                participantsToMute.add(participant);
+            }
         }
 
+        // Force mute at the backend. We assume this was successful. If for some reason it wasn't the colibri layer
+        // should handle it (e.g. remove a broken bridge).
+        colibriSessionManager.mute(
+                participantsToMute.stream().map(p -> p.getEndpointId()).collect(Collectors.toSet()),
+                true,
+                mediaType);
+
+        // Signal to the participants that they are being muted.
         for (Participant participant : participantsToMute)
         {
-            muteParticipant(participant, mediaType);
-        }
-    }
+            IQ muteIq = null;
+            if (mediaType == MediaType.AUDIO)
+            {
+                MuteIq muteStatusUpdate = new MuteIq();
+                muteStatusUpdate.setType(IQ.Type.set);
+                muteStatusUpdate.setTo(participant.getMucJid());
 
-    /**
-     * Mutes a participant, blocking for a colibri response (no-op if the participant is already muted).
-     * Will not mute jibri instances, and jigasi instances without "audioMute" support.
-     * @param participant the participant to mute.
-     * @param mediaType the media type for the operation.
-     */
-    public void muteParticipant(Participant participant, MediaType mediaType)
-    {
-        if (participant.shouldSuppressForceMute())
-        {
-            logger.info("Will not mute a trusted participant without unmute support (jibri, jigasi): " + participant);
-            return;
-        }
+                muteStatusUpdate.setMute(true);
 
-        if (!colibriSessionManager.mute(participant, true, mediaType))
-        {
-            logger.warn("Failed to mute colibri channels for " + participant);
-            return;
-        }
+                muteIq = muteStatusUpdate;
+            }
+            else if (mediaType == MediaType.VIDEO)
+            {
+                MuteVideoIq muteStatusUpdate = new MuteVideoIq();
+                muteStatusUpdate.setType(IQ.Type.set);
+                muteStatusUpdate.setTo(participant.getMucJid());
 
-        IQ muteIq = null;
-        if (mediaType == MediaType.AUDIO)
-        {
-            MuteIq muteStatusUpdate = new MuteIq();
-            muteStatusUpdate.setType(IQ.Type.set);
-            muteStatusUpdate.setTo(participant.getMucJid());
+                muteStatusUpdate.setMute(true);
 
-            muteStatusUpdate.setMute(true);
+                muteIq = muteStatusUpdate;
+            }
 
-            muteIq = muteStatusUpdate;
-        }
-        else if (mediaType == MediaType.VIDEO)
-        {
-            MuteVideoIq muteStatusUpdate = new MuteVideoIq();
-            muteStatusUpdate.setType(IQ.Type.set);
-            muteStatusUpdate.setTo(participant.getMucJid());
-
-            muteStatusUpdate.setMute(true);
-
-            muteIq = muteStatusUpdate;
-        }
-
-        if (muteIq != null)
-        {
-            UtilKt.tryToSendStanza(getClientXmppProvider().getXmppConnection(), muteIq);
+            if (muteIq != null)
+            {
+                UtilKt.tryToSendStanza(getClientXmppProvider().getXmppConnection(), muteIq);
+            }
         }
     }
 

--- a/src/main/java/org/jitsi/jicofo/conference/Participant.java
+++ b/src/main/java/org/jitsi/jicofo/conference/Participant.java
@@ -588,6 +588,15 @@ public class Participant
     }
 
     /**
+     * Whether force-muting should be suppressed for this participant (it is a trusted participant and doesn't
+     * support unmuting).
+     */
+    public boolean shouldSuppressForceMute()
+    {
+        return (getChatMember().isJigasi() && !hasAudioMuteSupport()) || getChatMember().isJibri();
+    }
+
+    /**
      * Checks whether this {@link Participant}'s role has moderator rights.
      */
     public boolean hasModeratorRights()

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/ColibriSessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/ColibriSessionManager.kt
@@ -48,7 +48,9 @@ interface ColibriSessionManager {
     @Throws(ColibriAllocationFailedException::class)
     fun allocate(
         participant: Participant,
-        contents: List<ContentPacketExtension>
+        contents: List<ContentPacketExtension>,
+        forceMuteAudio: Boolean,
+        forceMuteVideo: Boolean
     ): ColibriAllocation
 
     /** For use in java because @JvmOverloads is not available for interfaces. */

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/ColibriSessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/ColibriSessionManager.kt
@@ -42,7 +42,9 @@ interface ColibriSessionManager {
      */
     fun removeParticipants(participants: Collection<Participant>)
 
-    fun mute(participant: Participant, doMute: Boolean, mediaType: MediaType): Boolean
+    fun mute(participantId: String, doMute: Boolean, mediaType: MediaType): Boolean =
+        mute(setOf(participantId), doMute, mediaType)
+    fun mute(participantIds: Set<String>, doMute: Boolean, mediaType: MediaType): Boolean
     val bridgeCount: Int
     val bridgeRegions: Set<String>
     @Throws(ColibriAllocationFailedException::class)

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
@@ -88,6 +88,9 @@ internal class Colibri2Session(
             if (participant.supportsSourceNames) {
                 addCapability(Capability.CAP_SOURCE_NAME_SUPPORT)
             }
+            if (participant.audioMuted || participant.videoMuted) {
+                setForceMute(participant.audioMuted, participant.videoMuted)
+            }
             setTransport(
                 Transport.getBuilder().apply {
                     // TODO: we're hard-coding the role here, and it must be consistent with the role signaled to the

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/Colibri2Session.kt
@@ -144,18 +144,18 @@ internal class Colibri2Session(
         xmppConnection.sendIqAndLogResponse(request.build(), logger)
     }
 
-    /** Force-mutes a specific endpoint **/
-    internal fun mute(participant: ParticipantInfo, audio: Boolean, video: Boolean): StanzaCollector {
+    internal fun updateForceMute(participants: Set<ParticipantInfo>) {
         val request = createRequest()
-        request.addEndpoint(
-            Colibri2Endpoint.getBuilder().apply {
-                setForceMute(audio, video)
-                setId(participant.id)
-            }.build()
-        )
+        participants.forEach { participant ->
+            request.addEndpoint(
+                Colibri2Endpoint.getBuilder().apply {
+                    setId(participant.id)
+                    setForceMute(participant.audioMuted, participant.videoMuted)
+                }.build()
+            )
+        }
 
-        logger.trace { "Sending force-mute update: ${request.build().toXML()}" }
-        return xmppConnection.createStanzaCollectorAndSend(request.build())
+        xmppConnection.sendIqAndLogResponse(request.build(), logger)
     }
 
     internal fun expire(participantToExpire: ParticipantInfo) = expire(singletonList(participantToExpire))

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -246,7 +246,9 @@ class ColibriV2SessionManager(
     @Throws(ColibriAllocationFailedException::class)
     override fun allocate(
         participant: Participant,
-        contents: List<ContentPacketExtension>
+        contents: List<ContentPacketExtension>,
+        forceMuteAudio: Boolean,
+        forceMuteVideo: Boolean
     ): ColibriAllocation {
         logger.info("Allocating for ${participant.endpointId}")
         val stanzaCollector: StanzaCollector
@@ -277,6 +279,8 @@ class ColibriV2SessionManager(
             participantInfo = ParticipantInfo(
                 participant.endpointId,
                 participant.statId,
+                audioMuted = forceMuteAudio,
+                videoMuted = forceMuteVideo,
                 session = session,
                 supportsSourceNames = participant.hasSourceNameSupport()
             )

--- a/src/test/kotlin/org/jitsi/jicofo/conference/ParticipantInviteRunnableTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/conference/ParticipantInviteRunnableTest.kt
@@ -76,7 +76,7 @@ class ParticipantInviteRunnableTest : ShouldSpec({
             )
         )
         val colibriSessionManager = mockk<ColibriSessionManager> {
-            every { allocate(any(), any()) } returns ColibriAllocation(
+            every { allocate(any(), any(), any(), any()) } returns ColibriAllocation(
                 feedbackSources,
                 IceUdpTransportPacketExtension(),
                 null,


### PR DESCRIPTION
- fix: Set forceMute state with the initial colibri allocate request and jingle offer.
- fix: Send a single coolibri message for force-mute, do not block for a response.

Incidentally, this fixes a race condition between terminateParticipant() and muteAllParticipants() which throws an exception when trying to mute a participant that has been removed.
