### PR TITLE
Exclude jigasi from stats for "no source name" stats

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -656,11 +656,11 @@ public class JitsiMeetConferenceImpl
                     features);
 
             ConferenceMetrics.participants.inc();
-            if (!participant.supportsReceivingMultipleVideoStreams())
+            if (!participant.supportsReceivingMultipleVideoStreams() && !participant.getChatMember().isJigasi())
             {
                 ConferenceMetrics.participantsNoMultiStream.inc();
             }
-            if (!participant.hasSourceNameSupport())
+            if (!participant.hasSourceNameSupport() && !participant.getChatMember().isJigasi())
             {
                 ConferenceMetrics.participantsNoSourceName.inc();
             }


### PR DESCRIPTION
Jigasi doesn't advertise support for source-names, but it's unaffected
by them. The stats are indented to indicate if there are clients out there that
still need the non-source-name mode which is planned to be removed. Same
for receiving multiple streams.
