### PR TITLE
fix: Fix broken Colibri2SessionManager state.

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -147,6 +147,7 @@ class ColibriV2SessionManager(
             if (removeSession) {
                 logger.info("Removing session with no remaining participants: $session")
                 sessions.remove(session.bridge)
+                participantsBySession.remove(session)
                 session.expireAllRelays()
                 sessions.values.forEach { otherSession ->
                     otherSession.expireRelay(session.bridge.relayId)


### PR DESCRIPTION
When a session is removed the participantsBySession map is left with an
entry for the session (with an empty list of participants). This results
in the bridge being passed to BridgeSelector indefinitely.

In particular, this causes a serious problem when the bridge does not
have a relay, because BridgeSelector returns it back immediately, even
if the instance has disconnected.
