### PR TITLE
Move XMPP config to jicofo.conf

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -19,10 +19,6 @@
 if [ -f /etc/jitsi/jicofo/config ]; then
     . /etc/jitsi/jicofo/config
 fi
-# Assign default host if not configured
-if [ ! $JICOFO_HOST ]; then
-    JICOFO_HOST=localhost
-fi
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/share/jicofo/jicofo.sh
@@ -32,7 +28,20 @@ USER=jicofo
 PIDFILE=/var/run/jicofo.pid
 LOGFILE=/var/log/jitsi/jicofo.log
 DESC=jicofo
-DAEMON_OPTS=" --host=$JICOFO_HOST --domain=$JICOFO_HOSTNAME --user_name=$JICOFO_AUTH_USER --user_domain=$JICOFO_AUTH_DOMAIN $JICOFO_OPTS"
+DAEMON_OPTS=""
+if [ -n "$JICOFO_HOST" ] ;then
+  DAEMON_OPTS="$DAEMON_OPTS --host=$JICOFO_HOST"
+fi
+if [ -n "$JICOFO_HOSTNAME" ] ;then
+  DAEMON_OPTS="$DAEMON_OPTS --domain=$JICOFO_HOSTNAME"
+fi
+if [ -n "$JICOFO_AUTH_USER" ] ;then
+  DAEMON_OPTS="$DAEMON_OPTS --user_name=$JICOFO_AUTH_USER"
+fi
+if [ -n "$JICOFO_AUTH_DOMAIN" ] ;then
+  DAEMON_OPTS="$DAEMON_OPTS --user_domain=$JICOFO_AUTH_DOMAIN"
+fi
+DAEMON_OPTS="$DAEMON_OPTS $JICOFO_OPTS"
 
 
 if [ ! -x $DAEMON ] ;then

--- a/debian/init.d
+++ b/debian/init.d
@@ -28,20 +28,6 @@ USER=jicofo
 PIDFILE=/var/run/jicofo.pid
 LOGFILE=/var/log/jitsi/jicofo.log
 DESC=jicofo
-DAEMON_OPTS=""
-if [ -n "$JICOFO_HOST" ] ;then
-  DAEMON_OPTS="$DAEMON_OPTS --host=$JICOFO_HOST"
-fi
-if [ -n "$JICOFO_HOSTNAME" ] ;then
-  DAEMON_OPTS="$DAEMON_OPTS --domain=$JICOFO_HOSTNAME"
-fi
-if [ -n "$JICOFO_AUTH_USER" ] ;then
-  DAEMON_OPTS="$DAEMON_OPTS --user_name=$JICOFO_AUTH_USER"
-fi
-if [ -n "$JICOFO_AUTH_DOMAIN" ] ;then
-  DAEMON_OPTS="$DAEMON_OPTS --user_domain=$JICOFO_AUTH_DOMAIN"
-fi
-DAEMON_OPTS="$DAEMON_OPTS $JICOFO_OPTS"
 
 
 if [ ! -x $DAEMON ] ;then
@@ -73,7 +59,7 @@ start() {
     echo -n "Starting $NAME: "
     export JICOFO_AUTH_PASSWORD JICOFO_MAX_MEMORY
     start-stop-daemon --start --quiet --background --chuid $USER --make-pidfile --pidfile $PIDFILE \
-        --exec /bin/bash -- -c "cd $DAEMON_DIR; JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" exec $DAEMON $DAEMON_OPTS < /dev/null >> $LOGFILE 2>&1"
+        --exec /bin/bash -- -c "cd $DAEMON_DIR; JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" exec $DAEMON $JICOFO_OPTS < /dev/null >> $LOGFILE 2>&1"
     echo "$NAME started."
 }
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -84,10 +84,18 @@ jicofo {
 
         # Set the client XMPP config in jicofo.conf. The values were either read from an existing
         # /etc/jitsi/jicofo/config or generated above.
-        hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.xmpp-domain" "$JICOFO_HOSTNAME"
-        hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.domain" "$JICOFO_AUTH_DOMAIN"
-        hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.username" "$JICOFO_AUTH_USER"
-        hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.password" "$JICOFO_AUTH_PASSWORD"
+        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.xmpp-domain" > /dev/null 2>&1 ;then
+            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.xmpp-domain" "$JICOFO_HOSTNAME"
+        fi
+        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.domain" ;then
+            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.domain" "$JICOFO_AUTH_DOMAIN"
+        fi
+        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.username" ;then
+            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.username" "$JICOFO_AUTH_USER"
+        fi
+        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.password" ;then
+            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.password" "$JICOFO_AUTH_PASSWORD"
+        fi
 
         # Add the JvbBrewery config if missing
         if ! grep -sq "org.jitsi.jicofo.BRIDGE_MUC" "$OLD_JITSI_CONFIG" ;then

--- a/debian/postinst
+++ b/debian/postinst
@@ -87,13 +87,13 @@ jicofo {
         if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.xmpp-domain" > /dev/null 2>&1 ;then
             hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.xmpp-domain" "$JICOFO_HOSTNAME"
         fi
-        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.domain" ;then
+        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.domain" > /dev/null 2>&1 ;then
             hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.domain" "$JICOFO_AUTH_DOMAIN"
         fi
-        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.username" ;then
+        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.username" > /dev/null 2>&1 ;then
             hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.username" "$JICOFO_AUTH_USER"
         fi
-        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.password" ;then
+        if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.password" > /dev/null 2>&1 ;then
             hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.password" "$JICOFO_AUTH_PASSWORD"
         fi
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -44,27 +44,8 @@ case "$1" in
             fi
             JICOFO_AUTH_PASSWORD="$RET"
 
-            # storing default. TODO: move this to jicofo.conf
-            echo '# Jitsi Conference Focus settings' > $CONFIG
-            echo '# sets the host name of the XMPP server' >> $CONFIG
-            echo "JICOFO_HOST=localhost" >> $CONFIG
-            echo >> $CONFIG
-            echo '# sets the XMPP domain (default: none)' >> $CONFIG
-            echo "JICOFO_HOSTNAME=$JICOFO_HOSTNAME" >> $CONFIG
-            echo >> $CONFIG
-            echo '# sets the XMPP domain name to use for XMPP user logins' >> $CONFIG
-            echo "JICOFO_AUTH_DOMAIN=$JICOFO_AUTH_DOMAIN" >> $CONFIG
-            echo >> $CONFIG
-            echo '# sets the username to use for XMPP user logins' >> $CONFIG
-            echo "JICOFO_AUTH_USER=$JICOFO_AUTH_USER" >> $CONFIG
-            echo >> $CONFIG
-            echo '# sets the password to use for XMPP user logins' >> $CONFIG
-            echo "JICOFO_AUTH_PASSWORD=$JICOFO_AUTH_PASSWORD" >> $CONFIG
-            echo >> $CONFIG
-            echo '# extra options to pass to the jicofo daemon' >> $CONFIG
-            echo "JICOFO_OPTS=\"\"" >> $CONFIG
-            echo >> $CONFIG
-            echo '# adds java system props that are passed to jicofo (default are for home and logging config file)' >> $CONFIG
+            # This re-creates $CONFIG. If previous values existed, they will be set in jicofo.conf below.
+            echo '# adds java system props that are passed to jicofo (default are for home and logging config file)' > $CONFIG
             echo "JAVA_SYS_PROPS=\"-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi\
  -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=jicofo\
  -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi\
@@ -100,6 +81,13 @@ jicofo {
 
         # Make sure the client-proxy is set correctly.
         hocon -f $HOCON_CONFIG set jicofo.xmpp.client.client-proxy "focus.$JVB_HOSTNAME"
+
+        # Set the client XMPP config in jicofo.conf. The values were either read from an existing
+        # /etc/jitsi/jicofo/config or generated above.
+        hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.xmpp-domain" "$JICOFO_HOSTNAME"
+        hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.domain" "$JICOFO_AUTH_DOMAIN"
+        hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.username" "$JICOFO_AUTH_USER"
+        hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.password" "$JICOFO_AUTH_PASSWORD"
 
         # Add the JvbBrewery config if missing
         if ! grep -sq "org.jitsi.jicofo.BRIDGE_MUC" "$OLD_JITSI_CONFIG" ;then

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppConfig.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppConfig.kt
@@ -164,7 +164,9 @@ class XmppClientConnectionConfig : XmppConnectionConfig {
         legacyXmppDomainPropertyName.from(legacyConfig).convertFrom<String> {
             JidCreate.domainBareFrom(it)
         }
-        "jicofo.xmpp.client.xmpp-domain".from(newConfig)
+        "jicofo.xmpp.client.xmpp-domain".from(newConfig).convertFrom<String> {
+            JidCreate.domainBareFrom(it)
+        }
     }
 
     val conferenceMucJid: DomainBareJid by config {

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppConfig.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppConfig.kt
@@ -183,6 +183,7 @@ class XmppClientConnectionConfig : XmppConnectionConfig {
         legacyXmppDomainPropertyName.from(legacyConfig).convertFrom<String> {
             JidCreate.domainBareFrom(it)
         }
+        "jicofo.xmpp.client.xmpp-domain".from(newConfig)
     }
 
     val conferenceMucJid: DomainBareJid by config {

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppConfig.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppConfig.kt
@@ -117,16 +117,11 @@ class XmppServiceConnectionConfig : XmppConnectionConfig {
 
 class XmppClientConnectionConfig : XmppConnectionConfig {
     override val enabled: Boolean by config {
-        // If the legacy host is set to anything, the connection is enabled.
-        // The legacy name may be set as a system property in which case it the property is available via newConfig
-        legacyHostnamePropertyName.from(newConfig).convertFrom<String> { true }
         legacyHostnamePropertyName.from(legacyConfig).convertFrom<String> { true }
         "jicofo.xmpp.client.enabled".from(newConfig)
     }
 
     override val hostname: String by config {
-        // The legacy name may be set as a system property in which case it the property is available via newConfig
-        legacyHostnamePropertyName.from(newConfig)
         legacyHostnamePropertyName.from(legacyConfig)
         "jicofo.xmpp.client.hostname".from(newConfig)
     }
@@ -140,10 +135,6 @@ class XmppClientConnectionConfig : XmppConnectionConfig {
      * This is the domain used for login. Not necessarily the root XMPP domain.
      */
     override val domain: DomainBareJid by config {
-        // The legacy name may be set as a system property in which case the property is available via newConfig
-        legacyDomainPropertyName.from(newConfig).convertFrom<String> {
-            JidCreate.domainBareFrom(it)
-        }
         legacyDomainPropertyName.from(legacyConfig).convertFrom<String> {
             JidCreate.domainBareFrom(it)
         }
@@ -153,10 +144,6 @@ class XmppClientConnectionConfig : XmppConnectionConfig {
     }
 
     override val username: Resourcepart by config {
-        // The legacy name may be set as a system property in which case the property is available via newConfig
-        legacyUsernamePropertyName.from(newConfig).convertFrom<String> {
-            Resourcepart.from(it)
-        }
         legacyUsernamePropertyName.from(legacyConfig).convertFrom<String> {
             Resourcepart.from(it)
         }
@@ -166,8 +153,6 @@ class XmppClientConnectionConfig : XmppConnectionConfig {
     }
 
     override val password: String? by optionalconfig {
-        // The legacy name may be set as a system property in which case it the property is available via newConfig
-        legacyPasswordPropertyName.from(newConfig)
         legacyPasswordPropertyName.from(legacyConfig)
         "jicofo.xmpp.client.password".from(newConfig)
     }
@@ -176,10 +161,6 @@ class XmppClientConnectionConfig : XmppConnectionConfig {
      * This is the top-level domain hosted by the XMPP server (not necessarily the one used for login).
      */
     val xmppDomain: DomainBareJid by config {
-        // The legacy name may be set as a system property in which case it the property is available via newConfig
-        legacyXmppDomainPropertyName.from(newConfig).convertFrom<String> {
-            JidCreate.domainBareFrom(it)
-        }
         legacyXmppDomainPropertyName.from(legacyConfig).convertFrom<String> {
             JidCreate.domainBareFrom(it)
         }

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -326,7 +326,10 @@ jicofo {
       enabled = true
       hostname = "localhost"
       port = 5222
+      # The domain to use for login.
       #domain =
+      # The domain used to send XMPP ping to.
+      #xmpp-domain =
       username = "focus"
       #password =
 
@@ -353,6 +356,7 @@ jicofo {
       hostname = "localhost"
       port = 6222
       #domain =
+      #xmpp-domain =
       #username =
       #password =
 

--- a/jicofo/src/main/java/org/jitsi/jicofo/Main.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/Main.java
@@ -21,13 +21,11 @@ import kotlin.jvm.functions.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.cmd.*;
 import org.jitsi.config.*;
-import org.jitsi.jicofo.xmpp.*;
 import org.jitsi.metaconfig.*;
 import org.jitsi.shutdown.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 
-import static org.apache.commons.lang3.StringUtils.*;
 
 /**
  * Provides the <tt>main</tt> entry point of Jitsi Meet conference focus.
@@ -52,7 +50,6 @@ public class Main
                 logger.error("An uncaught exception occurred in thread=" + t, e));
 
         setupMetaconfigLogger();
-        setSystemProperties(args);
         JitsiConfig.Companion.reloadNewConfig();
 
         // Make sure that passwords are not printed by ConfigurationService
@@ -97,66 +94,6 @@ public class Main
         jicofoServices.shutdown();
         TaskPools.shutdown();
         JicofoServices.setJicofoServicesSingleton(null);
-    }
-
-    /**
-     * Read the command line arguments and env variables, and set the corresponding system properties used for
-     * configuration of the XMPP component and client connections.
-     */
-    private static void setSystemProperties(String[] args)
-            throws ParseException
-    {
-        CmdLine cmdLine = new CmdLine();
-
-        // We may end execution here if one of required arguments is missing
-        cmdLine.parse(args);
-
-        // XMPP host/domain
-        String host;
-        String componentDomain;
-        // Try to get domain, can be null after this call(we'll fix that later)
-        componentDomain = cmdLine.getOptionValue("domain");
-        // Host name
-        host = cmdLine.getOptionValue("--host", componentDomain == null ? "localhost" : componentDomain);
-        // Try to fix component domain
-        if (isBlank(componentDomain))
-        {
-            componentDomain = host;
-        }
-        if (componentDomain != null)
-        {
-            // For backward compat, the "--domain" command line argument controls the domain for the XMPP component
-            // as well as XMPP client connection.
-            System.setProperty(XmppClientConnectionConfig.legacyXmppDomainPropertyName, componentDomain);
-        }
-        if (host != null)
-        {
-            // For backward compat, the "--host" command line argument controls the hostname for the XMPP component
-            // as well as XMPP client connection.
-            System.setProperty(XmppClientConnectionConfig.legacyHostnamePropertyName, host);
-        }
-
-        // XMPP client connection
-        String focusDomain = cmdLine.getOptionValue("--user_domain");
-        String focusUserName = cmdLine.getOptionValue("--user_name");
-        String focusPassword = cmdLine.getOptionValue("--user_password");
-        if (isBlank(focusPassword))
-        {
-            focusPassword = System.getenv("JICOFO_AUTH_PASSWORD");
-        }
-
-        if (focusDomain != null)
-        {
-            System.setProperty(XmppClientConnectionConfig.legacyDomainPropertyName, focusDomain);
-        }
-        if (focusUserName != null)
-        {
-            System.setProperty(XmppClientConnectionConfig.legacyUsernamePropertyName, focusUserName);
-        }
-        if (isNotBlank(focusPassword))
-        {
-            System.setProperty(XmppClientConnectionConfig.legacyPasswordPropertyName, focusPassword);
-        }
     }
 
     private static void setupMetaconfigLogger()

--- a/resources/jicofo.bat
+++ b/resources/jicofo.bat
@@ -1,23 +1,11 @@
 @echo off
 
-if "%1"=="" goto usage
 if "%1"=="/h" goto usage
 if "%1"=="/?" goto usage
 goto :begin
 
 :usage
-echo Usage:
-echo %0 [OPTIONS], where options can be:
-echo 	--host=HOST	sets the hostname of the XMPP server (default: domain, if domain is set, localhost otherwise)
-echo 	--domain=DOMAIN	sets the XMPP domain
-echo    --user_domain=DOMAIN specifies the name of XMPP domain used by the focus user to login
-echo    --user_name=USERNAME specifies the username used by the focus XMPP user to login. (default: focus@user_domain)
-echo    --user_password=PASSWORD specifies the password used by focus XMPP user to login. If not provided then focus user will use anonymous authentication method.
-echo.
-echo    PASSWORD can alternatively be set via the environment variable JICOFO_AUTH_PASSWORD.
-echo.
-echo    All of the options can also be specified in the config file (which is the preferred way).
-echo.
+echo Usage: %0
 exit /B 1
 
 :begin

--- a/resources/jicofo.sh
+++ b/resources/jicofo.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
 
-if [[ "$1" == "--help"  || $# -lt 1 ]]; then
-    echo -e "Usage:"
-    echo -e "$0 [OPTIONS], where options can be:"
-    echo -e "\t--host=HOST\t sets the hostname of the XMPP server (default: domain, if domain is set, localhost otherwise)"
-    echo -e "\t--domain=DOMAIN\t sets the XMPP domain"
-    echo -e "\t--user_domain=DOMAIN\t specifies the name of XMPP domain used by the focus user to login."
-    echo -e "\t--user_name=USERNAME\t specifies the username used by the focus XMPP user to login. (default: focus@user_domain)"
-    echo -e "\t--user_password=PASSWORD\t specifies the password used by focus XMPP user to login. If not provided then focus user will use anonymous authentication method."
+if [[ "$1" == "--help"  ]]; then
+    echo -e "Usage: $0"
     echo
-    echo -e "\tPASSWORD can alternatively be set via the environment variable JICOFO_AUTH_PASSWORD."
-    echo
-    echo -e "\tAll of the options can also be specified in the config file (which is the preferred way)."
+    echo -e "Supported environment variables: JICOFO_AUTH_PASSWORD, JICOFO_MAX_MEMORY, JAVA_SYS_PROPS."
     echo
     exit 1
 fi


### PR DESCRIPTION
This needs more testing. But the idea is that command line arguments are no longer used. All options that used command line arguments are now set in jicofo.conf instead, and `postinst` takes care of moving things from `/etc/jitsi/jicofo/config` to `jicofo.conf`.


- debian: Only pass command line params if the options are defined.
- fix: Read xmpp-domain from jicofo.conf.
- debian: Move xmpp config from "config" to jicofo.conf.
- debian: Do not pass /etc/jitsi/jicofo/config values as command line arguments.
- ref: Do not read command line arguments (use jicofo.conf instead).
- Add docs to reference.conf.
