### PR TITLE
Visitor updates

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/Features.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/Features.kt
@@ -49,7 +49,8 @@ enum class Features(val value: String) {
     DTLS("urn:xmpp:jingle:apps:dtls:0"),
     RTCPMUX("urn:ietf:rfc:5761"),
     BUNDLE("urn:ietf:rfc:5888"),
-    RAYO("urn:xmpp:rayo:client:1");
+    RAYO("urn:xmpp:rayo:client:1"),
+    VISITORS_V1("http://jitsi.org/visitors-1");
 
     companion object {
         val defaultFeatures = setOf(AUDIO, VIDEO, SCTP)

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
@@ -46,6 +46,11 @@ interface ChatRoom {
     /** The size of [members], exposed separately for performance (avoid creating a new list just to get the count) */
     val memberCount: Int
 
+    /**
+     *  The number of [members] with role VISITOR. Exposed separately for performance (avoid creating a new list
+     *  just to get the count) */
+    val visitorCount: Int
+
     /** Whether this [ChatRoom] is a breakout room. */
     val isBreakoutRoom: Boolean
 

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -75,6 +75,7 @@ class ChatRoomImpl(
         get() = synchronized(membersMap) { return membersMap.values.toList() }
     override val memberCount
         get() = membersMap.size
+    override val visitorCount: Int = membersMap.count { it.value.role == MemberRole.VISITOR }
 
     /** Stores our last MUC presence packet for future update. */
     private var lastPresenceSent: PresenceBuilder? = null

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -75,7 +75,8 @@ class ChatRoomImpl(
         get() = synchronized(membersMap) { return membersMap.values.toList() }
     override val memberCount
         get() = membersMap.size
-    override val visitorCount: Int = membersMap.count { it.value.role == MemberRole.VISITOR }
+    override val visitorCount: Int
+        get() = membersMap.count { it.value.role == MemberRole.VISITOR }
 
     /** Stores our last MUC presence packet for future update. */
     private var lastPresenceSent: PresenceBuilder? = null

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -373,6 +373,16 @@ jicofo {
 
     # The minimum interval at which notification counts are updated
     notification-interval = 15 seconds
+
+    # The visitors process has two parts:
+    # 1. Endpoints are redirected to a vnode, and they join that separate MUC as visitors. They still don't receive
+    #      presence for the main participants and do not have Jingle sessions.
+    # 2. The visitors' and main MUCs are connected together (visitors now receive presence for participants), and
+    #      jicofo starts Jingle sessions with visitors (visitors now receive media for participants).
+    #
+    # With this option enabled the second part is started automatically as soon as any visitors join. Otherwise, jicofo
+    # waits to receive a <broadcast enabled=true> extension from one of the moderators in the conference.
+    auto-enable-broadcast = true
   }
 
   xmpp {

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
@@ -38,10 +38,13 @@ import java.util.*;
 public interface JitsiMeetConference extends XmppProvider.Listener
 {
     /**
-     * Checks how many {@link Participant}s are in the conference.
-     * @return an integer greater than 0.
+     * Checks how many {@link Participant}s are in the conference. This includes visitors.
+     * @return an integer equal to or greater than 0.
      */
     int getParticipantCount();
+
+    /** Return the number of visitors in the conference */
+    int getVisitorCount();
 
     /**
      * Find {@link Participant} for given MUC JID.

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
@@ -44,7 +44,7 @@ public interface JitsiMeetConference extends XmppProvider.Listener
     int getParticipantCount();
 
     /** Return the number of visitors in the conference */
-    int getVisitorCount();
+    long getVisitorCount();
 
     /**
      * Find {@link Participant} for given MUC JID.

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -43,7 +43,6 @@ import org.jitsi.jicofo.jibri.*;
 import org.jitsi.xmpp.extensions.visitors.*;
 import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.*;
-import org.jxmpp.jid.impl.*;
 
 import java.time.*;
 import java.util.*;
@@ -52,6 +51,7 @@ import java.util.concurrent.atomic.*;
 import java.util.logging.*;
 import java.util.stream.*;
 
+import static org.jitsi.jicofo.conference.ConferenceUtilKt.getVisitorMucJid;
 import static org.jitsi.jicofo.xmpp.IqProcessingResult.*;
 
 /**
@@ -1540,8 +1540,10 @@ public class JitsiMeetConferenceImpl
                 return null;
             }
 
-            EntityBareJid visitorMucJid
-                    = JidCreate.entityBareFrom(roomName.getLocalpart(), config.getConferenceService());
+            EntityBareJid visitorMucJid = getVisitorMucJid(
+                    roomName,
+                    jicofoServices.getXmppServices().getClientConnection(),
+                    xmppProvider);
 
             // Will call join after releasing the lock
             chatRoomToJoin = xmppProvider.findOrCreateRoom(visitorMucJid);

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1479,9 +1479,14 @@ public class JitsiMeetConferenceImpl
     }
 
     @Override
-    public int getVisitorCount()
+    public long getVisitorCount()
     {
-        return visitorChatRooms.values().stream().mapToInt(ChatRoom::getVisitorCount).sum();
+        synchronized (participantLock)
+        {
+            return participants.values().stream()
+                    .filter(p -> p.getChatMember().getRole() == MemberRole.VISITOR)
+                    .count();
+        }
     }
 
     /**

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1472,9 +1472,16 @@ public class JitsiMeetConferenceImpl
      * For example chat member which belongs to the focus never becomes
      * a participant.
      */
+    @Override
     public int getParticipantCount()
     {
         return participants.size();
+    }
+
+    @Override
+    public int getVisitorCount()
+    {
+        return visitorChatRooms.values().stream().mapToInt(ChatRoom::getVisitorCount).sum();
     }
 
     /**

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
@@ -68,9 +68,6 @@ class FocusManager(
      * [.conferencesSyncRoot] in `#getConferenceCount()` is safe.
      */
     private val conferences: MutableMap<EntityBareJid, JitsiMeetConferenceImpl> = ConcurrentHashMap()
-
-
-    /** TODO: move to companion object */
     private val conferencesCache: MutableList<JitsiMeetConference> = CopyOnWriteArrayList()
 
     /** The object used to synchronize access to [.conferences]. */

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
@@ -202,7 +202,7 @@ class FocusManager(
         var endpointPairs = 0
         val jibriSessions: MutableSet<JibriSession> = HashSet()
         var conferencesWithVisitors = 0
-        var visitors = 0
+        var visitors = 0L
 
         for (conference in getConferences()) {
             if (!conference.includeInStatistics()) {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceMetrics.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceMetrics.kt
@@ -81,7 +81,25 @@ class ConferenceMetrics {
         @JvmField
         val currentParticipants = metricsContainer.registerLongGauge(
             "participants_current",
-            "The current number of participants."
+            "The current number of participants. This includes visitors."
+        )
+
+        @JvmField
+        val currentVisitors = metricsContainer.registerLongGauge(
+            "visitors_current",
+            "The current number of visitors."
+        )
+
+        @JvmField
+        val conferenceCount = metricsContainer.registerLongGauge(
+            "conferences",
+            "Running count of conferences (excluding internal conferences created for health checks)."
+        )
+
+        @JvmField
+        val conferencesWithVisitors = metricsContainer.registerLongGauge(
+            "conferences_with_visitors",
+            "Running count of conferences which have at least 1 visitor."
         )
 
         /**

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceUtil.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceUtil.kt
@@ -78,7 +78,7 @@ internal fun selectVisitorNode(
 /**
  * Get the JID of the visitor MUC for a given [mainRoom]. Handles "tenants", i.e. the jitsi-meet URL
  * https://example.com/tenant/room would use a main room JID of room@conference.tenant.example.com and
- * a visitor MUC ID room@conference.tenant.meet.jitsi (where meet.jitsi is the xmpp-domain configured
+ * a visitor MUC ID room@conference.tenant.v1.meet.jitsi (where v1.meet.jitsi is the xmpp-domain configured
  * for the [visitorXmppProvider]).
  */
 internal fun getVisitorMucJid(

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceUtil.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceUtil.kt
@@ -64,13 +64,15 @@ internal fun selectVisitorNode(
     allNodes: List<XmppProvider>
 ): String? {
 
-    val min = existingNodes.minByOrNull { it.value.memberCount }
-    if (min != null && min.value.memberCount < VisitorsConfig.config.maxVisitorsPerNode) {
+    val min = existingNodes.minByOrNull { it.value.visitorCount }
+    if (min != null && min.value.visitorCount < VisitorsConfig.config.maxVisitorsPerNode) {
         return min.key
     }
 
-    val unusedNodes = allNodes.filterNot { existingNodes.keys.contains(it.config.name) }
-    return unusedNodes.firstOrNull { it.registered }?.config?.name ?: min?.key
+    return allNodes
+        .filterNot { existingNodes.keys.contains(it.config.name) }
+        .filter { it.registered }
+        .randomOrNull()?.config?.name
 }
 
 /**

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceUtil.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceUtil.kt
@@ -86,10 +86,10 @@ internal fun getVisitorMucJid(
     mainXmppProvider: XmppProvider,
     visitorXmppProvider: XmppProvider
 ): EntityBareJid {
-    val mainDomain = mainXmppProvider.config.xmppDomain?.toString() ?:
-        throw IllegalStateException("main domain not configured")
-    val visitorDomain = visitorXmppProvider.config.xmppDomain?.toString() ?:
-        throw IllegalStateException("visitor domain not configured for ${visitorXmppProvider.config.name}")
+    val mainDomain = mainXmppProvider.config.xmppDomain?.toString()
+        ?: throw IllegalStateException("main domain not configured")
+    val visitorDomain = visitorXmppProvider.config.xmppDomain?.toString()
+        ?: throw IllegalStateException("visitor domain not configured for ${visitorXmppProvider.config.name}")
 
     return JidCreate.entityBareFrom(mainRoom.toString().replace(mainDomain, visitorDomain))
 }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/visitors/VisitorsConfig.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/visitors/VisitorsConfig.kt
@@ -36,6 +36,10 @@ class VisitorsConfig private constructor() {
         "jicofo.visitors.notification-interval".from(newConfig)
     }
 
+    val autoEnableBroadcast: Boolean by config {
+        "jicofo.visitors.auto-enable-broadcast".from(newConfig)
+    }
+
     companion object {
         @JvmField
         val config = VisitorsConfig()

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -21,7 +21,6 @@ import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.auth.AuthenticationAuthority
 import org.jitsi.jicofo.auth.ErrorFactory
-import org.jitsi.jicofo.visitors.VisitorsConfig
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.jitsimeet.ConferenceIq
@@ -41,7 +40,8 @@ class ConferenceIqHandler(
     val focusManager: FocusManager,
     val focusAuthJid: String,
     val authAuthority: AuthenticationAuthority?,
-    val jigasiEnabled: Boolean
+    val jigasiEnabled: Boolean,
+    val visitorsManager: VisitorsManager
 ) : XmppProvider.Listener, AbstractIqRequestHandler(
     ConferenceIq.ELEMENT,
     ConferenceIq.NAMESPACE,
@@ -93,7 +93,7 @@ class ConferenceIqHandler(
         }
 
         val visitorRequested = query.properties.any { it.name == "visitor" && it.value == "true" }
-        val vnode = if (VisitorsConfig.config.enabled) conference?.redirectVisitor(visitorRequested) else null
+        val vnode = if (visitorsManager.enabled) conference?.redirectVisitor(visitorRequested) else null
         XmppConfig.visitors[vnode]?.jid?.let {
             response.vnode = vnode
             response.focusJid = it

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -92,8 +92,17 @@ class ConferenceIqHandler(
             return error
         }
 
+        val visitorSupported = query.properties.any { it.name == "visitors-version" }
         val visitorRequested = query.properties.any { it.name == "visitor" && it.value == "true" }
-        val vnode = if (visitorsManager.enabled) conference?.redirectVisitor(visitorRequested) else null
+        val vnode = if (visitorSupported && visitorsManager.enabled) {
+            conference?.redirectVisitor(visitorRequested)
+        } else {
+            null
+        }
+        if (visitorsManager.enabled && !visitorSupported) {
+            logger.info("Endpoint with no visitor support.")
+        }
+
         XmppConfig.visitors[vnode]?.jid?.let {
             response.vnode = vnode
             response.focusJid = it

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
@@ -1,0 +1,108 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2023-Present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.xmpp
+
+import org.jitsi.jicofo.ConferenceStore
+import org.jitsi.jicofo.TaskPools
+import org.jitsi.jicofo.visitors.VisitorsConfig
+import org.jitsi.utils.logging2.createLogger
+import org.jitsi.xmpp.extensions.visitors.VisitorsIq
+import org.jivesoftware.smack.StanzaListener
+import org.jivesoftware.smack.filter.StanzaFilter
+import org.jivesoftware.smack.packet.ExtensionElement
+import org.jivesoftware.smack.packet.IQ
+import org.jivesoftware.smack.packet.Stanza
+import org.jxmpp.jid.DomainBareJid
+import org.jxmpp.jid.EntityBareJid
+import org.jxmpp.jid.impl.JidCreate
+import java.lang.Exception
+
+/**
+ * Serve two purposes:
+ * 1. Communicates with a prosody "visitors" component (jicofo initiates communication).
+ * 2. Handle incoming [VisitorsIq]s from endpoints in a conference.
+ */
+class VisitorsManager(
+    val xmppProvider: XmppProvider,
+    val conferenceStore: ConferenceStore
+) : StanzaListener {
+    init {
+        xmppProvider.xmppConnection.addSyncStanzaListener(this, VisitorsIqFilter())
+    }
+
+    private val logger = createLogger().apply {
+        addContext("connection", xmppProvider.config.name)
+    }
+
+    var address: DomainBareJid? = null
+
+    private fun updateAddress(components: Set<XmppProvider.Component>) {
+        address = components.find { it.type == "visitors" }?.address?.let { JidCreate.domainBareFrom(it) }
+        logger.info("VisitorsComponentManager is now ${if (enabled) "en" else "dis"}abled with address $address")
+    }
+
+    fun sendIqToComponent(roomJid: EntityBareJid, extensions: List<ExtensionElement>) {
+        val address = this.address ?: throw Exception("Component not available.")
+        val iq = VisitorsIq.Builder(xmppProvider.xmppConnection).apply {
+            to(address)
+            ofType(IQ.Type.get)
+            room = roomJid
+            addExtensions(extensions)
+        }.build()
+
+        TaskPools.ioPool.submit {
+            val response = xmppProvider.xmppConnection.sendIqAndGetResponse(iq)
+            when {
+                response == null -> logger.warn("Timeout waiting for VisitorsIq response.")
+                response.type == IQ.Type.result -> logger.info("Received VisitorsIq response: ${response.toXML()}")
+                else -> logger.warn("Received error response: ${response.toXML()}")
+            }
+        }
+    }
+
+    init {
+        updateAddress(xmppProvider.components)
+        xmppProvider.addListener(
+            object : XmppProvider.Listener {
+                override fun componentsChanged(components: Set<XmppProvider.Component>) {
+                    updateAddress(components)
+                }
+            }
+        )
+    }
+    val enabled
+        get() = VisitorsConfig.config.enabled && address != null
+
+    override fun processStanza(stanza: Stanza) {
+        if (stanza !is VisitorsIq) {
+            logger.error("Received unexpected stanza type received: ${stanza.javaClass.name}")
+            return
+        }
+
+        conferenceStore.getConference(stanza.room) ?: run {
+            logger.warn("Ignoring VisitorsIq for unknown conference ${stanza.room}.")
+            return
+        }
+        logger.info("Received VisitorsIq: ${stanza.toXML()}")
+        // TODO pass to the conference
+    }
+}
+
+class VisitorsIqFilter : StanzaFilter {
+    override fun accept(stanza: Stanza) = stanza is VisitorsIq
+}

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
@@ -66,7 +66,6 @@ class VisitorsManager(
         }.build()
 
         TaskPools.ioPool.submit {
-            logger.warn("XXX sending ${iq.toXML()}")
             val response = xmppProvider.xmppConnection.sendIqAndGetResponse(iq)
             when {
                 response == null -> logger.warn("Timeout waiting for VisitorsIq response.")

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
@@ -66,6 +66,7 @@ class VisitorsManager(
         }.build()
 
         TaskPools.ioPool.submit {
+            logger.warn("XXX sending ${iq.toXML()}")
             val response = xmppProvider.xmppConnection.sendIqAndGetResponse(iq)
             when {
                 response == null -> logger.warn("Timeout waiting for VisitorsIq response.")

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
@@ -93,13 +93,15 @@ class XmppServices(
     val jingleHandler = JingleIqRequestHandler(
         visitorConnections.map { it.xmppConnection }.toSet() + clientConnection.xmppConnection
     )
+    val visitorsManager = VisitorsManager(clientConnection, focusManager)
 
     val conferenceIqHandler = ConferenceIqHandler(
         xmppProvider = clientConnection,
         focusManager = focusManager,
         focusAuthJid = XmppConfig.client.jid,
         authAuthority = authenticationAuthority,
-        jigasiEnabled = jigasiDetector != null
+        jigasiEnabled = jigasiDetector != null,
+        visitorsManager
     ).apply {
         clientConnection.xmppConnection.registerIQRequestHandler(this)
     }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/ConferenceIqHandlerTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/ConferenceIqHandlerTest.kt
@@ -35,7 +35,8 @@ class ConferenceIqHandlerTest : ShouldSpec() {
         },
         focusAuthJid = "",
         authAuthority = null,
-        jigasiEnabled = false
+        jigasiEnabled = false,
+        visitorsManager = mockk(relaxed = true)
     )
 
     init {

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/auth/ShibbolethAuthenticationAuthorityTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/auth/ShibbolethAuthenticationAuthorityTest.kt
@@ -56,7 +56,8 @@ class ShibbolethAuthenticationAuthorityTest : ShouldSpec() {
         focusManager = focusManager,
         focusAuthJid = "",
         authAuthority = shibbolethAuth,
-        jigasiEnabled = false
+        jigasiEnabled = false,
+        visitorsManager = mockk(relaxed = true)
     )
 
     override fun isolationMode(): IsolationMode = IsolationMode.SingleInstance

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/auth/XMPPDomainAuthAuthorityTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/auth/XMPPDomainAuthAuthorityTest.kt
@@ -31,7 +31,8 @@ class XMPPDomainAuthAuthorityTest : ShouldSpec() {
         focusManager = focusManager,
         focusAuthJid = "",
         authAuthority = authAuthority,
-        jigasiEnabled = false
+        jigasiEnabled = false,
+        visitorsManager = mockk(relaxed = true)
     )
 
     override fun isolationMode(): IsolationMode = IsolationMode.SingleInstance


### PR DESCRIPTION
- Send connect-vnode and disconnect-vnode to the visitors component.
- Check for visitors-version in conference-request.
- tmp
- fix: Fix generating visitor MUC JID when the room uses a tenant.
- fix: Fix counting visitors, randomize vnode selection.
- Add a Feature for visitors.
- Add metrics for visitors.
- Fix lint errors.
- squash: Fix visitor count.
- squash: Remove extra log.
- Fix visitor count.
