### PR TITLE
fix: Reduce the core size of the scheduled pool to 3.

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/TaskPools.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/TaskPools.kt
@@ -30,7 +30,7 @@ class TaskPools {
 
         @JvmStatic
         val scheduledPool: ScheduledExecutorService = Executors.newScheduledThreadPool(
-            200, CustomizableThreadFactory("Jicofo Global Scheduled Pool", true)
+            3, CustomizableThreadFactory("Jicofo Global Scheduled Pool", true)
         )
 
         @JvmStatic


### PR DESCRIPTION
It is unlimited, so it will grow as needed. There's no need to
keep 200 threads alive at all time.
