### PR TITLE
Monitor visitors' codec lists, and aggregate them into a conference property.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMember.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMember.kt
@@ -66,6 +66,9 @@ interface ChatRoomMember {
     /** The statistics id if any. */
     val statsId: String?
 
+    /** The supported video codecs if any */
+    val videoCodecs: List<String>?
+
     /**
      * The list of features advertised as XMPP capabilities. Note that although the features are cached (XEP-0115),
      * the first time [features] is accessed it may block waiting for a disco#info response!

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -27,6 +27,7 @@ import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.xmpp.extensions.jitsimeet.AudioMutedExtension
 import org.jitsi.xmpp.extensions.jitsimeet.FeaturesExtension
+import org.jitsi.xmpp.extensions.jitsimeet.JitsiParticipantCodecList
 import org.jitsi.xmpp.extensions.jitsimeet.JitsiParticipantRegionPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.StartMutedPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.StatsId
@@ -67,6 +68,8 @@ class ChatRoomMemberImpl(
     override var isJibri = false
         private set
     override var statsId: String? = null
+        private set
+    override var videoCodecs: List<String>? = null
         private set
     override var isAudioMuted = true
         private set
@@ -208,6 +211,18 @@ class ChatRoomMemberImpl(
 
         presence.getExtension(StatsId::class.java)?.let {
             statsId = it.statsId
+        }
+
+        presence.getExtension(JitsiParticipantCodecList::class.java)?.let {
+            if (videoCodecs != null && it.codecs != videoCodecs) {
+                logger.warn("Video codec list changed from {$videoCodecs} to {${it.codecs}} - not supported!")
+            }
+            if (!it.codecs.contains("vp8")) {
+                logger.warn("Video codec list {${it.codecs}} does not contain vp8! Adding manually.")
+                videoCodecs = it.codecs + "vp8"
+            } else {
+                videoCodecs = it.codecs
+            }
         }
     }
 

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -232,10 +232,11 @@ class ChatRoomMemberImpl(
         } ?: // Older clients sent a single codec in codecType rather than all supported ones in codecList
             presence.getExtensionElement("jitsi_participant_codecType", "jabber:client")?.let {
                 if (it is StandardExtensionElement) {
-                    val codecList = if (it.text == "vp8") {
-                        listOf(it.text)
+                    val codec = it.text.lowercase()
+                    val codecList = if (codec == "vp8") {
+                        listOf(codec)
                     } else {
-                        listOf(it.text, "vp8")
+                        listOf(codec, "vp8")
                     }
                     if (!firstPresence && codecList != videoCodecs) {
                         logger.warn("Video codec list changed from $videoCodecs to $codecList - not supported!")

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -221,7 +221,9 @@ class ChatRoomMemberImpl(
                 logger.warn("Video codec list changed from $videoCodecs to ${it.codecs} - not supported!")
             } else {
                 if (!it.codecs.contains("vp8")) {
-                    logger.warn("Video codec list {${it.codecs}} does not contain vp8! Adding manually.")
+                    if (firstPresence) {
+                        logger.warn("Video codec list {${it.codecs}} does not contain vp8! Adding manually.")
+                    }
                     videoCodecs = it.codecs + "vp8"
                 } else {
                     videoCodecs = it.codecs

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -37,6 +37,7 @@ import org.jitsi.xmpp.extensions.jitsimeet.VideoMutedExtension
 import org.jivesoftware.smack.packet.Presence
 import org.jivesoftware.smack.packet.StandardExtensionElement
 import org.jivesoftware.smackx.caps.packet.CapsExtension
+import org.json.simple.JSONArray
 import org.jxmpp.jid.EntityFullJid
 import org.jxmpp.jid.Jid
 
@@ -276,6 +277,7 @@ class ChatRoomMemberImpl(
             this["is_jibri"] = isJibri
             this["is_jigasi"] = isJigasi
             this["role"] = role.toString()
+            this["video_codecs"] = JSONArray().apply { videoCodecs?.let { addAll(it) } }
             this["stats_id"] = statsId.toString()
             this["is_audio_muted"] = isAudioMuted
             this["is_video_muted"] = isVideoMuted

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -223,7 +223,16 @@ class ChatRoomMemberImpl(
             } else {
                 videoCodecs = it.codecs
             }
-        }
+        } ?: // Older clients sent a single codec in codecType rather than all supported ones in codecList
+            presence.getExtensionElement("jitsi_participant_codecType", "jabber:client")?.let {
+                if (it is StandardExtensionElement) {
+                    videoCodecs = if (it.text == "vp8") {
+                        listOf(it.text)
+                    } else {
+                        listOf(it.text, "vp8")
+                    }
+                }
+            }
     }
 
     /**

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -2031,7 +2031,8 @@ public class JitsiMeetConferenceImpl
     private void visitorAdded(List<String> codecs)
     {
         visitorCount.adjustValue(+1);
-        if (codecs != null) {
+        if (codecs != null)
+        {
             visitorCodecs.addPreference(codecs);
         }
     }
@@ -2040,7 +2041,8 @@ public class JitsiMeetConferenceImpl
     private void visitorRemoved(List<String> codecs)
     {
         visitorCount.adjustValue(-1);
-        if (codecs != null) {
+        if (codecs != null)
+        {
             visitorCodecs.removePreference(codecs);
         }
     }

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -136,14 +136,7 @@ public class JitsiMeetConferenceImpl
     /**
      * The aggregated count of visitors' supported codecs
      */
-    private final PreferenceAggregator visitorCodecs = new PreferenceAggregator(
-        (codecs) -> {
-            setConferenceProperty(
-                ConferenceProperties.KEY_VISITOR_CODECS,
-                String.join(",", codecs)
-            );
-            return null;
-        });
+    private final PreferenceAggregator visitorCodecs;
 
     /**
      * The {@link JibriRecorder} instance used to provide live streaming through
@@ -301,6 +294,16 @@ public class JitsiMeetConferenceImpl
                 ConferenceConfig.config.getConferenceStartTimeout().toMillis(),
                 TimeUnit.MILLISECONDS);
 
+
+        visitorCodecs = new PreferenceAggregator(
+            logger,
+            (codecs) -> {
+                setConferenceProperty(
+                    ConferenceProperties.KEY_VISITOR_CODECS,
+                    String.join(",", codecs)
+                );
+                return null;
+            });
 
         logger.info("Created new conference.");
     }

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -134,6 +134,18 @@ public class JitsiMeetConferenceImpl
         });
 
     /**
+     * The aggregated count of visitors' supported codecs
+     */
+    private final PreferenceAggregator visitorCodecs = new PreferenceAggregator(
+        (codecs) -> {
+            setConferenceProperty(
+                ConferenceProperties.KEY_VISITOR_CODECS,
+                String.join(",", codecs)
+            );
+            return null;
+        });
+
+    /**
      * The {@link JibriRecorder} instance used to provide live streaming through
      * Jibri.
      */
@@ -816,7 +828,7 @@ public class JitsiMeetConferenceImpl
                 }
                 else if (participant.getChatMember().getRole() == MemberRole.VISITOR)
                 {
-                    visitorAdded();
+                    visitorAdded(participant.getChatMember().getVideoCodecs());
                 }
             }
 
@@ -1042,7 +1054,7 @@ public class JitsiMeetConferenceImpl
                 }
                 else if (removed.getChatMember().getRole() == MemberRole.VISITOR)
                 {
-                    visitorRemoved();
+                    visitorRemoved(removed.getChatMember().getVideoCodecs());
                 }
             }
         }
@@ -2013,15 +2025,21 @@ public class JitsiMeetConferenceImpl
     }
 
     /** Called when a new visitor has been added to the conference. */
-    private void visitorAdded()
+    private void visitorAdded(List<String> codecs)
     {
         visitorCount.adjustValue(+1);
+        if (codecs != null) {
+            visitorCodecs.addPreference(codecs);
+        }
     }
 
     /** Called when a new visitor has been added to the conference. */
-    private void visitorRemoved()
+    private void visitorRemoved(List<String> codecs)
     {
         visitorCount.adjustValue(-1);
+        if (codecs != null) {
+            visitorCodecs.removePreference(codecs);
+        }
     }
 
     /**

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1594,6 +1594,7 @@ public class JitsiMeetConferenceImpl
             }
         }
         o.put("visitor_count", visitorCount);
+        o.put("visitor_codecs", visitorCodecs.debugState());
         o.put("participant_count", participantCount);
         o.put("jibri_count", jibriCount);
         o.put("jigasi_count", jigasiCount);

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
@@ -22,7 +22,8 @@ package org.jitsi.jicofo.util
  *
  * The intended use case is maintaining the list of supported codecs for conference visitors.
  *
- * Preferences are aggregated using the Borda count; this isn't theoretically optimal, but it's computationally cheap.
+ * Preference orders are aggregated using the Borda count; this isn't theoretically optimal, but it should be
+ * good enough, and it's computationally cheap.
  */
 class PreferenceAggregator(
     private val onChanged: (List<String>) -> Unit

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
@@ -1,0 +1,114 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2015-Present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.util
+
+/** Aggregate lists of preferences coming from a large group of people, such that the resulting aggregated
+ * list consists of preference items supported by everyone, and in a rough consensus of preference order.
+ *
+ * The intended use case is maintaining the list of supported codecs for conference visitors.
+ *
+ * Preferences are aggregated using the Borda count; this isn't theoretically optimal, but it's computationally cheap.
+ */
+class PreferenceAggregator(
+    private val onChanged: (List<String>) -> Unit
+) {
+    private val lock = Any()
+
+    var aggregate: List<String> = emptyList()
+        private set
+
+    var count = 0
+        private set
+
+    private val values = mutableMapOf<String, ValueInfo>()
+
+    /**
+     * Add a preference to the aggregator.
+     */
+    fun addPreference(prefs: List<String>) {
+        synchronized(lock) {
+            count++
+            prefs.forEachIndexed { index, element ->
+                val info = values.computeIfAbsent(element) { ValueInfo() }
+                info.count++
+                info.rankAggregate += index
+            }
+            updateAggregate()
+        }
+    }
+
+    /**
+     * Remove a preference from the aggregator.
+     */
+    fun removePreference(prefs: List<String>) {
+        synchronized(lock) {
+            count--
+            check(count >= 0) {
+                "Preference count $count should not be negative"
+            }
+            prefs.forEachIndexed { index, element ->
+                val info = values[element]
+                check(info != null) {
+                    "Preference info for $element should exist when preferences are being removed"
+                }
+                info.count--
+                check(info.count >= 0) {
+                    "Preference count for $element ${info.count} should not be negative"
+                }
+                info.rankAggregate -= index
+                check(info.rankAggregate >= 0) {
+                    "Preference rank aggregate for $element ${info.rankAggregate} should not be negative"
+                }
+                if (info.count == 0) {
+                    check(info.rankAggregate == 0) {
+                        "Preference rank aggregate for $element ${info.rankAggregate} should be zero " +
+                            "when preference count is 0"
+                    }
+                    values.remove(element)
+                }
+            }
+            updateAggregate()
+        }
+    }
+
+    fun reset() {
+        synchronized(lock) {
+            aggregate = emptyList()
+            count = 0
+            values.clear()
+        }
+    }
+
+    private fun updateAggregate() {
+        val newAggregate = values.asSequence()
+            .filter { it.value.count == count }
+            .sortedBy { it.value.rankAggregate }
+            .map { it.key }
+            .toList()
+        if (aggregate != newAggregate) {
+            aggregate = newAggregate
+            /* ?? Do we need to drop the lock before calling this? */
+            onChanged(aggregate)
+        }
+    }
+
+    private class ValueInfo {
+        var count = 0
+        var rankAggregate = 0
+    }
+}

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
@@ -17,8 +17,10 @@
  */
 package org.jitsi.jicofo.util
 
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import org.json.simple.JSONArray
 
 /** Aggregate lists of preferences coming from a large group of people, such that the resulting aggregated
  * list consists of preference items supported by everyone, and in a rough consensus of preference order.
@@ -108,6 +110,21 @@ class PreferenceAggregator(
         }
     }
 
+    fun debugState() = OrderedJsonObject().apply {
+        synchronized(lock) {
+            put("count", count)
+            put(
+                "ranks",
+                OrderedJsonObject().apply {
+                    this@PreferenceAggregator.values.asSequence()
+                        .sortedBy { it.value.rankAggregate }
+                        .forEach { put(it.key, it.value.debugState()) }
+                }
+            )
+            put("aggregate", JSONArray().apply { addAll(aggregate) })
+        }
+    }
+
     private fun updateAggregate() {
         val newAggregate = values.asSequence()
             .filter { it.value.count == count }
@@ -124,5 +141,10 @@ class PreferenceAggregator(
     private class ValueInfo {
         var count = 0
         var rankAggregate = 0
+
+        fun debugState() = OrderedJsonObject().apply {
+            put("count", count)
+            put("rank_aggregate", rankAggregate)
+        }
     }
 }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/Smack.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/Smack.kt
@@ -36,6 +36,7 @@ import org.jitsi.xmpp.extensions.jitsimeet.ConferenceIqProvider
 import org.jitsi.xmpp.extensions.jitsimeet.FeatureExtension
 import org.jitsi.xmpp.extensions.jitsimeet.FeaturesExtension
 import org.jitsi.xmpp.extensions.jitsimeet.IceStatePacketExtension
+import org.jitsi.xmpp.extensions.jitsimeet.JitsiParticipantCodecList
 import org.jitsi.xmpp.extensions.jitsimeet.JitsiParticipantRegionPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.JsonMessageExtension
 import org.jitsi.xmpp.extensions.jitsimeet.LoginUrlIqProvider
@@ -118,6 +119,11 @@ fun registerXmppExtensions() {
         StatsId.ELEMENT,
         StatsId.NAMESPACE,
         StatsId.Provider()
+    )
+    ProviderManager.addExtensionProvider(
+        JitsiParticipantCodecList.ELEMENT,
+        JitsiParticipantCodecList.NAMESPACE,
+        DefaultPacketExtensionProvider(JitsiParticipantCodecList::class.java)
     )
 
     // Add the extensions used for handling the inviting of transcriber

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
@@ -144,7 +144,7 @@ class JibriChatRoomMember(
     override val isVideoMuted: Boolean get() = TODO("Not yet implemented")
     override val region: String? get() = TODO("Not yet implemented")
     override val statsId: String? get() = TODO("Not yet implemented")
-    override val videoCodecs: Set<String>? get() = TODO("Not yet implemented")
+    override val videoCodecs: List<String>? get() = TODO("Not yet implemented")
     override val features: Set<Features> get() = TODO("Not yet implemented")
     override val debugState: OrderedJsonObject get() = TODO("Not yet implemented")
 

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
@@ -144,6 +144,7 @@ class JibriChatRoomMember(
     override val isVideoMuted: Boolean get() = TODO("Not yet implemented")
     override val region: String? get() = TODO("Not yet implemented")
     override val statsId: String? get() = TODO("Not yet implemented")
+    override val videoCodecs: Set<String>? get() = TODO("Not yet implemented")
     override val features: Set<Features> get() = TODO("Not yet implemented")
     override val debugState: OrderedJsonObject get() = TODO("Not yet implemented")
 

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/util/PreferenceAggregatorTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/util/PreferenceAggregatorTest.kt
@@ -1,0 +1,94 @@
+package org.jitsi.jicofo.util
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+class PreferenceAggregatorTest : ShouldSpec() {
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    private val calledWith = mutableListOf<List<String>>()
+    private val aggregator = PreferenceAggregator {
+        calledWith.add(it)
+    }
+
+    init {
+        context("An aggregator with no values added") {
+            should("Not call its callback") {
+                calledWith shouldBe emptyList()
+            }
+        }
+        context("An aggregator called once") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            should("Call the callback exactly once with that set of values") {
+                calledWith shouldContainExactly listOf(listOf("vp9", "vp8", "h264"))
+            }
+        }
+        context("An aggregator called twice with the same values") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            should("Call the callback exactly once") {
+                calledWith shouldContainExactly listOf(listOf("vp9", "vp8", "h264"))
+            }
+        }
+        context("An aggregator with all preferences removed") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.removePreference(listOf("vp9", "vp8", "h264"))
+            should("Have its final output be the empty set") {
+                calledWith.last() shouldBe emptyList()
+            }
+        }
+        context("Aggregating preferences with disparate values (subset)") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.addPreference(listOf("vp8", "h264"))
+            should("Output the minimal agreed set") {
+                calledWith.last().shouldContainExactly("vp8", "h264")
+            }
+        }
+        context("Aggregating preferences with disparate values (non-subset)") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.addPreference(listOf("vp8", "h264"))
+            aggregator.addPreference(listOf("vp9", "vp8"))
+            should("Output the minimal agreed set") {
+                calledWith.last().shouldContainExactly("vp8")
+            }
+        }
+        context("Aggregating a new superset") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.addPreference(listOf("av1", "vp9", "vp8", "h264"))
+            should("Not call the callback a second time") {
+                calledWith shouldContainExactly listOf(listOf("vp9", "vp8", "h264"))
+            }
+        }
+        context("Removing the only preference that does not support a value") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.addPreference(listOf("vp8", "h264"))
+            aggregator.addPreference(listOf("vp9", "vp8"))
+
+            aggregator.removePreference(listOf("vp8", "h264"))
+            should("Return that value to the set of preferences") {
+                calledWith.last().shouldContainExactly(listOf("vp9", "vp8"))
+            }
+        }
+        context("Preferences that express different orders") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.addPreference(listOf("vp9", "h264", "vp8"))
+
+            should("Reflect the majority preference") {
+                calledWith shouldContainExactly listOf(listOf("vp9", "vp8", "h264"))
+            }
+        }
+        context("Ties in preference order") {
+            aggregator.addPreference(listOf("vp9", "vp8", "h264"))
+            aggregator.addPreference(listOf("vp9", "h264", "vp8"))
+
+            should("Result in the correct set, in some order, with consensus where it exists") {
+                calledWith.last().shouldContainExactlyInAnyOrder("h264", "vp9", "vp8")
+                calledWith.last().first() shouldBe "vp9"
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-79-gdc9285e</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-78-g62d03d4</version>
+        <version>1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Depends on https://github.com/jitsi/jitsi-xmpp-extensions/pull/104.