### PR TITLE
fix: Use a ConcurrentHashMap to avoid an exception.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -123,7 +123,7 @@ class ChatRoomImpl(
     override var mainRoom: String? = null
         private set
 
-    private val avModerationByMediaType = mutableMapOf<MediaType, AvModerationForMediaType>()
+    private val avModerationByMediaType = ConcurrentHashMap<MediaType, AvModerationForMediaType>()
 
     /** The emitter used to fire events. */
     private val eventEmitter: EventEmitter<ChatRoomListener> = SyncEventEmitter()


### PR DESCRIPTION
java.util.ConcurrentModificationException
    at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1135)
    at org.jitsi.jicofo.xmpp.muc.ChatRoomImpl.avModeration(ChatRoomImpl.kt:168)
    at org.jitsi.jicofo.xmpp.muc.ChatRoomImpl.isAvModerationEnabled(ChatRoomImpl.kt:169)
    at org.jitsi.jicofo.xmpp.AvModerationHandler.processStanza$lambda-5(AvModerationHandler.kt:86)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
