### PR TITLE
fix: Fix a deadlock when CSM calls bridgeRemoved.

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -19,6 +19,7 @@
 package org.jitsi.jicofo.conference.colibri.v2
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.bridge.Bridge
 import org.jitsi.jicofo.bridge.BridgeSelector
 import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl
@@ -30,7 +31,7 @@ import org.jitsi.jicofo.conference.colibri.ColibriSessionManager
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.OrderedJsonObject
-import org.jitsi.utils.event.SyncEventEmitter
+import org.jitsi.utils.event.AsyncEventEmitter
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Error
@@ -61,7 +62,7 @@ class ColibriV2SessionManager(
 ) : ColibriSessionManager {
     private val logger = createChildLogger(parentLogger)
 
-    private val eventEmitter = SyncEventEmitter<ColibriSessionManager.Listener>()
+    private val eventEmitter = AsyncEventEmitter<ColibriSessionManager.Listener>(TaskPools.ioPool)
     override fun addListener(listener: ColibriSessionManager.Listener) = eventEmitter.addHandler(listener)
     override fun removeListener(listener: ColibriSessionManager.Listener) = eventEmitter.removeHandler(listener)
 
@@ -84,8 +85,6 @@ class ColibriV2SessionManager(
 
     /**
      * Protects access to [sessions], [participants] and [participantsBySession].
-     *
-     * Note that we currently fire some events via [eventEmitter] while holding this lock.
      */
     private val syncRoot = Any()
 


### PR DESCRIPTION
The following deadlock was observed when ColibriV2SessionManager fails
to allocate channels and calls into bridgeRemoved in the same thread
while holding syncRoot:

BridgeSelector-AsyncEventEmitterpool-5-thread-1  Blocked Thread ID: 56
  org.jitsi.jicofo.conference.colibri.v2.ColibriV2SessionManager.updateParticipant(Participant, IceUdpTransportPacketExtension, ConferenceSourceMap, boolean) ColibriV2SessionManager.kt:441
  org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.removeSources(Participant, EndpointSourceSet, boolean, boolean) JitsiMeetConferenceImpl.java:1360
  org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.reInviteParticipants(Collection) JitsiMeetConferenceImpl.java:1781
  org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.reInviteParticipantsById(List) JitsiMeetConferenceImpl.java:1689
  org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.onBridgeDown(Bridge) JitsiMeetConferenceImpl.java:1667
  org.jitsi.jicofo.conference.JitsiMeetConferenceImpl$BridgeSelectorEventHandler.bridgeRemoved(Bridge) JitsiMeetConferenceImpl.java:1966
  org.jitsi.jicofo.bridge.BridgeSelector$removeJvbAddress$1$1.invoke(BridgeSelector$EventHandler) BridgeSelector.kt:116
  org.jitsi.jicofo.bridge.BridgeSelector$removeJvbAddress$1$1.invoke(Object) BridgeSelector.kt:116
  org.jitsi.utils.event.AsyncEventEmitter$fireEvent$1$1$1.invoke() EventEmitter.kt:78
  org.jitsi.utils.event.AsyncEventEmitter$fireEvent$1$1$1.invoke() EventEmitter.kt:78
  org.jitsi.utils.event.BaseEventEmitter.wrap(Function0) EventEmitter.kt:49
  org.jitsi.utils.event.AsyncEventEmitter.fireEvent$lambda-1$lambda-0(AsyncEventEmitter, Object, Function1) EventEmitter.kt:78
  org.jitsi.utils.event.AsyncEventEmitter$$Lambda$392.run()
  java.lang.Thread.run() Thread.java:829

Jicofo Global IO Poolpool-2-thread-489  Blocked Thread ID: 1650
  org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.reInviteParticipantsById(List) JitsiMeetConferenceImpl.java:1675
  org.jitsi.jicofo.conference.JitsiMeetConferenceImpl$ColibriSessionManagerListener.bridgeRemoved(Bridge, List) JitsiMeetConferenceImpl.java:2089
  org.jitsi.jicofo.conference.colibri.v2.ColibriV2SessionManager$allocate$4$1.invoke(ColibriSessionManager$Listener) ColibriV2SessionManager.kt:322
  org.jitsi.jicofo.conference.colibri.v2.ColibriV2SessionManager$allocate$4$1.invoke(Object) ColibriV2SessionManager.kt:322
  org.jitsi.utils.event.SyncEventEmitter$fireEvent$1$1.invoke() EventEmitter.kt:64
  org.jitsi.utils.event.SyncEventEmitter$fireEvent$1$1.invoke() EventEmitter.kt:64
  org.jitsi.utils.event.BaseEventEmitter.wrap(Function0) EventEmitter.kt:49
  org.jitsi.utils.event.SyncEventEmitter.fireEvent(Function1) EventEmitter.kt:64
  org.jitsi.jicofo.conference.colibri.v2.ColibriV2SessionManager.allocate(Participant, List, boolean, boolean) ColibriV2SessionManager.kt:322
  org.jitsi.jicofo.conference.ParticipantInviteRunnable.doRun() ParticipantInviteRunnable.java:204
  org.jitsi.jicofo.conference.ParticipantInviteRunnable.run() ParticipantInviteRunnable.java:170
  java.lang.Thread.run() Thread.java:829

Thread 56 attempts to lock JMC.participantsLock and then CSM.syncRoot,
thread 1650 does it in the other order.

This fix fires all events from ColibriV2SessionManager in the IO pool.
