### PR TITLE
Avoid counting participants

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -90,8 +90,9 @@ class ChatRoomImpl(
         get() = synchronized(membersMap) { return membersMap.values.toList() }
     override val memberCount
         get() = membersMap.size
+    private var visitorMemberCount: Int = 0
     override val visitorCount: Int
-        get() = membersMap.count { it.value.role == MemberRole.VISITOR } +
+        get() = synchronized(membersMap) { visitorMemberCount } +
             pendingVisitorsCounter.getCount().toInt()
 
     /** Stores our last MUC presence packet for future update. */
@@ -401,6 +402,7 @@ class ChatRoomImpl(
             if (!newMember.isVideoMuted) videoSendersCount++
             if (newMember.role == MemberRole.VISITOR) {
                 pendingVisitorsCounter.eventOccurred()
+                visitorMemberCount++
             }
             return newMember
         }
@@ -552,6 +554,9 @@ class ChatRoomImpl(
                 } else {
                     if (!removed.isAudioMuted) audioSendersCount--
                     if (!removed.isVideoMuted) videoSendersCount--
+                    if (removed.role == MemberRole.VISITOR) {
+                        visitorMemberCount--
+                    }
                 }
                 return removed
             }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -211,8 +211,11 @@ class ChatRoomImpl(
     private fun resetState() {
         synchronized(membersMap) {
             if (membersMap.isNotEmpty()) {
-                logger.warn("Removing ${membersMap.size} stale members.")
+                logger.warn("Removing ${membersMap.size} stale members ($visitorMemberCount stale visitors).")
                 membersMap.clear()
+                visitorMemberCount = 0
+                audioSendersCount = 0
+                videoSendersCount = 0
             }
         }
         synchronized(this) {

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -77,12 +77,9 @@ class ChatRoomMemberImpl(
     /** The node#ver advertised in a Caps extension. */
     private var capsNodeVer: String? = null
 
-    override val role: MemberRole
-        get() {
-            return chatRoom.getOccupant(this)?.let {
-                fromSmack(it.role, it.affiliation)
-            } ?: MemberRole.VISITOR
-        }
+    override var role: MemberRole =
+        chatRoom.getOccupant(this)?.let { fromSmack(it.role, it.affiliation) } ?: MemberRole.VISITOR
+        private set
 
     /**
      * Caches user JID of the participant if we're able to see it.
@@ -157,6 +154,14 @@ class ChatRoomMemberImpl(
         } else {
             isJigasi = false
             isJibri = false
+        }
+
+        val oldRole = role
+        chatRoom.getOccupant(this)?.let { role = fromSmack(it.role, it.affiliation) }
+        if ((role == MemberRole.VISITOR) != (oldRole == MemberRole.VISITOR)) {
+            // This will mess up various member counts
+            // TODO: Should we try to update them, instead?
+            logger.warn("Member role changed from $oldRole to $role - not supported!")
         }
 
         isTranscriber = isJigasi && presence.getExtension(TranscriptionStatusExtension::class.java) != null

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -956,10 +956,6 @@ public class JitsiMeetConferenceImpl
             {
                 expireBridgeSessions();
             }
-
-            visitorCount.setValue(() -> (int) participants.values().stream()
-                .filter(p -> p.getChatMember().getRole() == MemberRole.VISITOR)
-                .count());
         }
 
         maybeStop();
@@ -1028,6 +1024,9 @@ public class JitsiMeetConferenceImpl
                     "Removed participant " + participant.getChatMember().getName() + " removed=" + (removed != null));
             if (removed != null && removed.isUserParticipant()) {
                 removeUserParticipant();
+            }
+            if (removed != null && removed.getChatMember().getRole() == MemberRole.VISITOR) {
+                visitorRemoved();
             }
         }
 
@@ -1975,6 +1974,12 @@ public class JitsiMeetConferenceImpl
     private void visitorAdded()
     {
         visitorCount.adjustValue(+1);
+    }
+
+    /** Called when a new visitor has been added to the conference. */
+    private void visitorRemoved()
+    {
+        visitorCount.adjustValue(-1);
     }
 
     /**

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -806,13 +806,16 @@ public class JitsiMeetConferenceImpl
             }
 
             boolean added = (participants.put(chatRoomMember.getOccupantJid(), participant) == null);
-            if (added && participant.isUserParticipant())
+            if (added)
             {
-                userParticipantAdded();
-            }
-            if (added && participant.getChatMember().getRole() == MemberRole.VISITOR)
-            {
-                visitorAdded();
+                if (participant.isUserParticipant())
+                {
+                    userParticipantAdded();
+                }
+                else if (participant.getChatMember().getRole() == MemberRole.VISITOR)
+                {
+                    visitorAdded();
+                }
             }
 
             inviteParticipant(participant, false, justJoined);
@@ -1023,13 +1026,16 @@ public class JitsiMeetConferenceImpl
             Participant removed = participants.remove(participant.getChatMember().getOccupantJid());
             logger.info(
                     "Removed participant " + participant.getChatMember().getName() + " removed=" + (removed != null));
-            if (!willReinvite && removed != null && removed.isUserParticipant())
+            if (!willReinvite && removed != null)
             {
-                userParticipantRemoved();
-            }
-            if (!willReinvite && removed != null && removed.getChatMember().getRole() == MemberRole.VISITOR)
-            {
-                visitorRemoved();
+                if (removed.isUserParticipant())
+                {
+                    userParticipantRemoved();
+                }
+                else if (removed.getChatMember().getRole() == MemberRole.VISITOR)
+                {
+                    visitorRemoved();
+                }
             }
         }
 

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -810,7 +810,8 @@ public class JitsiMeetConferenceImpl
             {
                 userParticipantAdded();
             }
-            if (added && participant.getChatMember().getRole() == MemberRole.VISITOR) {
+            if (added && participant.getChatMember().getRole() == MemberRole.VISITOR)
+            {
                 visitorAdded();
             }
 
@@ -1022,10 +1023,12 @@ public class JitsiMeetConferenceImpl
             Participant removed = participants.remove(participant.getChatMember().getOccupantJid());
             logger.info(
                     "Removed participant " + participant.getChatMember().getName() + " removed=" + (removed != null));
-            if (!willReinvite && removed != null && removed.isUserParticipant()) {
+            if (!willReinvite && removed != null && removed.isUserParticipant())
+            {
                 userParticipantRemoved();
             }
-            if (!willReinvite && removed != null && removed.getChatMember().getRole() == MemberRole.VISITOR) {
+            if (!willReinvite && removed != null && removed.getChatMember().getRole() == MemberRole.VISITOR)
+            {
                 visitorRemoved();
             }
         }
@@ -1690,15 +1693,20 @@ public class JitsiMeetConferenceImpl
 
     private long userParticipantCount = 0;
 
-    private void userParticipantAdded() {
-        synchronized (participantLock) {
+    private void userParticipantAdded()
+    {
+        synchronized (participantLock)
+        {
             userParticipantCount++;
         }
     }
 
-    private void userParticipantRemoved() {
-        synchronized(participantLock) {
-            if (userParticipantCount <= 0) {
+    private void userParticipantRemoved()
+    {
+        synchronized(participantLock)
+        {
+            if (userParticipantCount <= 0)
+            {
                 logger.error("userParticipantCount out of sync - trying to reduce when value is " +
                     userParticipantCount);
             }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -355,9 +355,10 @@ open class Participant @JvmOverloads constructor(
 
     /**
      * Whether force-muting should be suppressed for this participant (it is a trusted participant and doesn't
-     * support unmuting).
+     * support unmuting, or is a visitor and muting is redundant).
      */
-    fun shouldSuppressForceMute() = (chatMember.isJigasi && !hasAudioMuteSupport()) || chatMember.isJibri
+    fun shouldSuppressForceMute() = (chatMember.isJigasi && !hasAudioMuteSupport()) || chatMember.isJibri ||
+        chatMember.role == MemberRole.VISITOR
 
     /** Checks whether this [Participant]'s role has moderator rights. */
     fun hasModeratorRights() = chatMember.role.hasModeratorRights()

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -133,6 +133,13 @@ open class Participant @JvmOverloads constructor(
      */
     private var desktopSourceIsMuted = false
 
+    /**
+     * Whether this participant is a "user participant" for the purposes of
+     * [JitsiMeetConferenceImpl.getUserParticipantCount].
+     * Needs to be unchanging so counts don't get out of sync.
+     */
+    val isUserParticipant = !chatMember.isJibri && !chatMember.isTranscriber && chatMember.role != MemberRole.VISITOR
+
     init {
         updateDesktopSourceIsMuted(chatMember.sourceInfos)
     }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/ParticipantInviteRunnableTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/ParticipantInviteRunnableTest.kt
@@ -111,6 +111,8 @@ class ParticipantInviteRunnableTest : ShouldSpec({
                     every { sourceInfos } returns emptySet()
                     every { statsId } returns "statsId"
                     every { region } returns "region"
+                    every { isJibri } returns false
+                    every { isTranscriber } returns false
                 },
                 conference,
                 mockk(),


### PR DESCRIPTION
Iterating over participant lists causes quadratic behavior when adding large numbers of visitors to a conference.

Instead, keep counts of the relevant values in parallel with the maps.