### PR TITLE
ref(colibri2 session participant re-invite): re-invite user on unknown endpoint error

### DIFF
--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -308,7 +308,7 @@ class Colibri2Session(
                         // If colibri2 error extension is present then the message came from
                         // a jitsi-videobridge instance. Otherwise, it might come from another component
                         // (e.g. the XMPP server or MUC component).
-                        val reInvite = reason == UNKNOWN_ENDPOINT && endpointId != null
+                        val reInvite = reason == Colibri2Error.Reason.UNKNOWN_ENDPOINT && endpointId != null
                         if (reInvite) {
                             logger.warn(
                                 "Endpoint [$endpointId] is not found, session failed: ${it.toXML()}, " +

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -82,6 +82,9 @@ interface ColibriSessionManager {
             /** The list of participant IDs which were on the removed bridge. **/
             participantIds: List<String>
         )
+
+        /** Endpoint removed due to a failure e.g. unknown endpoint */
+        fun endpointRemoved(endpointId: String)
     }
 }
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -514,6 +514,16 @@ class ColibriV2SessionManager(
         }
     }
 
+    internal fun endpointFailed(endpointId: String) {
+        val participantInfo = participants[endpointId]
+        if (participantInfo != null) {
+            remove(participantInfo)
+            eventEmitter.fireEvent { endpointRemoved(participantInfo.id) }
+        } else {
+            logger.error("Cannot find endpointFailed by $endpointId.")
+        }
+    }
+
     override fun updateParticipant(
         participantId: String,
         transport: IceUdpTransportPacketExtension?,


### PR DESCRIPTION
Added functionality to re-invite participant when UNKNOWN_ENDPOINT Colibri2Error happened instead of recreating the whole bridge and re-invite all participants. It can happen when endpoint is expired on jvb but jicofo tries to send update about this endpoint and gets error back.
Added this change as part of https://github.com/jitsi/jicofo/issues/1047