### PR TITLE
Update metrics periodically, port more stats to metrics.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/metrics/GlobalMetrics.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/metrics/GlobalMetrics.kt
@@ -1,0 +1,35 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2023 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.metrics
+
+import java.lang.management.ManagementFactory
+import org.jitsi.jicofo.metrics.JicofoMetricsContainer.Companion.instance as metricsContainer
+
+class GlobalMetrics {
+    companion object {
+        @JvmField
+        val threadsMetrics = metricsContainer.registerLongGauge(
+            "threads",
+            "The current number of JVM threads"
+        )
+
+        fun update() {
+            threadsMetrics.set(ManagementFactory.getThreadMXBean().threadCount.toLong())
+        }
+    }
+}

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -311,6 +311,12 @@ jicofo {
   // The region in which the machine is running.
   #local-region="us-east-1"
 
+  // Controls the metrics accessible at /metrics (but not /stats).
+  metrics {
+    // A subset of the metrics are re-calculated and updated periodically. This controls how often.
+    update-interval = 30 seconds
+  }
+
   octo {
     // Whether or not to use Octo. Note that when enabled, its use will be determined by
     // $jicofo.bridge.selection-strategy. There's a corresponding flag in the JVB and these

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/JicofoSelectorKotestProjectConfig.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/JicofoSelectorKotestProjectConfig.kt
@@ -28,5 +28,6 @@ class JicofoSelectorKotestProjectConfig : AbstractProjectConfig() {
         MetaconfigSettings.cacheEnabled = false
 
         JicofoMetricsContainer.instance.checkForNameConflicts = false
+        JicofoMetricsContainer.instance.disablePeriodicUpdates = true
     }
 }

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -2078,6 +2078,7 @@ public class JitsiMeetConferenceImpl
         @Override
         public void bridgeRemoved(@NotNull Bridge bridge, @NotNull List<String> participantIds)
         {
+            ConferenceMetrics.bridgesRemoved.inc();
             logger.info("Bridge " + bridge + " was removed from the conference. Re-inviting its participants: "
                     + participantIds);
             reInviteParticipantsById(participantIds);

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
@@ -23,7 +23,6 @@ import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl
 import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.ConferenceListener
 import org.jitsi.jicofo.jibri.JibriSession
 import org.jitsi.jicofo.jibri.JibriStats
-import org.jitsi.jicofo.metrics.JicofoMetricsContainer.Companion.instance
 import org.jitsi.jicofo.xmpp.XmppProvider
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
@@ -40,6 +39,7 @@ import java.time.temporal.ChronoUnit
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.logging.Level
+import org.jitsi.jicofo.metrics.JicofoMetricsContainer.Companion.instance as metricsContainer
 
 /**
  * Manages the set of [JitsiMeetConference]s in this instance.
@@ -69,7 +69,7 @@ class FocusManager(
     private val conferences: MutableMap<EntityBareJid, JitsiMeetConferenceImpl> = ConcurrentHashMap()
 
     /** TODO: move to companion object */
-    private val conferenceCount = instance.registerLongGauge(
+    private val conferenceCount = metricsContainer.registerLongGauge(
         "conferences",
         "Running count of conferences (excluding internal conferences created for health checks)."
     )
@@ -84,7 +84,11 @@ class FocusManager(
     /** Holds the conferences that are currently pinned to a specific bridge version. */
     private val pinnedConferences: MutableMap<EntityBareJid, PinnedConference> = HashMap()
 
-    fun start() = expireThread.start()
+    fun start() {
+        expireThread.start()
+        metricsContainer.addUpdateTask { updateMetrics() }
+    }
+
     fun stop() = expireThread.stop()
 
     /**
@@ -247,8 +251,6 @@ class FocusManager(
     // so we'll merge stats from different "child" objects here.
     val stats: JSONObject
         get() {
-            updateMetrics()
-
             // We want to avoid exposing unnecessary hierarchy levels in the stats,
             // so we'll merge stats from different "child" objects here.
             val stats = JSONObject()

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
@@ -261,6 +261,7 @@ class FocusManager(
             stats["conferences"] = conferenceCount.get()
             val bridgeFailures = JSONObject()
             bridgeFailures["participants_moved"] = ConferenceMetrics.participantsMoved.get()
+            bridgeFailures["bridges_removed"] = ConferenceMetrics.bridgesRemoved.get()
             stats["bridge_failures"] = bridgeFailures
             val participantNotifications = JSONObject()
             participantNotifications["ice_failed"] = ConferenceMetrics.participantsIceFailed.get()

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -34,6 +34,7 @@ import org.jitsi.jicofo.health.HealthConfig
 import org.jitsi.jicofo.health.JicofoHealthChecker
 import org.jitsi.jicofo.jibri.JibriConfig
 import org.jitsi.jicofo.jibri.JibriDetector
+import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jicofo.rest.Application
 import org.jitsi.jicofo.rest.ConferenceRequest
 import org.jitsi.jicofo.rest.RestConfig
@@ -156,6 +157,7 @@ class JicofoServices {
             it.shutdown()
         }
         healthChecker?.shutdown()
+        JicofoMetricsContainer.instance.stop()
         jettyServer?.stop()
         jvbDoctor?.let {
             bridgeSelector.removeHandler(it)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -34,6 +34,7 @@ import org.jitsi.jicofo.health.HealthConfig
 import org.jitsi.jicofo.health.JicofoHealthChecker
 import org.jitsi.jicofo.jibri.JibriConfig
 import org.jitsi.jicofo.jibri.JibriDetector
+import org.jitsi.jicofo.metrics.GlobalMetrics
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jicofo.rest.Application
 import org.jitsi.jicofo.rest.ConferenceRequest
@@ -49,7 +50,6 @@ import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.json.simple.JSONObject
 import org.jxmpp.jid.impl.JidCreate
-import java.lang.management.ManagementFactory
 import org.jitsi.jicofo.auth.AuthConfig.Companion.config as authConfig
 
 /**
@@ -151,6 +151,11 @@ class JicofoServices {
         } else null
     }
 
+    init {
+        logger.info("Registering GlobalMetrics periodic updates.")
+        JicofoMetricsContainer.instance.addUpdateTask { GlobalMetrics.update() }
+    }
+
     fun shutdown() {
         authenticationAuthority?.let {
             focusManager.removeListener(it)
@@ -209,7 +214,7 @@ class JicofoServices {
         sipJibriDetector?.let { put("sip_jibri_detector", it.stats) }
         xmppServices.jigasiDetector?.let { put("jigasi_detector", it.stats) }
         put("jigasi", xmppServices.jigasiStats)
-        put("threads", ManagementFactory.getThreadMXBean().threadCount)
+        put("threads", GlobalMetrics.threadsMetrics.get())
         put("jingle", JingleStats.toJson())
         healthChecker?.let {
             val result = it.result

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceMetrics.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceMetrics.kt
@@ -55,6 +55,12 @@ class ConferenceMetrics {
         )
 
         @JvmField
+        val bridgesRemoved = metricsContainer.registerCounter(
+            "bridges_removed",
+            "Number of times a bridge was removed from a conference due to a failure"
+        )
+
+        @JvmField
         val participantsIceFailed = metricsContainer.registerCounter(
             "participants_ice_failed",
             "Number of participants that reported an ICE failure"

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/health/JicofoHealthChecker.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/health/JicofoHealthChecker.kt
@@ -20,6 +20,7 @@ import org.jitsi.health.HealthChecker
 import org.jitsi.health.Result
 import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.bridge.BridgeSelector
+import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jicofo.xmpp.XmppConfig
 import org.jitsi.jicofo.xmpp.XmppProvider
 import org.jitsi.utils.logging2.createLogger
@@ -82,6 +83,7 @@ class JicofoHealthChecker(
                 logger.error("Health check took too long: $duration ms")
                 totalSlowHealthChecks++
             }
+            healthyMetric.set(it.success)
         }
     }
 
@@ -171,6 +173,12 @@ class JicofoHealthChecker(
         } finally {
             xmppProvider.xmppConnection.removeSyncStanzaListener(listener)
         }
+    }
+
+    companion object {
+        val healthyMetric = JicofoMetricsContainer.instance.registerBooleanMetric(
+            "healthy", "Whether jicofo is healthy or not.", true
+        )
     }
 }
 


### PR DESCRIPTION
- feat: Update metrics periodically instead of when /stats is accessed.
- Move the threads stat to a metric.
- Add a "healthy" metrics.
- Convert BridgeSelector stats to metrics.
- Bring back bridges_removed, now as a metric.
- Port jibri counts to metrics.
