### PR TITLE
feat: Skip redirecting to vnodes any trusted domains.

### DIFF
--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -94,7 +94,9 @@ class ConferenceIqHandler(
 
         val visitorSupported = query.properties.any { it.name == "visitors-version" }
         val visitorRequested = query.properties.any { it.name == "visitor" && it.value == "true" }
-        val vnode = if (visitorSupported && visitorsManager.enabled) {
+        val vnode = if (visitorSupported && visitorsManager.enabled &&
+            !XmppConfig.config.trustedDomains.contains(query.from.asDomainBareJid())
+        ) {
             conference?.redirectVisitor(visitorRequested)
         } else {
             null


### PR DESCRIPTION
Does not redirect jibri to the visitor nodes.