### PR TITLE
Do not use visitors when lobby enabled.

### DIFF
--- a/jicofo-common/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
+++ b/jicofo-common/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
@@ -171,7 +171,7 @@ public abstract class BaseBrewery<T extends ExtensionElement>
         {
             chatRoom = xmppProvider.createRoom(breweryJid);
             chatRoom.addListener(chatRoomListener);
-            chatRoom.join(null);
+            chatRoom.join();
 
             logger.info("Joined the room.");
         }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
@@ -70,13 +70,7 @@ interface ChatRoom {
 
     /** Joins this chat room with the preconfigured nickname. */
     @Throws(SmackException::class, XMPPException::class, InterruptedException::class)
-    fun join(
-        /**
-         *  Optional meetingId to set in the room after joining. When the value is null the meetingId is read from the
-         *  room and left unmodified.
-         */
-        meetingIdToSet: String? = null
-    )
+    fun join()
 
     /** Leave the chat room. */
     fun leave()

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
@@ -63,6 +63,9 @@ interface ChatRoom {
      */
     var meetingId: String?
 
+    /** Whether a lobby is enabled for the room. Read from the MUC config form. */
+    val lobbyEnabled: Boolean
+
     val debugState: OrderedJsonObject
 
     /** Returns the number of members that currently have their audio sources unmuted. */
@@ -131,4 +134,7 @@ interface ChatRoom {
 
     /** whether the current A/V moderation setting allow the member [jid] to unmute (for a specific [mediaType]). */
     fun isMemberAllowedToUnmute(jid: Jid, mediaType: MediaType): Boolean
+
+    /** Re-load the MUC configuration form, updating local state if relevant fields have changed. */
+    fun reloadConfiguration()
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
@@ -57,8 +57,11 @@ interface ChatRoom {
     /** The JID of the main room associated with this [ChatRoom], if this [ChatRoom] is a breakout room (else null) */
     val mainRoom: String?
 
-    /** Get the unique meeting ID associated by this room (set by the MUC service). */
-    val meetingId: String?
+    /**
+     * The unique meeting ID associated by this room. It is updated on join or when the MUC form is read if the
+     * corresponding field is present.
+     */
+    var meetingId: String?
 
     val debugState: OrderedJsonObject
 

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -115,7 +115,12 @@ class ChatRoomImpl(
 
     /** The value of the "meetingId" field from the MUC form, if present. */
     override var meetingId: String? = null
-        private set
+        set(value) {
+            if (value != null) {
+                logger.addContext("meeting_id", value)
+            }
+            field = value
+        }
 
     /** The value of the "isbreakout" field from the MUC form, if present. */
     override var isBreakoutRoom = false
@@ -238,9 +243,6 @@ class ChatRoomImpl(
         val meetingIdField = config.getField(MucConfigFields.MEETING_ID)
         if (meetingIdField != null) {
             meetingId = meetingIdField.firstValue
-            if (meetingId != null) {
-                logger.addContext("meeting_id", meetingId)
-            }
         }
 
         // Make the room non-anonymous, so that others can recognize focus JID

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
@@ -46,6 +46,9 @@ public interface JitsiMeetConference extends XmppProvider.Listener
     /** Return the number of visitors in the conference */
     long getVisitorCount();
 
+    /** Notify this conference that the configuration for the main MUC has changed. */
+    void mucConfigurationChanged();
+
     /**
      * Find {@link Participant} for given MUC JID.
      *

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -921,6 +921,16 @@ public class JitsiMeetConferenceImpl
         }
     }
 
+    @Override
+    public void mucConfigurationChanged()
+    {
+        ChatRoom chatRoom = this.chatRoom;
+        if (chatRoom != null)
+        {
+            chatRoom.reloadConfiguration();
+        }
+    }
+
     private void terminateParticipant(
             Participant participant,
             @NotNull Reason reason,
@@ -1536,6 +1546,13 @@ public class JitsiMeetConferenceImpl
         throws Exception
     {
         if (!VisitorsConfig.config.getEnabled())
+        {
+            return null;
+        }
+
+        // We don't support both visitors and a lobby. Once a lobby is enabled we don't use visitors anymore.
+        ChatRoom chatRoom = this.chatRoom;
+        if (chatRoom != null && chatRoom.getLobbyEnabled())
         {
             return null;
         }

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1614,7 +1614,15 @@ public class JitsiMeetConferenceImpl
 
             // Will call join after releasing the lock
             chatRoomToJoin = xmppProvider.findOrCreateRoom(visitorMucJid);
+
+            ChatRoom mainChatRoom = this.chatRoom;
+            String meetingId = mainChatRoom == null ? null : mainChatRoom.getMeetingId();
+            if (meetingId != null)
+            {
+                chatRoomToJoin.setMeetingId(meetingId);
+            }
             chatRoomToJoin.addListener(new VisitorChatRoomListenerImpl(chatRoomToJoin));
+
             visitorChatRooms.put(node, chatRoomToJoin);
         }
 

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -479,7 +479,7 @@ public class JitsiMeetConferenceImpl
             jicofoServices.getXmppServices().getJigasiDetector(),
             logger);
 
-        chatRoom.join(null);
+        chatRoom.join();
         String meetingId = chatRoom.getMeetingId();
         if (meetingId != null)
         {
@@ -1618,8 +1618,7 @@ public class JitsiMeetConferenceImpl
             visitorChatRooms.put(node, chatRoomToJoin);
         }
 
-        // Set the meetingId of the visitor room to the meetingId of the main room.
-        chatRoomToJoin.join(chatRoom.getMeetingId());
+        chatRoomToJoin.join();
         Collection<ExtensionElement> presenceExtensions = new ArrayList<>();
 
         ComponentVersionsExtension versionsExtension = new ComponentVersionsExtension();

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConfigurationChangeHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConfigurationChangeHandler.kt
@@ -1,0 +1,67 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2021-Present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.xmpp
+
+import org.jitsi.jicofo.ConferenceStore
+import org.jitsi.jicofo.TaskPools
+import org.jitsi.utils.logging2.createLogger
+import org.jivesoftware.smack.StanzaListener
+import org.jivesoftware.smack.filter.MessageTypeFilter
+import org.jivesoftware.smack.packet.Message
+import org.jivesoftware.smack.packet.Stanza
+import org.jivesoftware.smackx.muc.packet.MUCUser
+import org.jxmpp.jid.EntityBareJid
+
+/**
+ * Handle MUC Notification of Configuration Changes messages.
+ * See https://xmpp.org/extensions/xep-0045.html#roomconfig-notify
+ */
+class ConfigurationChangeHandler(
+    private val xmppProvider: XmppProvider,
+    private val conferenceStore: ConferenceStore
+) : XmppProvider.Listener, StanzaListener {
+    private val logger = createLogger()
+
+    init {
+        xmppProvider.xmppConnection.addSyncStanzaListener(this, MessageTypeFilter.GROUPCHAT)
+    }
+
+    override fun processStanza(stanza: Stanza) {
+        if (stanza !is Message) {
+            logger.error("Not a message")
+            return
+        }
+
+        MUCUser.from(stanza)?.let { mucUser ->
+            // Code 104 is for MUC configuration form changes
+            if (mucUser.status?.any { it.code == 104 } == true) {
+                val roomJid = stanza.from
+                if (roomJid !is EntityBareJid) {
+                    logger.info("An occupant sending status 104?")
+                    return
+                }
+                logger.info("Configuration changed for $roomJid")
+                conferenceStore.getConference(roomJid)?.let { conference ->
+                    TaskPools.ioPool.submit { conference.mucConfigurationChanged() }
+                } ?: run {
+                    logger.info("Configuration changed for unknown conference.")
+                }
+            }
+        }
+    }
+}

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
@@ -92,6 +92,7 @@ class XmppServices(
         get() = jigasiIqHandler?.statsJson ?: OrderedJsonObject()
 
     val avModerationHandler = AvModerationHandler(clientConnection, conferenceStore)
+    val configurationChangeHandler = ConfigurationChangeHandler(clientConnection, conferenceStore)
     private val audioMuteHandler = AudioMuteIqHandler(setOf(clientConnection.xmppConnection), conferenceStore)
     private val videoMuteHandler = VideoMuteIqHandler(setOf(clientConnection.xmppConnection), conferenceStore)
     val jingleHandler = JingleIqRequestHandler(


### PR DESCRIPTION
- Revert "Set the meetingId for the visitors room to that of the main room. (#1072)"
- Set the meetingId of visitor ChatRooms locally.
- feat: Reload MUC config if changed, read lobbyEnabled, do not use visitors when lobby enabled.
