### PR TITLE
Check for meetingId conflicts

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -243,7 +243,7 @@ class ChatRoomImpl(
         }
         synchronized(this) {
             lastPresenceSent = null
-            logger.addContext("meeting_id", "")
+            logger.removeContext("meeting_id")
             avModerationByMediaType.values.forEach { it.reset() }
         }
     }

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -49,7 +49,6 @@ import org.jivesoftware.smackx.caps.packet.*;
 import org.jxmpp.jid.*;
 
 import java.time.*;
-import java.net.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -257,7 +256,7 @@ public class JitsiMeetConferenceImpl
      * Whether broadcasting to visitors is currently enabled.
      * TODO: support changing it.
      */
-    private boolean visitorsBroadcastEnabled = VisitorsConfig.config.getAutoEnableBroadcast();
+    private final boolean visitorsBroadcastEnabled = VisitorsConfig.config.getAutoEnableBroadcast();
 
     @NotNull private final Instant createdInstant = Instant.now();
 
@@ -998,7 +997,7 @@ public class JitsiMeetConferenceImpl
             {
                 rescheduleSingleParticipantTimeout();
             }
-            else if (participants.size() == 0)
+            else if (participants.isEmpty())
             {
                 expireBridgeSessions();
             }
@@ -1098,7 +1097,7 @@ public class JitsiMeetConferenceImpl
     }
 
     @Override
-    public void componentsChanged(Set<XmppProvider.Component> components)
+    public void componentsChanged(@NotNull Set<XmppProvider.Component> components)
     {
     }
 
@@ -1903,7 +1902,7 @@ public class JitsiMeetConferenceImpl
 
     /**
      * Selects a visitor node for a new participant, and joins the associated chat room if not already joined
-     * @return
+     * @return the ID of the selected node, or null if the endpoint is to be sent to the main room.
      * @throws Exception if joining the chat room failed.
      */
     private String selectVisitorNode()

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -521,7 +521,7 @@ public class JitsiMeetConferenceImpl
         chatRoom.addListener(chatRoomListener);
 
         ChatRoomInfo chatRoomInfo = chatRoom.join();
-        if (chatRoomInfo.getMeetingId() == null)
+        if (org.apache.commons.lang3.StringUtils.isBlank(chatRoomInfo.getMeetingId()))
         {
             meetingId = UUID.randomUUID().toString();
             logger.warn("No meetingId set for the MUC. Generating one locally.");

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <kotest.version>5.7.2</kotest.version>
     <slf4j.version>1.7.32</slf4j.version>
     <jackson.version>2.19.0</jackson.version>
-    <jitsi.utils.version>1.0-140-g16ddce7</jitsi.utils.version>
+    <jitsi.utils.version>1.0-141-g3b92141</jitsi.utils.version>
     <jicoco.version>1.1-160-g4ad2288</jicoco.version>
     <ktlint-maven-plugin.version>3.0.0</ktlint-maven-plugin.version>
     <spotbugs.version>4.8.6</spotbugs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-96-gb0509fc</version>
+        <version>1.0-97-g6f2f8f9</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
- **log: Remove meeting_id when resetting log context.**
- **chore: Update jitsi-xmpp-extensions.**
- **fix: Consider blank string from MUC form as unset meeting_id.**
- **chore: Fix warnings.**
