### PR TITLE
Do not try to parse the "data" content as Media.

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
@@ -184,6 +184,11 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
         {
             Set<Media> medias = new HashSet<>();
             offer.getContents().forEach(content -> {
+                // Ignore the "data" content here (SCTP).
+                if (!"audio".equals(content.getName()) && !"video".equals(content.getName()))
+                {
+                    return;
+                }
                 Media media = ConferenceUtilKt.toMedia(content);
                 if (media != null)
                 {


### PR DESCRIPTION
With SCTP enabled we log "Failed to convert ContentPacketExtension to Media" at WARN when we create an offer.