### PR TITLE
ref(endpoint-allocation): add conference expiration and re-request allocation upon already existed conference error

### DIFF
--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -311,7 +311,12 @@ class ColibriV2SessionManager(
             try {
                 return handleResponse(response, session, created, participantInfo)
             } catch (e: Exception) {
-                logger.error("Failed to allocate a colibri2 endpoint for ${participantInfo.id}: ${e.message}")
+                if (e is ConferenceAlreadyExistsException) {
+                    logger.warn("Failed to allocate a colibri2 endpoint for ${participantInfo.id}: ${e.message}")
+                } else {
+                    logger.error("Failed to allocate a colibri2 endpoint for ${participantInfo.id}: ${e.message}")
+                }
+
                 if (e is ColibriAllocationFailedException && e.removeBridge) {
                     // Add participantInfo just in case it wasn't there already (the set will take care of dups).
                     val removedParticipants = removeSession(session) + participantInfo
@@ -386,6 +391,10 @@ class ColibriV2SessionManager(
                             "XMPP error: ${response.error?.toXML()}",
                             true
                         )
+                    } else if (reason == Colibri2Error.Reason.CONFERENCE_ALREADY_EXISTS) {
+                        // The conference on the bridge already exists. The state between jicofo and the bridge
+                        // is out of sync.
+                        throw ConferenceAlreadyExistsException("Conference already exists error", true)
                     } else {
                         // An error coming from the bridge. The state between jicofo and the bridge must be out of sync.
                         // It's not clear how to handle this. Ideally we should expire the conference and retry, but

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Exceptions.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Exceptions.kt
@@ -18,7 +18,12 @@ package org.jitsi.jicofo.bridge.colibri
 /** Bridge selection failed, i.e. there were no bridges available. */
 class BridgeSelectionFailedException : Exception("Bridge selection failed")
 
-class ColibriAllocationFailedException(
+open class ColibriAllocationFailedException(
     message: String = "",
     val removeBridge: Boolean = false
 ) : Exception(message)
+
+class ConferenceAlreadyExistsException(
+    message: String,
+    removeBridge: Boolean
+) : ColibriAllocationFailedException(message, removeBridge)

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
@@ -212,6 +212,12 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
             cancel();
             return;
         }
+        catch (ConferenceAlreadyExistsException e)
+        {
+            logger.warn("Can not allocate colibri channels, conference already exists.");
+            cancel();
+            return;
+        }
         catch (ColibriAllocationFailedException e)
         {
             logger.error("Failed to allocate colibri channels", e);


### PR DESCRIPTION
Added conference expiration and then re-request allocation for endpoint when allocation is failed with error of already existed conference which can happen after jicofo restart.

Hi guys, added the code which should handle the case when jicofo after restart tries to re-create endpoints and have error from jvb that such conferences already existed which prevent jicofo to restore the existed before conferences.