### PR TITLE
fix(visitors): Make sure we disconnect vnodes before leaving rooms.

### DIFF
--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
@@ -57,7 +57,7 @@ class VisitorsManager(
         logger.info("VisitorsComponentManager is now ${if (enabled) "en" else "dis"}abled with address $address")
     }
 
-    fun sendIqToComponent(roomJid: EntityBareJid, extensions: List<ExtensionElement>) {
+    fun sendIqToComponent(roomJid: EntityBareJid, extensions: List<ExtensionElement>, callback: (() -> Unit)?) {
         val address = this.address ?: throw Exception("Component not available.")
         val iq = VisitorsIq.Builder(xmppProvider.xmppConnection).apply {
             to(address)
@@ -75,6 +75,8 @@ class VisitorsManager(
                 }
                 else -> logger.warn("Received error response: ${response.toStringOpt()}")
             }
+
+            callback?.invoke()
         }
     }
 


### PR DESCRIPTION
Use case is a single main participant and a visitor node. If jicofo leaves visitor room before disconnecting, the client will reload seeing jicofo leaving. If we disconnect first, we destroy the room with an appropriate message shown to visitors.