### PR TITLE
fix: Refresh the conference start timeout on a conference-request.

### DIFF
--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
@@ -103,6 +103,7 @@ class FocusManager(
             val existingConference = conferences[room]
             conference = existingConference ?: createConference(room, properties, loggingLevel, includeInStatistics)
             isConferenceCreator = existingConference == null
+            if (!isConferenceCreator) conference.rescheduleConferenceStartTimeout()
         }
         try {
             if (isConferenceCreator) {


### PR DESCRIPTION
There's the following race condition:
1. ClientA sends conference-request
2. Jicofo creates and joins the MUC, responds to the request
3. The client doesn't join for some reason (waiting on authentication screen, fails to join or is just delayed)
4. ClientB sends conference-request (about 15 seconds after the conference is created)
5. Jicofo responds
6. The conference start timeout runs and destroys the MUC
7. ClientB tries to join and gets an error (either "room creation is restricted" or "room-not-found")

It's a rare case, but it gets triggered by this test sometimes, as it tries to join with invalid tokens a few times:
https://github.com/jitsi/jitsi-meet/blob/master/tests/specs/jaas/joinMuc.spec.ts