### PR TITLE
fix: Temporary fix for counting visitors.

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -882,11 +882,11 @@ public class JitsiMeetConferenceImpl
             {
                 expireBridgeSessions();
             }
-        }
 
-        if (chatRoomMember.getRole() == MemberRole.VISITOR)
-        {
-            visitorRemoved();
+            int newVisitorCount = (int) participants.values().stream()
+                    .filter(p -> p.getChatMember().getRole() == MemberRole.VISITOR)
+                    .count();
+            visitorCount.setValue(newVisitorCount);
         }
 
         if (chatRoom == null || chatRoom.getMemberCount() == 0)
@@ -1789,12 +1789,6 @@ public class JitsiMeetConferenceImpl
     private void visitorAdded()
     {
         visitorCount.adjustValue(+1);
-    }
-
-    /** Called when a new visitor has been added to the conference. */
-    private void visitorRemoved()
-    {
-        visitorCount.adjustValue(-1);
     }
 
     /**


### PR DESCRIPTION
When a non-visitor leaves, the MUC occupant is removed, leading to
getRole() falsely returning VISITOR, and visitorRemoved() being run.
