### PR TITLE
Fix the ID of the RID extension.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
@@ -258,7 +258,7 @@ class CodecUtil {
 
             if (config.rid.enabled()) {
                 val rtpStreamId = RTPHdrExtPacketExtension()
-                rtpStreamId.id = config.rid.enabled().toString()
+                rtpStreamId.id = config.rid.id.toString()
                 rtpStreamId.uri = URI.create("urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id")
                 add(rtpStreamId)
             }


### PR DESCRIPTION
Reported by @zhing https://community.jitsi.org/t/header-extension-parse-failed-in-jicofo/129619
