### PR TITLE
fix: Fix scheduling jvb health checks.

### DIFF
--- a/jicofo-selector/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
+++ b/jicofo-selector/src/main/java/org/jitsi/jicofo/bridge/JvbDoctor.java
@@ -144,7 +144,7 @@ public class JvbDoctor
         private PeriodicHealthCheckTask(Runnable task, long healthCheckInterval)
         {
             innerTask = task;
-            future = TaskPools.getScheduledPool().scheduleAtFixedRate(
+            future = TaskPools.getScheduledPool().scheduleWithFixedDelay(
                 () -> innerFuture = TaskPools.getIoPool().submit(runInner),
                 healthCheckInterval,
                 healthCheckInterval,


### PR DESCRIPTION
Scheduling at a fixed rate leads to IO threads building up when a bridge
becomes unresponsibe and the duration of health checks becomes longer
than the health check interval.
