### PR TITLE
fix: gracefully handle receiving a session-terminate with reinvite

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -950,8 +950,8 @@ public class JitsiMeetConferenceImpl
         {
             terminateParticipant(
                     participant,
-                    null,
-                    null,
+                    Reason.SUCCESS,
+                    (reinvite) ? "reinvite requested" : null,
                     /* do not send session-terminate */ false,
                     /* do send source-remove */ true);
 

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -816,7 +816,7 @@ public class JitsiMeetConferenceImpl
 
     private void terminateParticipant(
             Participant participant,
-            Reason reason,
+            @NotNull Reason reason,
             String message,
             boolean sendSessionTerminate,
             boolean sendSourceRemove)


### PR DESCRIPTION
A reason must be specified otherwise an exception is thrown and the reinvite doesn't happen:

```
Jicofo 2022-12-05 12:59:44.822 INFO: [32] [room=saghul8@conference.alpha.jitsi.net meeting_id=86b66da8-47ac-4107-82db-032d73af282c] JitsiMeetConferenceImpl.terminateParticipant#824: Terminating 94892c10, reason: null, send session-terminate: false
Jicofo 2022-12-05 12:59:44.823 WARNING: [32] org.jivesoftware.smack.AbstractXMPPConnection$1$1.uncaughtException: Thread[Smack Cached Executor,5,main] encountered uncaught exception
java.lang.NullPointerException: Parameter specified as non-null is null: method org.jitsi.jicofo.xmpp.jingle.JingleSession.terminate, parameter reason
	at org.jitsi.jicofo.xmpp.jingle.JingleSession.terminate(JingleSession.kt)
	at org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.terminateParticipant(JitsiMeetConferenceImpl.java:835)
	at org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.terminateSession(JitsiMeetConferenceImpl.java:951)
```