### PR TITLE
fix: Prevent jetty from trying to register ShibbolethLogin

### DIFF
--- a/src/main/java/org/jitsi/jicofo/auth/ShibbolethAuthAuthority.java
+++ b/src/main/java/org/jitsi/jicofo/auth/ShibbolethAuthAuthority.java
@@ -17,7 +17,7 @@
  */
 package org.jitsi.jicofo.auth;
 
-import org.jitsi.jicofo.rest.*;
+import org.jitsi.jicofo.auth.rest.*;
 import org.jitsi.xmpp.extensions.jitsimeet.*;
 import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.*;

--- a/src/main/java/org/jitsi/jicofo/auth/rest/ShibbolethLogin.java
+++ b/src/main/java/org/jitsi/jicofo/auth/rest/ShibbolethLogin.java
@@ -75,7 +75,8 @@ public class ShibbolethLogin
         try
         {
             roomJid = JidCreate.entityBareFrom(room);
-        } catch (XmppStringprepException e)
+        }
+        catch (XmppStringprepException e)
         {
             // This used to return 500, but is clearly a bad request.
             throw new BadRequestExceptionWithMessage("Room name is not a valid JID");
@@ -117,27 +118,27 @@ public class ShibbolethLogin
 
         // Store session-id script
         String script =
-                "<script>\n" +
-                        "(function() {\n" +
-                        " var sessionId = '" + sessionId + "';\n" +
-                        " localStorage.setItem('sessionId', sessionId);\n" +
-                        " console.info('sessionID :' + sessionId);\n" +
-                        " var displayName = '" + displayName + "';\n" +
-                        " console.info('displayName :' + displayName);\n" +
-                        " var settings = localStorage.getItem('features/base/settings');\n" +
-                        " console.info('settings :' + settings);\n" +
-                        " if (settings){\n" +
-                        "     try {\n" +
-                        "            var settingsObj = JSON.parse(settings);\n" +
-                        "            if ( settingsObj && !settingsObj.displayName ) {\n" +
-                        "                settingsObj.displayName = displayName;\n" +
-                        "                localStorage.setItem('features/base/settings', JSON.stringify(settingsObj));\n" +
-                        "         }\n" +
-                        "     }\n" +
-                        "   catch(e){\n" +
-                        "     console.error('Unable to parse settings JSON');\n" +
-                        "   }\n" +
-                        " }\n";
+            "<script>\n" +
+                    "(function() {\n" +
+                    " var sessionId = '" + sessionId + "';\n" +
+                    " localStorage.setItem('sessionId', sessionId);\n" +
+                    " console.info('sessionID :' + sessionId);\n" +
+                    " var displayName = '" + displayName + "';\n" +
+                    " console.info('displayName :' + displayName);\n" +
+                    " var settings = localStorage.getItem('features/base/settings');\n" +
+                    " console.info('settings :' + settings);\n" +
+                    " if (settings){\n" +
+                    "     try {\n" +
+                    "            var settingsObj = JSON.parse(settings);\n" +
+                    "            if ( settingsObj && !settingsObj.displayName ) {\n" +
+                    "                settingsObj.displayName = displayName;\n" +
+                    "                localStorage.setItem('features/base/settings', JSON.stringify(settingsObj));\n" +
+                    "         }\n" +
+                    "     }\n" +
+                    "   catch(e){\n" +
+                    "     console.error('Unable to parse settings JSON');\n" +
+                    "   }\n" +
+                    " }\n";
         if (close)
         {
             // Pass session id and close the popup

--- a/src/main/java/org/jitsi/jicofo/auth/rest/ShibbolethLogin.java
+++ b/src/main/java/org/jitsi/jicofo/auth/rest/ShibbolethLogin.java
@@ -1,23 +1,9 @@
-/*
- * Copyright @ 2018 - present 8x8, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.jitsi.jicofo.rest;
+package org.jitsi.jicofo.auth.rest;
 
 import com.google.common.html.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.jicofo.auth.*;
+import org.jitsi.jicofo.rest.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
 import org.jxmpp.stringprep.*;
@@ -25,7 +11,6 @@ import org.jxmpp.stringprep.*;
 import javax.servlet.http.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
-import javax.ws.rs.core.Response;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -40,10 +25,9 @@ public class ShibbolethLogin
      *
      * @param request <tt>HttpServletRequest</tt> instance used to obtain
      *                Shibboleth attributes.
-     * @param name the name of Shibboleth attribute to get.
-     *
+     * @param name    the name of Shibboleth attribute to get.
      * @return Shibboleth attribute value retrieved from the request or
-     *         <tt>null</tt> if there is no value for given <tt>name</tt>.
+     * <tt>null</tt> if there is no value for given <tt>name</tt>.
      */
     private static String getShibAttr(HttpServletRequest request, String name)
     {
@@ -58,7 +42,7 @@ public class ShibbolethLogin
     @NotNull
     private final ShibbolethAuthAuthority shibbolethAuthAuthority;
 
-    ShibbolethLogin(@NotNull ShibbolethAuthAuthority shibbolethAuthAuthority)
+    public ShibbolethLogin(@NotNull ShibbolethAuthAuthority shibbolethAuthAuthority)
     {
         this.shibbolethAuthAuthority = shibbolethAuthAuthority;
     }
@@ -91,8 +75,7 @@ public class ShibbolethLogin
         try
         {
             roomJid = JidCreate.entityBareFrom(room);
-        }
-        catch (XmppStringprepException e)
+        } catch (XmppStringprepException e)
         {
             // This used to return 500, but is clearly a bad request.
             throw new BadRequestExceptionWithMessage("Room name is not a valid JID");
@@ -134,39 +117,39 @@ public class ShibbolethLogin
 
         // Store session-id script
         String script =
-            "<script>\n" +
-                "(function() {\n" +
-                " var sessionId = '" + sessionId + "';\n" +
-                " localStorage.setItem('sessionId', sessionId);\n" +
-                " console.info('sessionID :' + sessionId);\n" +
-                " var displayName = '" + displayName + "';\n" +
-                " console.info('displayName :' + displayName);\n" +
-                " var settings = localStorage.getItem('features/base/settings');\n" +
-                " console.info('settings :' + settings);\n" +
-                " if (settings){\n" +
-                "     try {\n" +
-                "            var settingsObj = JSON.parse(settings);\n" +
-                "            if ( settingsObj && !settingsObj.displayName ) {\n" +
-                "                settingsObj.displayName = displayName;\n" +
-                "                localStorage.setItem('features/base/settings', JSON.stringify(settingsObj));\n" +
-                "         }\n" +
-                "     }\n" +
-                "   catch(e){\n" +
-                "     console.error('Unable to parse settings JSON');\n" +
-                "   }\n" +
-                " }\n" ;
+                "<script>\n" +
+                        "(function() {\n" +
+                        " var sessionId = '" + sessionId + "';\n" +
+                        " localStorage.setItem('sessionId', sessionId);\n" +
+                        " console.info('sessionID :' + sessionId);\n" +
+                        " var displayName = '" + displayName + "';\n" +
+                        " console.info('displayName :' + displayName);\n" +
+                        " var settings = localStorage.getItem('features/base/settings');\n" +
+                        " console.info('settings :' + settings);\n" +
+                        " if (settings){\n" +
+                        "     try {\n" +
+                        "            var settingsObj = JSON.parse(settings);\n" +
+                        "            if ( settingsObj && !settingsObj.displayName ) {\n" +
+                        "                settingsObj.displayName = displayName;\n" +
+                        "                localStorage.setItem('features/base/settings', JSON.stringify(settingsObj));\n" +
+                        "         }\n" +
+                        "     }\n" +
+                        "   catch(e){\n" +
+                        "     console.error('Unable to parse settings JSON');\n" +
+                        "   }\n" +
+                        " }\n";
         if (close)
         {
             // Pass session id and close the popup
-            script += "var opener = window.opener;\n"+
-                    "if (opener) {\n"+
+            script += "var opener = window.opener;\n" +
+                    "if (opener) {\n" +
                     "   var res = opener.postMessage(" +
                     "      { sessionId: sessionId },\n" +
-                    "      window.opener.location.href);\n"+
+                    "      window.opener.location.href);\n" +
                     "   console.info('res: ', res);\n" +
-                    "   window.close();\n"+
+                    "   window.close();\n" +
                     "} else {\n" +
-                    "   console.error('No opener !');\n"+
+                    "   console.error('No opener !');\n" +
                     "}\n";
         }
         else
@@ -182,7 +165,6 @@ public class ShibbolethLogin
         return sb.toString();
     }
 }
-
 class BadRequestExceptionWithMessage extends BadRequestException
 {
     public BadRequestExceptionWithMessage(String message)

--- a/src/main/java/org/jitsi/jicofo/auth/rest/ShibbolethLogin.java
+++ b/src/main/java/org/jitsi/jicofo/auth/rest/ShibbolethLogin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jitsi.jicofo.auth.rest;
 
 import com.google.common.html.*;

--- a/src/main/java/org/jitsi/jicofo/rest/Application.java
+++ b/src/main/java/org/jitsi/jicofo/rest/Application.java
@@ -19,6 +19,7 @@ import org.glassfish.hk2.utilities.binding.*;
 import org.glassfish.jersey.server.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.jicofo.auth.*;
+import org.jitsi.jicofo.auth.rest.*;
 import org.jitsi.jicofo.health.*;
 import org.jitsi.utils.version.*;
 


### PR DESCRIPTION
as part of the org.jitsi.jicofo.rest package. This was a harmless bug,
resulting in 5XX instead of 404 when serving /login when shibboleth is
disabled.
