### PR TITLE
fix: Fix NPE when a conference request has no payload

### DIFF
--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/rest/ConferenceRequest.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/rest/ConferenceRequest.kt
@@ -44,8 +44,9 @@ class ConferenceRequest(
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    fun conferenceRequest(conferenceRequest: org.jitsi.jicofo.ConferenceRequest): String {
+    fun conferenceRequest(conferenceRequest: org.jitsi.jicofo.ConferenceRequest?): String {
         val response: IQ
+        if (conferenceRequest == null) throw BadRequestExceptionWithMessage("Missing body.")
         try {
             response = conferenceIqHandler.handleConferenceIq(conferenceRequest.toConferenceIq())
         } catch (e: XmppStringprepException) {


### PR DESCRIPTION
Jetty doesn't recognize that the kotlin param can't be null which
results in a NPE and response 500. Return 400 without polluting the logs
instead.
