### PR TITLE
Update JRE dependencies for debian trixie

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,6 @@ Homepage: https://jitsi.org/meet
 
 Package: jicofo
 Architecture: all
-Depends: ${misc:Depends}, openjdk-17-jre-headless | openjdk-11-jre-headless, ruby-hocon, jq
+Depends: ${misc:Depends}, openjdk-17-jre-headless | openjdk-11-jre-headless | java-runtime-headless (>= 17), ruby-hocon, jq
 Description: JItsi Meet COnference FOcus
  Jicofo is a conference focus for Jitsi Meet application.


### PR DESCRIPTION
debian trixie comes (currently) with `openjdk-21-jre-headless` (selected by `default-jre-headless`) or `openjdk-25-jre-headless`, but not `openjdk-17-jre-headless` (nor 11). I'm currently running (a small personal instance) with `openjdk-25-jre-headless` and it seems fine.

(`openjdk-17-jre-headless` is still installed but not selected as `/usr/bin/java`, and apt is unhappy about "locally installed" packages.)

Another options for the dependency list would be `default-jre-headless | java-runtime-headless (>= 17)`.  `default-jre-headless` is a real package that depends on the default JRE of a debian release, and `java-runtime-headless` is a (versioned) virtual package provided by all `openjdk*-jre-headless` packages since version 17 - on trixie this should default to 21 but allow 25. `openjdk-11-jre-headless` should be usable on buster and bullseye via the `default-jre-headless` in those dists, or you could append `| openjdk-11-jre-headless` as final alternative (afaik the versioned `java-runtime-headless (>= ...)` shouldn't accept `openjdk-11-jre-headless`, because it provides `java-runtime-headless` only without a version).

I don't think a versioned dependency on `default-jre-headless` (e.g. like `default-jre-headless (>=2:1.11)`) would be a proper solution; if you want to make sure a recent enough java is installed (although that doesn't guarantee it is selected for `/usr/bin/java`) you should stick to `java-runtime-headless (>= 17)`.

Similar names could be used for the build dependencies.

If you tell me what semantics you'd like in the dependencies I can adjust this PR (within the limits of what is reasonably possible with the debian packages).

Also see https://github.com/jitsi/jitsi-videobridge/pull/2342