### PR TITLE
Send extmap-allow-mixed in Jingle and Colibri2, if configured.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecConfig.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecConfig.kt
@@ -159,6 +159,9 @@ class Config {
     @JvmField
     val framemarking: RtpExtensionConfig =
         RtpExtensionConfigWithLegacy("$LEGACY_BASE.ENABLE_FRAMEMARKING", "jicofo.codec.rtp-extensions.framemarking")
+    val extmapAllowMixed: Boolean by config {
+        "jicofo.codec.rtp-extensions.extmap-allow-mixed".from(JitsiConfig.newConfig)
+    }
 
     companion object {
         const val LEGACY_BASE = "org.jitsi.jicofo"

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -21,6 +21,7 @@ import org.jitsi.jicofo.bridge.Bridge
 import org.jitsi.jicofo.bridge.CascadeLink
 import org.jitsi.jicofo.bridge.CascadeNode
 import org.jitsi.jicofo.codec.CodecUtil
+import org.jitsi.jicofo.codec.Config
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
 import org.jitsi.utils.MediaType
@@ -37,6 +38,7 @@ import org.jitsi.xmpp.extensions.colibri2.Media
 import org.jitsi.xmpp.extensions.colibri2.Sctp
 import org.jitsi.xmpp.extensions.colibri2.Transport
 import org.jitsi.xmpp.extensions.jingle.DtlsFingerprintPacketExtension
+import org.jitsi.xmpp.extensions.jingle.ExtmapAllowMixedPacketExtension
 import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 import org.jivesoftware.smack.StanzaCollector
 import org.jivesoftware.smack.packet.IQ
@@ -456,6 +458,9 @@ class Colibri2Session(
                     setType(MediaType.AUDIO)
                     CodecUtil.createAudioPayloadTypeExtensions().forEach { addPayloadType(it) }
                     CodecUtil.createAudioRtpHdrExtExtensions().forEach { addRtpHdrExt(it) }
+                    if (Config.Companion.config.extmapAllowMixed) {
+                        setExtmapAllowMixed(ExtmapAllowMixedPacketExtension())
+                    }
                 }.build()
             )
             relay.addMedia(
@@ -463,6 +468,9 @@ class Colibri2Session(
                     setType(MediaType.VIDEO)
                     CodecUtil.createVideoPayloadTypeExtensions().forEach { addPayloadType(it) }
                     CodecUtil.createVideoRtpHdrExtExtensions().forEach { addRtpHdrExt(it) }
+                    if (Config.Companion.config.extmapAllowMixed) {
+                        setExtmapAllowMixed(ExtmapAllowMixedPacketExtension())
+                    }
                 }.build()
             )
 

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -186,6 +186,7 @@ jicofo {
         enabled = false
         id = 10
       }
+      extmap-allow-mixed = true
     }
   }
 

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -186,7 +186,7 @@ jicofo {
         enabled = false
         id = 10
       }
-      extmap-allow-mixed = true
+      extmap-allow-mixed = false
     }
   }
 

--- a/jicofo/src/main/java/org/jitsi/jicofo/codec/JingleOfferFactory.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/codec/JingleOfferFactory.java
@@ -136,6 +136,9 @@ public class JingleOfferFactory
 
         CodecUtil.Companion.createVideoPayloadTypeExtensions(options).forEach(rtpDesc::addPayloadType);
         CodecUtil.Companion.createVideoRtpHdrExtExtensions(options).forEach(rtpDesc::addExtmap);
+        if (Config.config.getExtmapAllowMixed()) {
+            rtpDesc.setExtmapAllowMixed(new ExtmapAllowMixedPacketExtension());
+        }
 
         content.addChildExtension(rtpDesc);
     }
@@ -152,6 +155,9 @@ public class JingleOfferFactory
 
         CodecUtil.Companion.createAudioRtpHdrExtExtensions(options).forEach(rtpDesc::addExtmap);
         CodecUtil.Companion.createAudioPayloadTypeExtensions(options).forEach(rtpDesc::addPayloadType);
+        if (Config.config.getExtmapAllowMixed()) {
+            rtpDesc.setExtmapAllowMixed(new ExtmapAllowMixedPacketExtension());
+        }
 
         // a=maxptime:60
         rtpDesc.setAttribute("maxptime", "60");

--- a/jicofo/src/main/java/org/jitsi/jicofo/codec/JingleOfferFactory.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/codec/JingleOfferFactory.java
@@ -136,7 +136,8 @@ public class JingleOfferFactory
 
         CodecUtil.Companion.createVideoPayloadTypeExtensions(options).forEach(rtpDesc::addPayloadType);
         CodecUtil.Companion.createVideoRtpHdrExtExtensions(options).forEach(rtpDesc::addExtmap);
-        if (Config.config.getExtmapAllowMixed()) {
+        if (Config.config.getExtmapAllowMixed())
+        {
             rtpDesc.setExtmapAllowMixed(new ExtmapAllowMixedPacketExtension());
         }
 
@@ -155,7 +156,8 @@ public class JingleOfferFactory
 
         CodecUtil.Companion.createAudioRtpHdrExtExtensions(options).forEach(rtpDesc::addExtmap);
         CodecUtil.Companion.createAudioPayloadTypeExtensions(options).forEach(rtpDesc::addPayloadType);
-        if (Config.config.getExtmapAllowMixed()) {
+        if (Config.config.getExtmapAllowMixed())
+        {
             rtpDesc.setExtmapAllowMixed(new ExtmapAllowMixedPacketExtension());
         }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceUtil.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceUtil.kt
@@ -41,6 +41,7 @@ internal fun ContentPacketExtension.toMedia(): Media? {
         it.extmapList.forEach { rtpHdrExtPacketExtension ->
             media.addRtpHdrExt(rtpHdrExtPacketExtension)
         }
+        it.extmapAllowMixed?.let { allowMixed -> media.setExtmapAllowMixed(allowMixed) }
     }
     return media.build()
 }

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-64-gf221325</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-62-g911b404</version>
+        <version>1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Depends on https://github.com/jitsi/jitsi-xmpp-extensions/pull/90.