### PR TITLE
fix: update sourcesignaling when received simultaneously source-add

### DIFF
--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -311,7 +311,11 @@ open class Participant @JvmOverloads constructor(
             logger.warn("Can not signal remote sources, Jingle session not established.")
             return
         }
-        for ((action, sources) in sourceSignaling.update()) {
+        var modifiedSources: List<SourcesToAddOrRemove>
+        synchronized(sourceSignaling) {
+            modifiedSources = sourceSignaling.update()
+        }
+        for ((action, sources) in modifiedSources) {
             logger.info("Sending a queued source-${action.toString().lowercase()}, sources=$sources")
             if (action === AddOrRemove.Add) {
                 jingleSession.addSource(sources)


### PR DESCRIPTION
i have problem which is https://community.jitsi.org/t/sometimes-source-add-is-not-propagated-properly/119046

test version : stable/jitsi-meet_7648

when new participants come into meeting, some of participants could hear, but the others couldn't hear

i think it's data racing within sourcesingaling reset, with synchronized version, it's never occured.

could you please reivew it?
