### PR TITLE
Revert "feat: Skip redirecting to vnodes any trusted domains."

### DIFF
--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -94,9 +94,7 @@ class ConferenceIqHandler(
 
         val visitorSupported = query.properties.any { it.name == "visitors-version" }
         val visitorRequested = query.properties.any { it.name == "visitor" && it.value == "true" }
-        val vnode = if (visitorSupported && visitorsManager.enabled &&
-            (query.from == null || !XmppConfig.config.trustedDomains.contains(query.from.asDomainBareJid()))
-        ) {
+        val vnode = if (visitorSupported && visitorsManager.enabled) {
             conference?.redirectVisitor(visitorRequested)
         } else {
             null


### PR DESCRIPTION
This reverts commit e05f8dab. Jibri now reports that visitors are not supported and this is not needed.