### PR TITLE
Remove iSAC from the offer.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecConfig.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecConfig.kt
@@ -124,10 +124,6 @@ class Config {
     val h264: RtxCodecConfig = RtxCodecConfigWithLegacy(LEGACY_BASE, "jicofo.codec.video.h264", "H264")
 
     @JvmField
-    val isac16 = CodecConfig("jicofo.codec.audio.isac-16000", "isac-16000")
-    @JvmField
-    val isac32 = CodecConfig("jicofo.codec.audio.isac-32000", "isac-32000")
-    @JvmField
     val opus = OpusConfig()
     @JvmField
     val telephoneEvent = CodecConfig("jicofo.codec.audio.telephone-event", "telephone-event")

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
@@ -170,14 +170,6 @@ class CodecUtil {
                     opus.addRtcpFeedbackType(createRtcpFbPacketExtension("transport-cc", null))
                 }
             }
-            if (config.isac16.enabled()) {
-                // a=rtpmap:103 ISAC/16000
-                add(createPayloadTypeExtension(config.isac16.pt(), "ISAC", 16000))
-            }
-            if (config.isac32.enabled()) {
-                // a=rtpmap:104 ISAC/32000
-                add(createPayloadTypeExtension(config.isac32.pt(), "ISAC", 32000))
-            }
             if (config.telephoneEvent.enabled()) {
                 // rtpmap:126 telephone-event/8000
                 add(createPayloadTypeExtension(config.telephoneEvent.pt(), "telephone-event", 8000))

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -121,14 +121,6 @@ jicofo {
     }
 
     audio {
-      isac-16000 {
-        enabled = true
-        pt = 103
-      }
-      isac-32000 {
-        enabled = true
-        pt = 104
-      }
       opus {
         enabled = true
         pt = 111

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/CodecConfigTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/CodecConfigTest.kt
@@ -49,12 +49,6 @@ class CodecConfigTest : ShouldSpec() {
             config.opus.red.enabled() shouldBe false
             shouldThrow<Throwable> { config.opus.red.pt() }
 
-            config.isac16.enabled() shouldBe true
-            config.isac16.pt() shouldBe 103
-
-            config.isac32.enabled() shouldBe true
-            config.isac32.pt() shouldBe 104
-
             config.framemarking.enabled shouldBe false
             config.framemarking.id shouldBe 9
 


### PR DESCRIPTION
It has never been used with jicofo/jitsi-meet as far as we know, and it was removed in Chrome 110 as pointed out here:
https://community.jitsi.org/t/remove-the-support-for-isac/122815/2
