### PR TITLE
Send Jingle source parameters with the correct namespace

### DIFF
--- a/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
@@ -18,7 +18,7 @@ package org.jitsi.jicofo.conference.source
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
-import org.jitsi.xmpp.extensions.jingle.ParameterPacketExtension
+import org.jitsi.xmpp.extensions.jingle.SourceParameterPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.SSRCInfoPacketExtension
 import org.jxmpp.jid.Jid
 
@@ -41,7 +41,7 @@ data class Source(
         sourcePacketExtension.ssrc,
         mediaType,
         sourcePacketExtension.name,
-        sourcePacketExtension.getChildExtensionsOfType(ParameterPacketExtension::class.java)
+        sourcePacketExtension.getChildExtensionsOfType(SourceParameterPacketExtension::class.java)
             .filter { it.name == "msid" }.map { it.value }.firstOrNull(),
         if (sourcePacketExtension.videoType == null) null else VideoType.parseString(sourcePacketExtension.videoType)
     )
@@ -60,7 +60,7 @@ data class Source(
         }
 
         if (encodeMsid && msid != null) {
-            addChildExtension(ParameterPacketExtension("msid", msid))
+            addChildExtension(SourceParameterPacketExtension("msid", msid))
         }
 
         this@Source.videoType?.let {

--- a/src/test/kotlin/org/jitsi/jicofo/conference/source/SourceTest.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/conference/source/SourceTest.kt
@@ -22,7 +22,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.jitsi.utils.MediaType
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
-import org.jitsi.xmpp.extensions.jingle.ParameterPacketExtension
+import org.jitsi.xmpp.extensions.jingle.SourceParameterPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.SSRCInfoPacketExtension
 import org.jxmpp.jid.impl.JidCreate
 
@@ -33,7 +33,7 @@ class SourceTest : ShouldSpec() {
                 ssrc = 1
                 name = "name-1"
                 videoType = "camera"
-                addChildExtension(ParameterPacketExtension("msid", "msid"))
+                addChildExtension(SourceParameterPacketExtension("msid", "msid"))
             }
 
             Source(MediaType.VIDEO, packetExtension) shouldBe
@@ -50,7 +50,7 @@ class SourceTest : ShouldSpec() {
             extension.ssrc shouldBe 1
             extension.name shouldBe nameValue
             extension.videoType shouldBe videoType.toString()
-            val parameters = extension.getChildExtensionsOfType(ParameterPacketExtension::class.java)
+            val parameters = extension.getChildExtensionsOfType(SourceParameterPacketExtension::class.java)
             parameters.filter { it.name == "msid" && it.value == msidValue }.size shouldBe 1
 
             val ssrcInfo = extension.getFirstChildOfType(SSRCInfoPacketExtension::class.java)

--- a/src/test/kotlin/org/jitsi/jicofo/mock/MockColibri2Server.kt
+++ b/src/test/kotlin/org/jitsi/jicofo/mock/MockColibri2Server.kt
@@ -30,7 +30,7 @@ import org.jitsi.xmpp.extensions.colibri2.Sources
 import org.jitsi.xmpp.extensions.colibri2.Transport
 import org.jitsi.xmpp.extensions.jingle.DtlsFingerprintPacketExtension
 import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
-import org.jitsi.xmpp.extensions.jingle.ParameterPacketExtension
+import org.jitsi.xmpp.extensions.jingle.SourceParameterPacketExtension
 import org.jitsi.xmpp.util.createError
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.packet.StanzaError
@@ -195,7 +195,7 @@ private fun buildFeedbackSources(localAudioSsrc: Long, localVideoSsrc: Long): So
                     ssrc = localAudioSsrc
                     name = "jvb-a0"
                     addParameter(
-                        ParameterPacketExtension().apply {
+                        SourceParameterPacketExtension().apply {
                             name = "msid"
                             value = "mixedmslabel mixedlabelaudio0"
                         }
@@ -213,7 +213,7 @@ private fun buildFeedbackSources(localAudioSsrc: Long, localVideoSsrc: Long): So
                     ssrc = localVideoSsrc
                     name = "jvb-v0"
                     addParameter(
-                        ParameterPacketExtension().apply {
+                        SourceParameterPacketExtension().apply {
                             name = "msid"
                             value = "mixedmslabel mixedlabelvideo0"
                         }


### PR DESCRIPTION
Ref: jitsi-xmpp-extensions#82

This shouldn't be merged until jitsi-xmpp-extensions is updated.