### PR TITLE
fix: Temporary fix for JingleSession-s being GC too early

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
@@ -387,6 +387,8 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
                 jingleSession.terminate(Reason.UNDEFINED, null, false);
             }
             jingleSession = participant.createNewJingleSession();
+            // Save a reference to jingleSession to prevent it from being garbage collected. Temporary fix!
+            participant.setJingleSessionTmp(jingleSession);
             logger.info("Sending session-initiate to: " + participant.getMucJid() + " sources=" + sources);
             ack = jingleSession.initiateSession(
                     offer.getContents(),

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -80,6 +80,9 @@ open class Participant @JvmOverloads constructor(
         addContext("participant", endpointId)
     }
 
+    // Save a reference to jingleSession to prevent it from being garbage collected. Temporary fix!
+    var jingleSessionTmp: JingleSession? = null
+
     /**
      * The layer which keeps track of which sources have been signaled to this participant.
      */


### PR DESCRIPTION
JingleSessions register with JingleIqHandler which saves a weak
reference and there are no other references to the object until
the session is accepted and saved as Participant.jingleSession. If
the weak reference expires before session-accept is received the
session fails to establish.

This is a quick and dirty fix, a proper solution will follow later.
