### PR TITLE
fix: Do not re-invite participants when the selected bridge is unavailable.

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -392,7 +392,9 @@ class ColibriV2SessionManager(
                     } else {
                         // This is an item_not_found NOT coming from the bridge. Most likely coming from the MUC
                         // because the occupant left.
-                        throw ColibriAllocationFailedException("Item not found, bridge unavailable?", true)
+                        // This is probably a wrong selection decision, and if we re-try we run the risk of it
+                        // repeating.
+                        throw ColibriAllocationFailedException("Item not found, bridge unavailable?", false)
                     }
                 }
                 conflict -> {


### PR DESCRIPTION
Prior to #925 a bridge with no relay-id configured leaving the MUC would result in it being selected over and over again. 

This PR limits the consequences if a similar situation happens again.