### PR TITLE
log: Only log when a session is removed.

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -486,12 +486,8 @@ class ColibriV2SessionManager(
     }
 
     override fun removeBridge(bridge: Bridge): List<String> = synchronized(syncRoot) {
+        val sessionToRemove = sessions.values.find { it.bridge.jid == bridge.jid } ?: return emptyList()
         logger.info("Removing bridges: $bridge")
-        val sessionToRemove = sessions.values.find { it.bridge.jid == bridge.jid }
-            ?: run {
-                logger.warn("Can not remove bridge, no session")
-                return@synchronized emptyList()
-            }
         val participantsToRemove = getSessionParticipants(sessionToRemove)
 
         removeParticipantInfosBySession(mapOf(sessionToRemove to participantsToRemove))


### PR DESCRIPTION
The API is called whenever any bridge goes down, regardless if it is
used by the conference.
