### PR TITLE
fix: Fix leaking conferences.

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
@@ -38,7 +38,7 @@ import java.util.*;
  *
  * @author Pawel Domas
  */
-public interface JitsiMeetConference
+public interface JitsiMeetConference extends RegistrationListener
 {
     /**
      * Checks how many {@link Participant}s are in the conference.

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -330,8 +330,6 @@ public class JitsiMeetConferenceImpl
                 joinTheRoom();
             }
 
-            clientXmppProvider.addRegistrationListener(this);
-
             JibriDetector jibriDetector = jicofoServices.getJibriDetector();
             if (jibriDetector != null)
             {
@@ -403,8 +401,6 @@ public class JitsiMeetConferenceImpl
             }
             jibriRecorder = null;
         }
-
-        getClientXmppProvider().removeRegistrationListener(this);
 
         BridgeSelector bridgeSelector = jicofoServices.getBridgeSelector();
         bridgeSelector.removeHandler(bridgeSelectorEventHandler);

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -87,7 +87,9 @@ open class JicofoServices {
         conferenceStore = focusManager,
         focusManager = focusManager, // TODO do not use FocusManager directly
         authenticationAuthority = authenticationAuthority
-    )
+    ).also {
+        it.clientConnection.addRegistrationListener(focusManager)
+    }
 
     val bridgeSelector = BridgeSelector()
     private val jvbDoctor = if (BridgeConfig.config.healthChecksEnabled) {


### PR DESCRIPTION
I don't understand how the leak occurs, but I see multiple conferences
left as listeners of XmppProviderImpl, which are not in FocusManager
anymore. Fire events via FocusManager instead of registering individual
conferences.
