### PR TITLE
Update Java Debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,12 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>, Pawel Domas <pawel.domas@jitsi.org>
-Build-Depends: debhelper, java11-runtime-headless | java11-runtime, maven
+Build-Depends: debhelper, java11-sdk, maven
 Standards-Version: 3.9.3
 Homepage: https://jitsi.org/meet
 
 Package: jicofo
 Architecture: all
-Depends: ${misc:Depends}, openjdk-11-jre-headless | openjdk-11-jre | java11-runtime-headless | java11-runtime, ruby-hocon, jq
+Depends: ${misc:Depends}, java11-runtime-headless | java11-runtime, ruby-hocon, jq
 Description: JItsi Meet COnference FOcus
  Jicofo is a conference focus for Jitsi Meet application.


### PR DESCRIPTION
Allows for running with Java 17 without any additional install.