### PR TITLE
feat: Return ready=false when the MUC is not joined (regardless of whether authentication is enabled).

### DIFF
--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -93,12 +93,7 @@ class ConferenceIqHandler(
             logger.error("No XmppConnectionConfig for vnode=$vnode")
         }
 
-        var ready: Boolean = focusManager.conferenceRequest(room, query.propertiesMap)
-        if (!isFocusAnonymous && authAuthority == null) {
-            // Focus is authenticated system admin, so we let them in immediately. Focus will get OWNER anyway.
-            ready = true
-        }
-        response.isReady = ready
+        response.isReady = focusManager.conferenceRequest(room, query.propertiesMap)
 
         // Authentication module enabled?
         if (authAuthority != null) {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -39,7 +39,6 @@ class ConferenceIqHandler(
     val xmppProvider: XmppProvider,
     val focusManager: FocusManager,
     val focusAuthJid: String,
-    val isFocusAnonymous: Boolean,
     val authAuthority: AuthenticationAuthority?,
     val jigasiEnabled: Boolean
 ) : XmppProvider.Listener, AbstractIqRequestHandler(

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
@@ -17,7 +17,6 @@
  */
 package org.jitsi.jicofo.xmpp
 
-import org.apache.commons.lang3.StringUtils
 import org.jitsi.jicofo.ConferenceStore
 import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.auth.AbstractAuthAuthority
@@ -99,7 +98,6 @@ class XmppServices(
         xmppProvider = clientConnection,
         focusManager = focusManager,
         focusAuthJid = XmppConfig.client.jid,
-        isFocusAnonymous = StringUtils.isBlank(XmppConfig.client.password),
         authAuthority = authenticationAuthority,
         jigasiEnabled = jigasiDetector != null
     ).apply {

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/ConferenceIqHandlerTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/ConferenceIqHandlerTest.kt
@@ -34,7 +34,6 @@ class ConferenceIqHandlerTest : ShouldSpec() {
             every { conferenceRequest(any(), any()) } returns true
         },
         focusAuthJid = "",
-        isFocusAnonymous = true,
         authAuthority = null,
         jigasiEnabled = false
     )

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/auth/ShibbolethAuthenticationAuthorityTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/auth/ShibbolethAuthenticationAuthorityTest.kt
@@ -55,7 +55,6 @@ class ShibbolethAuthenticationAuthorityTest : ShouldSpec() {
         xmppProvider = mockk(relaxed = true),
         focusManager = focusManager,
         focusAuthJid = "",
-        isFocusAnonymous = true,
         authAuthority = shibbolethAuth,
         jigasiEnabled = false
     )

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/auth/XMPPDomainAuthAuthorityTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/auth/XMPPDomainAuthAuthorityTest.kt
@@ -30,7 +30,6 @@ class XMPPDomainAuthAuthorityTest : ShouldSpec() {
         xmppProvider = mockk(relaxed = true),
         focusManager = focusManager,
         focusAuthJid = "",
-        isFocusAnonymous = true,
         authAuthority = authAuthority,
         jigasiEnabled = false
     )


### PR DESCRIPTION
- feat: Return ready=false when the MUC is not joined (regardless of whether authentication is enabled).
- ref: Remove isFocusAnonymous (unused now).
