### PR TITLE
fix: Honor visitorRequested above preferredInMainRoom.

### DIFF
--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -87,6 +87,7 @@ class ConferenceIqHandler(
             to = query.from
             this.room = query.room
             focusJid = focusAuthJid
+            addProperty("visitors-supported", visitorsManager.enabled.toString())
         }
 
         logger.info("Conference request for room $room, from ${query.from}, token=${query.token != null}")
@@ -140,7 +141,7 @@ class ConferenceIqHandler(
             return response
         }
 
-        val vnode = if (visitorSupported && visitorsManager.enabled && !preferredInMainRoom) {
+        val vnode = if (visitorSupported && visitorsManager.enabled && (visitorRequested || !preferredInMainRoom)) {
             conference.redirectVisitor(
                 visitorRequested || !allowedInMainRoom,
                 userId,


### PR DESCRIPTION
Allow visitor redirection when (visitorRequested &&
preferredInMainRoom).

Also, add a visitors-supported flag to the response.
