### PR TITLE
Fail (instead of timeuot) jvb health check when jvb reports unhealthy

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
@@ -318,8 +318,8 @@ public class JvbDoctor
 
             logger.debug("Checking presence for health for: " + bridge);
 
-            boolean healthy = bridge.isHealthy() &&
-                    bridge.getTimeSinceLastPresence().compareTo(config.getPresenceHealthTimeout()) < 0;
+            boolean healthy = bridge.isHealthy();
+            boolean timeout = bridge.getTimeSinceLastPresence().compareTo(config.getPresenceHealthTimeout()) > 0;
 
             // Sync on start/stop and bridges state
             synchronized (JvbDoctor.this)
@@ -327,7 +327,17 @@ public class JvbDoctor
                 if (taskInvalid())
                     return;
 
-                if (healthy)
+                if (timeout)
+                {
+                    logger.warn("Health check timed out for: " + bridge);
+                    listener.healthCheckTimedOut(bridge.getJid());
+                }
+                else if (!healthy)
+                {
+                    logger.warn("JVB reported unhealthy" + bridge);
+                    listener.healthCheckFailed(bridge.getJid());
+                }
+                else // healthy
                 {
                     if (logger.isDebugEnabled())
                     {
@@ -336,11 +346,6 @@ public class JvbDoctor
                     // TODO: we should be able to do this directly when we receive presence with healthy=true, but
                     // I don't want to modify the flow right now.
                     listener.healthCheckPassed(bridge.getJid());
-                }
-                else
-                {
-                    logger.warn("Health check timed out for: " + bridge);
-                    listener.healthCheckTimedOut(bridge.getJid());
                 }
             }
         }

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -91,10 +91,10 @@ class BridgeSelector @JvmOverloads constructor(
         it.setStats(stats)
         return it
     } ?: Bridge(bridgeJid, clock).also { newBridge ->
-        logger.info("Added new videobridge: $newBridge")
         if (stats != null) {
             newBridge.setStats(stats)
         }
+        logger.info("Added new videobridge: $newBridge")
         bridges[bridgeJid] = newBridge
         eventEmitter.fireEvent { bridgeAdded(newBridge) }
     }


### PR DESCRIPTION
- log: Set initial fields before logging.
- Use healthCheckFailed when a bridge reports healthy (instead of handling as a timeout).
