### PR TITLE
Fix graceful-shutdown handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-xmpp-extensions</artifactId>
-      <version>1.0-56-g7efff95</version>
+      <version>1.0-58-g31445c4</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
@@ -115,7 +115,6 @@ class Bridge @JvmOverloads internal constructor(
      * Stores a boolean that indicates whether the bridge is in graceful shutdown mode.
      */
     var isInGracefulShutdown = false /* we assume it is not shutting down */
-        private set
 
     /**
      * Whether the bridge is in SHUTTING_DOWN mode.

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -35,6 +35,8 @@ import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.AsyncEventEmitter
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import org.jitsi.xmpp.extensions.colibri.ColibriConferenceIQ
+import org.jitsi.xmpp.extensions.colibri.ColibriConferenceIQ.GracefulShutdown
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Error
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifiedIQ
 import org.jitsi.xmpp.extensions.jingle.ContentPacketExtension
@@ -418,12 +420,21 @@ class ColibriV2SessionManager(
                     }
                 }
                 service_unavailable -> {
-                    // This only happens if the bridge is in graceful-shutdown and we request a new conference.
-                    // Since it's a new conference, remove the bridge and re-invite.
-                    // The fact that this bridge was selected means that we haven't received its updated presence yet,
-                    // so set the graceful-shutdown flag explicitly to prevent future selection.
-                    session.bridge.isInGracefulShutdown = true
-                    throw ColibriAllocationFailedException("Bridge in graceful shutdown", true)
+                    val gracefulShutdown = reason == Colibri2Error.Reason.GRACEFUL_SHUTDOWN ||
+                        response.error?.getExtension<GracefulShutdown>(
+                        GracefulShutdown.ELEMENT,
+                        ColibriConferenceIQ.NAMESPACE
+                    ) != null
+
+                    if (gracefulShutdown) {
+                        // The fact that this bridge was selected means that we haven't received its updated presence yet,
+                        // so set the graceful-shutdown flag explicitly to prevent future selection.
+                        session.bridge.isInGracefulShutdown = true
+                        throw ColibriAllocationFailedException("Bridge in graceful shutdown", true)
+                    } else {
+                        session.bridge.isOperational = false
+                        throw ColibriAllocationFailedException("Bridge failed with service_unavailable.", true)
+                    }
                 }
                 else -> {
                     session.bridge.isOperational = false

--- a/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
+++ b/src/main/kotlin/org/jitsi/jicofo/conference/colibri/v2/ColibriV2SessionManager.kt
@@ -420,6 +420,9 @@ class ColibriV2SessionManager(
                 service_unavailable -> {
                     // This only happens if the bridge is in graceful-shutdown and we request a new conference.
                     // Since it's a new conference, remove the bridge and re-invite.
+                    // The fact that this bridge was selected means that we haven't received its updated presence yet,
+                    // so set the graceful-shutdown flag explicitly to prevent future selection.
+                    session.bridge.isInGracefulShutdown = true
                     throw ColibriAllocationFailedException("Bridge in graceful shutdown", true)
                 }
                 else -> {


### PR DESCRIPTION
- fix: Set the graceful-shutdown flag when we receive a graceful-shutdown error from jvb.
- Recognize colibri2 graceful-shutdown errors.
