### PR TITLE
Recognize and exclude transcriber/jibri from participant count for visitor redirection

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMember.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMember.kt
@@ -54,6 +54,7 @@ interface ChatRoomMember {
 
     val isRobot: Boolean
     val isJigasi: Boolean
+    val isTranscriber: Boolean
     val isJibri: Boolean
     val isAudioMuted: Boolean
     val isVideoMuted: Boolean

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -29,6 +29,7 @@ import org.jitsi.xmpp.extensions.jitsimeet.FeaturesExtension
 import org.jitsi.xmpp.extensions.jitsimeet.JitsiParticipantRegionPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.StartMutedPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.StatsId
+import org.jitsi.xmpp.extensions.jitsimeet.TranscriptionStatusExtension
 import org.jitsi.xmpp.extensions.jitsimeet.UserInfoPacketExt
 import org.jitsi.xmpp.extensions.jitsimeet.VideoMutedExtension
 import org.jivesoftware.smack.packet.Presence
@@ -59,6 +60,8 @@ class ChatRoomMemberImpl(
     override var presence: Presence? = null
         private set
     override var isJigasi = false
+        private set
+    override var isTranscriber = false
         private set
     override var isJibri = false
         private set
@@ -155,6 +158,8 @@ class ChatRoomMemberImpl(
             isJigasi = false
             isJibri = false
         }
+
+        isTranscriber = isJigasi && presence.getExtension(TranscriptionStatusExtension::class.java) != null
 
         presence.getExtension(JitsiParticipantRegionPacketExtension::class.java)?.let {
             region = it.regionId

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1502,12 +1502,29 @@ public class JitsiMeetConferenceImpl
             return null;
         }
 
-        if (!visitorRequested && getParticipantCount() < VisitorsConfig.config.getMaxParticipants())
+        long participantCount = getUserParticipantCount();
+
+        if (!visitorRequested && participantCount < VisitorsConfig.config.getMaxParticipants())
         {
             return null;
         }
 
         return selectVisitorNode();
+    }
+
+    /**
+     * Get the number of participants for the purpose of visitor node selection. Exclude participants for jibri and
+     * transcribers, because they shouldn't count towards the max participant limit.
+     */
+    private long getUserParticipantCount()
+    {
+        synchronized (participantLock)
+        {
+            return participants.values().stream().filter(
+                    p -> !p.getChatMember().isJigasi()
+                            && !p.getChatMember().isTranscriber()
+                            && p.getChatMember().getRole() != MemberRole.VISITOR).count();
+        }
     }
 
     /**

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/Smack.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/Smack.kt
@@ -151,6 +151,11 @@ fun registerXmppExtensions() {
     MuteIqProvider.registerMuteIqProvider()
     MuteVideoIqProvider.registerMuteVideoIqProvider()
     StartMutedProvider.registerStartMutedProvider()
+    ProviderManager.addExtensionProvider(
+        TranscriptionStatusExtension.ELEMENT,
+        TranscriptionStatusExtension.NAMESPACE,
+        DefaultPacketExtensionProvider(TranscriptionStatusExtension::class.java)
+    )
 
     ProviderManager.addExtensionProvider(
         AudioMutedExtension.ELEMENT,

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
@@ -138,6 +138,7 @@ class JibriChatRoomMember(
     override val sourceInfos: Set<SourceInfo> get() = TODO("Not yet implemented")
     override val isRobot: Boolean get() = TODO("Not yet implemented")
     override val isJigasi: Boolean get() = TODO("Not yet implemented")
+    override val isTranscriber: Boolean get() = TODO("Not yet implemented")
     override val isJibri: Boolean get() = TODO("Not yet implemented")
     override val isAudioMuted: Boolean get() = TODO("Not yet implemented")
     override val isVideoMuted: Boolean get() = TODO("Not yet implemented")


### PR DESCRIPTION
- Recognize chat room members as jigasi transcribers.
- Exclude jibri and transcribers from participant count for visitor redirection.
