### PR TITLE
Fix stress accounting for recently added endpoints

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
@@ -53,7 +53,8 @@ class Bridge @JvmOverloads internal constructor(
      */
     private val newEndpointsRate = RateTracker(
         BridgeConfig.config.participantRampupInterval(),
-        Duration.ofMillis(100)
+        Duration.ofMillis(100),
+        clock
     )
 
     /**

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -216,7 +216,10 @@ class BridgeSelector @JvmOverloads constructor(
             conferenceBridges,
             participantRegion,
             OctoConfig.config.enabled
-        )
+        ).also {
+            // The bridge was selected for an endpoint, increment its counter.
+            it?.endpointAdded()
+        }
     }
 
     val stats: JSONObject


### PR DESCRIPTION
- fix: Update newEndpointsRate when a Bridge is selected (fixes #943).
- test: Add test for recently added endpoint affecting stress.
