### PR TITLE
Fix feature discovery blocking a smack thread.

### DIFF
--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/mock/MockChatRoom.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/mock/MockChatRoom.kt
@@ -34,6 +34,7 @@ class MockChatRoom(val xmppProvider: XmppProvider) {
         every { memberCount } answers { memberList.size }
         every { xmppProvider } returns this@MockChatRoom.xmppProvider
         every { debugState } returns OrderedJsonObject()
+        every { getChatMember(any()) } answers { memberList.find { it.occupantJid == arg(0) } }
     }
 
     fun addMember(id: String): ChatRoomMember {

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/mock/MockChatRoom.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/mock/MockChatRoom.kt
@@ -23,7 +23,9 @@ import org.jitsi.jicofo.xmpp.muc.ChatRoom
 import org.jitsi.jicofo.xmpp.muc.ChatRoomListener
 import org.jitsi.jicofo.xmpp.muc.ChatRoomMember
 import org.jitsi.utils.OrderedJsonObject
+import org.jivesoftware.smack.packet.ExtensionElement
 import java.lang.IllegalArgumentException
+import javax.xml.namespace.QName
 
 class MockChatRoom(val xmppProvider: XmppProvider) {
     val chatRoomListeners = mutableListOf<ChatRoomListener>()
@@ -42,8 +44,12 @@ class MockChatRoom(val xmppProvider: XmppProvider) {
             every { name } returns id
             every { chatRoom } returns this@MockChatRoom.chatRoom
             every { features } returns Features.defaultFeatures
-
             every { debugState } returns OrderedJsonObject()
+            every { presence } returns mockk {
+                every { getExtension(any<String>()) } returns null
+                every { getExtension(any<QName>()) } returns null
+                every { getExtension(any<Class<out ExtensionElement>>()) } returns null
+            }
         }
         memberList.add(member)
         chatRoomListeners.forEach { it.memberJoined(member) }


### PR DESCRIPTION
- fix: Run feature discovery in a separate thread.
- fix: Try to avoid sending unnecessary disco#info
