### PR TITLE
Default extmap-allow-mixed to on.

### DIFF
--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -177,7 +177,7 @@ jicofo {
         enabled = false
         id = 10
       }
-      extmap-allow-mixed = false
+      extmap-allow-mixed = true
     }
   }
 


### PR DESCRIPTION
JVB has supported it for a while.