### PR TITLE
fix: Fire registratinChanged in IO pool.

### DIFF
--- a/jicofo-common/src/main/java/org/jitsi/impl/protocol/xmpp/AbstractXmppProvider.java
+++ b/jicofo-common/src/main/java/org/jitsi/impl/protocol/xmpp/AbstractXmppProvider.java
@@ -20,6 +20,7 @@ package org.jitsi.impl.protocol.xmpp;
 import java.util.*;
 
 import org.jetbrains.annotations.*;
+import org.jitsi.jicofo.*;
 import org.jitsi.utils.logging2.*;
 
 /**
@@ -83,20 +84,19 @@ public abstract class AbstractXmppProvider
         }
 
         for (RegistrationListener listener : listeners)
-            try
+            TaskPools.getIoPool().submit(() ->
             {
-                listener.registrationChanged(registered);
-            }
-            catch (Throwable throwable)
-            {
-                logger.error(
-                    "An error occurred while executing "
-                        + "RegistrationStateChangeListener"
-                        + "#registrationStateChanged"
-                        + "(RegistrationStateChangeEvent) of "
-                        + listener,
-                    throwable);
-            }
+                try
+                {
+                    listener.registrationChanged(registered);
+                }
+                catch (Throwable throwable)
+                {
+                    logger.error(
+                            "An error occurred while executing registrationStateChanged() on " + listener,
+                            throwable);
+                }
+            });
     }
 
     /**


### PR DESCRIPTION
Smack calls the reconnect callback while holding the XMPPConnection
lock. Run our own listeners in an IO thread in case on of them blocks
(as we've observed happening)
