### PR TITLE
feat: cname is needed for better A/V synchronization

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
@@ -33,6 +33,8 @@ data class Source(
     val name: String? = null,
     /** Optional msid */
     val msid: String? = null,
+    /** Optional cname */
+    val cname: String? = null,
     /** Optional video type (camera or desktop) */
     val videoType: VideoType? = null
 ) {
@@ -43,6 +45,8 @@ data class Source(
         sourcePacketExtension.name,
         sourcePacketExtension.getChildExtensionsOfType(ParameterPacketExtension::class.java)
             .filter { it.name == "msid" }.map { it.value }.firstOrNull(),
+        sourcePacketExtension.getChildExtensionsOfType(ParameterPacketExtension::class.java)
+            .filter { it.name == "cname" }.map { it.value }.firstOrNull(),
         if (sourcePacketExtension.videoType == null) null else VideoType.parseString(sourcePacketExtension.videoType)
     )
 
@@ -61,6 +65,10 @@ data class Source(
 
         if (encodeMsid && msid != null) {
             addChildExtension(ParameterPacketExtension("msid", msid))
+        }
+
+        if (cname != null) {
+            addChildExtension(ParameterPacketExtension("cname", cname))
         }
 
         this@Source.videoType?.let {
@@ -82,6 +90,9 @@ data class Source(
             msid?.let {
                 append(""","m":"$it"""")
             }
+            cname?.let {
+                append(""","c":"$it"""")
+            }
             if (videoType == VideoType.Desktop) {
                 append(""","v":"d"""")
             }
@@ -95,6 +106,7 @@ data class Source(
         put("media_type", mediaType.toString())
         put("name", name ?: "null")
         put("msid", msid ?: "null")
+        put("cname", cname ?: "null")
         put("videoType", videoType.toString())
     }
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
@@ -47,7 +47,8 @@ fun ConferenceModifiedIQ.parseSources(): ConferenceSourceMap {
     sources?.mediaSources?.forEach { mediaSource ->
         mediaSource.sources.forEach { sourcePacketExtension ->
             val msid = "mixedmslabel mixedlabel${mediaSource.type}0"
-            val source = Source(sourcePacketExtension.ssrc, mediaSource.type, sourcePacketExtension.name, msid)
+            val cname = "mixed"
+            val source = Source(sourcePacketExtension.ssrc, mediaSource.type, sourcePacketExtension.name, msid, cname)
             parsedSources.add(SSRC_OWNER_JVB, EndpointSourceSet(source))
         }
         mediaSource.ssrcGroups.forEach {

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/ValidatingConferenceSourceMapTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/ValidatingConferenceSourceMapTest.kt
@@ -46,13 +46,14 @@ class ValidatingConferenceSourceMapTest : ShouldSpec() {
         val jid1 = "jid1"
         val jid2 = "jid2"
         val msid = "msid"
+        val cname = "cname"
 
-        val s1 = Source(1, VIDEO, msid = msid)
-        val s2 = Source(2, VIDEO, msid = msid)
-        val s3 = Source(3, VIDEO, msid = msid)
-        val s4 = Source(4, VIDEO, msid = msid)
-        val s5 = Source(5, VIDEO, msid = msid)
-        val s6 = Source(6, VIDEO, msid = msid)
+        val s1 = Source(1, VIDEO, msid = msid, cname = cname)
+        val s2 = Source(2, VIDEO, msid = msid, cname = cname)
+        val s3 = Source(3, VIDEO, msid = msid, cname = cname)
+        val s4 = Source(4, VIDEO, msid = msid, cname = cname)
+        val s5 = Source(5, VIDEO, msid = msid, cname = cname)
+        val s6 = Source(6, VIDEO, msid = msid, cname = cname)
         val s7 = Source(7, AUDIO)
         val videoSources = setOf(s1, s2, s3, s4, s5, s6)
         val sources = setOf(s1, s2, s3, s4, s5, s6, s7)
@@ -91,8 +92,8 @@ class ValidatingConferenceSourceMapTest : ShouldSpec() {
                 context("Adding a second endpoint") {
                     val sourceSet2 = EndpointSourceSet(
                         setOf(
-                            Source(101, VIDEO, msid = "msid2"),
-                            Source(102, VIDEO, msid = "msid2"),
+                            Source(101, VIDEO, msid = "msid2", cname = cname),
+                            Source(102, VIDEO, msid = "msid2", cname = cname),
                             Source(103, AUDIO)
                         ),
                         setOf(SsrcGroup(SsrcGroupSemantics.Fid, listOf(101, 102)))
@@ -192,9 +193,9 @@ class ValidatingConferenceSourceMapTest : ShouldSpec() {
             }
             context("SSRC group with missing MSID") {
                 val sources = setOf(
-                    Source(1, VIDEO, msid = null),
-                    Source(2, VIDEO, msid = null),
-                    Source(3, VIDEO, msid = null)
+                    Source(1, VIDEO, msid = null, cname = cname),
+                    Source(2, VIDEO, msid = null, cname = cname),
+                    Source(3, VIDEO, msid = null, cname = cname)
                 )
                 val groups = setOf(SsrcGroup(SsrcGroupSemantics.Sim, listOf(1, 2, 3)))
                 shouldThrow<RequiredParameterMissingException> {
@@ -203,9 +204,9 @@ class ValidatingConferenceSourceMapTest : ShouldSpec() {
             }
             context("SSRC group with different MSID values") {
                 val sources = setOf(
-                    Source(1, VIDEO, msid = msid),
-                    Source(2, VIDEO, msid = msid),
-                    Source(3, VIDEO, msid = "differentMsid")
+                    Source(1, VIDEO, cname = cname, msid = msid),
+                    Source(2, VIDEO, cname = cname, msid = msid),
+                    Source(3, VIDEO, cname = cname, msid = "differentMsid")
                 )
                 val groups = setOf(SsrcGroup(SsrcGroupSemantics.Sim, listOf(1, 2, 3)))
 
@@ -219,7 +220,7 @@ class ValidatingConferenceSourceMapTest : ShouldSpec() {
                         jid1,
                         EndpointSourceSet(
                             // No source for ssrc 2
-                            setOf(Source(1, VIDEO, msid = "msid")),
+                            setOf(Source(1, VIDEO, msid = "msid", cname = cname)),
                             setOf(SsrcGroup(SsrcGroupSemantics.Fid, listOf(1, 2)))
                         )
                     )

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/source/SourceTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/source/SourceTest.kt
@@ -33,16 +33,18 @@ class SourceTest : ShouldSpec() {
                 name = "name-1"
                 videoType = "camera"
                 addChildExtension(ParameterPacketExtension("msid", "msid"))
+                addChildExtension(ParameterPacketExtension("cname", "cname"))
             }
 
             Source(MediaType.VIDEO, packetExtension) shouldBe
-                Source(1, MediaType.VIDEO, name = "name-1", msid = "msid", videoType = VideoType.Camera)
+                Source(1, MediaType.VIDEO, name = "name-1", msid = "msid", cname = "cname", videoType = VideoType.Camera)
         }
         context("To XML") {
             val msidValue = "msid-value"
+            val cnameValue = "cname-value"
             val nameValue = "source-name-value"
             val videoType = VideoType.Desktop
-            val source = Source(1, MediaType.VIDEO, name = nameValue, msid = msidValue, videoType = videoType)
+            val source = Source(1, MediaType.VIDEO, name = nameValue, msid = msidValue, cname = cnameValue, videoType = videoType)
             val owner = "abcdabcd"
             val extension = source.toPacketExtension(owner = owner)
 
@@ -51,15 +53,16 @@ class SourceTest : ShouldSpec() {
             extension.videoType shouldBe videoType.toString()
             val parameters = extension.getChildExtensionsOfType(ParameterPacketExtension::class.java)
             parameters.filter { it.name == "msid" && it.value == msidValue }.size shouldBe 1
+            parameters.filter { it.name == "cname" && it.value == cnameValue }.size shouldBe 1
 
             val ssrcInfo = extension.getFirstChildOfType(SSRCInfoPacketExtension::class.java)
             ssrcInfo shouldNotBe null
             ssrcInfo.owner.toString() shouldBe owner
         }
         context("Compact JSON") {
-            Source(1, MediaType.VIDEO, name = "test-name", msid = "msid").compactJson shouldBe
+            Source(1, MediaType.VIDEO, name = "test-name", msid = "msid", cname = "cname").compactJson shouldBe
                 """
-                {"s":1,"n":"test-name","m":"msid"}
+                {"s":1,"n":"test-name","m":"msid","c":"cname"}
                 """.trimIndent()
             Source(
                 1,


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-rtp-usage-00#section-4.9-2

https://datatracker.ietf.org/doc/html/rfc7022#section-4.1

Right now it is not possible to correlate the audio and video tracks of the remote participant from sdp