### PR TITLE
Turn off Opus inband FEC when RED is in use

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
@@ -113,7 +113,6 @@ class CodecUtil {
             options: OfferOptions = OfferOptions()
         ): Collection<PayloadTypePacketExtension> = buildList {
             if (config.opus.enabled()) {
-                var addedRed: Boolean = false
                 // Though RED has a payload type of its own and can be used to encode multiple other payload types, we need
                 // it to be advertised with the same clock rate as opus, so it's defined here.
                 // Add the RED payload type before Opus, so that it is the selected codec.
@@ -127,7 +126,6 @@ class CodecUtil {
                     red.addParameterExtension(null, config.opus.pt().toString() + "/" + config.opus.pt())
 
                     add(red)
-                    addedRed = true
                 }
 
                 // a=rtpmap:111 opus/48000/2
@@ -145,10 +143,10 @@ class CodecUtil {
                 if (options.opusMaxAverageBitrate != null) {
                     opus.addParameterExtension("maxaveragebitrate", options.opusMaxAverageBitrate.toString())
                 }
-                if (config.opus.useInbandFec()) {
+                // Avoid double FEC if RED is offered already.
+                if (config.opus.useInbandFec() && !config.opus.red.enabled()) {
                     // fmtp:111 useinbandfec=1
-                    val fecval = addedRed.compareTo(true).toString()
-                    opus.addParameterExtension("useinbandfec", fecval)
+                    opus.addParameterExtension("useinbandfec", "1")
                 }
                 if (config.tcc.enabled() && options.tcc) {
                     // a=rtcp-fb:111 transport-cc

--- a/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
@@ -113,6 +113,7 @@ class CodecUtil {
             options: OfferOptions = OfferOptions()
         ): Collection<PayloadTypePacketExtension> = buildList {
             if (config.opus.enabled()) {
+                var addedRed: Boolean = false
                 // Though RED has a payload type of its own and can be used to encode multiple other payload types, we need
                 // it to be advertised with the same clock rate as opus, so it's defined here.
                 // Add the RED payload type before Opus, so that it is the selected codec.
@@ -126,6 +127,7 @@ class CodecUtil {
                     red.addParameterExtension(null, config.opus.pt().toString() + "/" + config.opus.pt())
 
                     add(red)
+                    addedRed = true
                 }
 
                 // a=rtpmap:111 opus/48000/2
@@ -145,7 +147,8 @@ class CodecUtil {
                 }
                 if (config.opus.useInbandFec()) {
                     // fmtp:111 useinbandfec=1
-                    opus.addParameterExtension("useinbandfec", "1")
+                    val fecval = addedRed.compareTo(true).toString()
+                    opus.addParameterExtension("useinbandfec", fecval)
                 }
                 if (config.tcc.enabled() && options.tcc) {
                     // a=rtcp-fb:111 transport-cc


### PR DESCRIPTION
Currently when RED is being used as FEC we also signal the usage of Opus inband FEC. Running these two FECs algorithms together just wastes bandwidth for little to no gain. Since the results for RED for heavier packet loss is better compared to Opus FEC, this PR turns off Opus FEC when RED is in use.