### PR TITLE
Fix updating jicofo.conf

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -40,7 +40,7 @@ case "$1" in
             JICOFO_AUTH_USER="focus"
             db_get jicofo/jicofo-authpassword
             if [ -z "$RET" ] ; then
-                RET=`head -c 8 /dev/urandom | tr '\0-\377' 'a-zA-Z0-9a-zA-Z0-9a-zA-Z0-9a-zA-Z0-9@@@@####'`
+                RET=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 16`
             fi
             JICOFO_AUTH_PASSWORD="$RET"
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -80,21 +80,21 @@ jicofo {
         fi
 
         # Make sure the client-proxy is set correctly.
-        hocon -f $HOCON_CONFIG set jicofo.xmpp.client.client-proxy "focus.$JVB_HOSTNAME"
+        hocon -f $HOCON_CONFIG set jicofo.xmpp.client.client-proxy "\"focus.$JVB_HOSTNAME\""
 
         # Set the client XMPP config in jicofo.conf. The values were either read from an existing
         # /etc/jitsi/jicofo/config or generated above.
         if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.xmpp-domain" > /dev/null 2>&1 ;then
-            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.xmpp-domain" "$JICOFO_HOSTNAME"
+            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.xmpp-domain" "\"$JICOFO_HOSTNAME\""
         fi
         if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.domain" > /dev/null 2>&1 ;then
-            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.domain" "$JICOFO_AUTH_DOMAIN"
+            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.domain" "\"$JICOFO_AUTH_DOMAIN\""
         fi
         if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.username" > /dev/null 2>&1 ;then
-            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.username" "$JICOFO_AUTH_USER"
+            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.username" "\"$JICOFO_AUTH_USER\""
         fi
         if ! hocon -f $HOCON_CONFIG get "jicofo.xmpp.client.password" > /dev/null 2>&1 ;then
-            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.password" "$JICOFO_AUTH_PASSWORD"
+            hocon -f $HOCON_CONFIG set "jicofo.xmpp.client.password" "\"$JICOFO_AUTH_PASSWORD\""
         fi
 
         # Add the JvbBrewery config if missing


### PR DESCRIPTION
- Use only alpha-numerics when generating passwords.
- fix: Quote strings in hocon.
