### PR TITLE
Add selection tests, fallback to local region

### DIFF
--- a/src/main/java/org/jitsi/jicofo/bridge/RegionBasedBridgeSelectionStrategy.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/RegionBasedBridgeSelectionStrategy.java
@@ -67,6 +67,8 @@ public class RegionBasedBridgeSelectionStrategy
      */
     private final Map<String, Set<String>> regionGroups = new HashMap<>();
 
+    public final String localRegion = JicofoConfig.config.localRegion();
+
     /**
      * Default constructor.
      */
@@ -94,7 +96,6 @@ public class RegionBasedBridgeSelectionStrategy
             return null;
         }
 
-        String localRegion = JicofoConfig.config.localRegion();
         String r = participantRegion == null ? localRegion : participantRegion;
         if (localRegion != null)
         {

--- a/src/main/java/org/jitsi/jicofo/bridge/RegionBasedBridgeSelectionStrategy.java
+++ b/src/main/java/org/jitsi/jicofo/bridge/RegionBasedBridgeSelectionStrategy.java
@@ -99,19 +99,26 @@ public class RegionBasedBridgeSelectionStrategy
         String r = participantRegion == null ? localRegion : participantRegion;
         if (localRegion != null)
         {
+            Set<String> regionGroup = getRegionGroup(r);
+
             if (conferenceBridges.isEmpty() && !Objects.equals(r, JicofoConfig.config.localRegion()))
             {
                 // Selecting an initial bridge for a participant not in the local region. This is most likely because
                 // exactly one of the first two participants in the conference is not in the local region, and we're
                 // selecting for it first. I.e. there is another participant in the local region which will be
                 // subsequently invited.
-                Set<String> regionGroup = regionGroups.get(r);
-                if (regionGroup != null && regionGroup.contains(localRegion))
+                if (regionGroup.contains(localRegion))
                 {
                     // With the above assumption, there are two participants in the local region group. Therefore,
                     // they will use the same bridge. Prefer to use a bridge in the local region.
                     r = localRegion;
                 }
+            }
+
+            // If there are no bridges in the participant region or region group, select from the local region instead.
+            if (bridges.stream().noneMatch(b -> regionGroup.contains(b.getRegion())))
+            {
+                r = localRegion;
             }
         }
 

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategyTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategyTest.kt
@@ -46,7 +46,7 @@ class BridgeSelectionStrategyTest : ShouldSpec() {
             strategy.select(allBridges, conferenceBridges, region2, true) shouldBe bridge2
 
             // Or a bridge in the local region otherwise
-            //strategy.select(allBridges, conferenceBridges, "invalid region", true) shouldBe localBridge
+            strategy.select(allBridges, conferenceBridges, "invalid region", true) shouldBe localBridge
             strategy.select(allBridges, conferenceBridges, null, true) shouldBe localBridge
 
             conferenceBridges[bridge3] = 1

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategyTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategyTest.kt
@@ -19,11 +19,15 @@ package org.jitsi.jicofo.bridge
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import org.jitsi.config.withNewConfig
 import org.jxmpp.jid.impl.JidCreate
 
 class BridgeSelectionStrategyTest : ShouldSpec() {
     init {
-        val strategy: BridgeSelectionStrategy = RegionBasedBridgeSelectionStrategy()
+        val localRegion = "local-region"
+        val strategy: RegionBasedBridgeSelectionStrategy = createWithNewConfig("jicofo.local-region=$localRegion") {
+            RegionBasedBridgeSelectionStrategy()
+        }
 
         context("testRegionBasedSelection") {
             val region1 = "region1"
@@ -139,4 +143,12 @@ class BridgeSelectionStrategyTest : ShouldSpec() {
 
 private fun createBridge(region: String, stress: Double) = Bridge(JidCreate.from(region)).apply {
     setStats(stress = stress, region = region)
+}
+
+private fun <T : Any> createWithNewConfig(config: String, block: () -> T): T {
+    lateinit var ret: T
+    withNewConfig(config) {
+        ret = block()
+    }
+    return ret
 }

--- a/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategyTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategyTest.kt
@@ -31,11 +31,12 @@ class BridgeSelectionStrategyTest : ShouldSpec() {
 
         context("testRegionBasedSelection") {
             val region1 = "region1"
-            val region2 = "region2"
+            val region2 = localRegion
             val region3 = "region3"
             val bridge1 = Bridge(JidCreate.from("bridge1")).apply { setStats(region = region1) }
             val bridge2 = Bridge(JidCreate.from("bridge2")).apply { setStats(region = region2) }
             val bridge3 = Bridge(JidCreate.from("bridge3")).apply { setStats(region = region3) }
+            val localBridge = bridge2
 
             val allBridges = listOf(bridge1, bridge2, bridge3)
             val conferenceBridges: MutableMap<Bridge, Int> = HashMap()
@@ -45,16 +46,14 @@ class BridgeSelectionStrategyTest : ShouldSpec() {
             strategy.select(allBridges, conferenceBridges, region2, true) shouldBe bridge2
 
             // Or a bridge in the local region otherwise
-            // This is not actually implemented.
-            // val localBridge = bridge1
-            // strategy.select(allBridges, conferenceBridges, "invalid region", true) shouldBe localBridge
-            // strategy.select(allBridges, conferenceBridges, null, true) shouldBe localBridge
+            //strategy.select(allBridges, conferenceBridges, "invalid region", true) shouldBe localBridge
+            strategy.select(allBridges, conferenceBridges, null, true) shouldBe localBridge
 
             conferenceBridges[bridge3] = 1
             strategy.select(allBridges, conferenceBridges, region3, true) shouldBe bridge3
             strategy.select(allBridges, conferenceBridges, region2, true) shouldBe bridge2
-            // A participant in an unknown region should be allocated on the existing conference bridge.
-            strategy.select(allBridges, conferenceBridges, null, true) shouldBe bridge3
+            // A participant in an unknown region should be allocated on a local bridge.
+            strategy.select(allBridges, conferenceBridges, null, true) shouldBe localBridge
 
             conferenceBridges[bridge2] = 1
             // A participant in an unknown region should be allocated on the least loaded (according to the order of


### PR DESCRIPTION
- test: Set local-region for selection tests.
- test: Use local region, fix expected selection.
- fix: Fall back to local region if there are no bridge in a participant's region group.
