### PR TITLE
Keep track of rtcstats disabled and start muted rmd support.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/Features.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/Features.kt
@@ -57,6 +57,9 @@ enum class Features(val value: String) {
     RTCPMUX("urn:ietf:rfc:5761"),
     BUNDLE("urn:ietf:rfc:5888"),
     RAYO("urn:xmpp:rayo:client:1"),
+
+    // Supports handling "start muted" via room metadata (instead of via jingle).
+    START_MUTED_RMD("start-muted-room-metadata"),
     VISITORS_V1("http://jitsi.org/visitors-1");
 
     companion object {

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -826,6 +826,10 @@ public class JitsiMeetConferenceImpl
                     features);
 
             ConferenceMetrics.participants.inc();
+            if (!features.contains(Features.START_MUTED_RMD))
+            {
+                ConferenceMetrics.participantsNoStartMutedRmd.inc();
+            }
 
             boolean added = (participants.put(chatRoomMember.getOccupantJid(), participant) == null);
             if (added)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceMetrics.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/ConferenceMetrics.kt
@@ -49,6 +49,12 @@ class ConferenceMetrics {
         )
 
         @JvmField
+        val participantsNoStartMutedRmd = metricsContainer.registerCounter(
+            "participants_no_start_muted_rmd",
+            "The number of participants with no support for start muted via room-metadata."
+        )
+
+        @JvmField
         val participantsMoved = metricsContainer.registerCounter(
             "participants_moved",
             "Number of participants moved away from a failed bridge"

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -34,6 +34,8 @@ import org.jxmpp.jid.DomainBareJid
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
 
+import java.lang.Boolean.parseBoolean
+
 /**
  * Handles XMPP requests for a new conference ([ConferenceIq]).
  */
@@ -88,7 +90,12 @@ class ConferenceIqHandler(
         conferenceRequestCounter.inc()
         val conference = focusManager.getConference(room)
         val roomExists = conference != null
-        if (!roomExists) newConferenceRequestCounter.inc()
+        if (!roomExists) {
+            newConferenceRequestCounter.inc()
+            if (!parseBoolean(query.propertiesMap.getOrDefault("rtcstatsEnabled", "true"))) {
+                logger.info("New room with rtcstats disabled: $room")
+            }
+        }
 
         // Authentication logic
         val error: IQ? = processExtensions(query, room, response, roomExists)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -33,7 +33,6 @@ import org.jivesoftware.smack.packet.StanzaError
 import org.jxmpp.jid.DomainBareJid
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
-
 import java.lang.Boolean.parseBoolean
 
 /**


### PR DESCRIPTION
- **log: Log when rtcstats is disabled.**
- **feat: Keep track of participants without support for start muted via room-metadata.**
