### PR TITLE
fix: Fix ChatRoomImpl log level.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -73,8 +73,7 @@ class ChatRoomImpl(
     /** Callback to call when the room is left. */
     private val leaveCallback: (ChatRoomImpl) -> Unit
 ) : ChatRoom, PresenceListener {
-    private val logger = createLogger().apply {
-        logLevel?.let { level = it }
+    private val logger = createLogger(minLogLevel = logLevel ?: Level.ALL).apply {
         addContext("room", roomJid.toString())
     }
 


### PR DESCRIPTION
LoggerImpl delegates to a java.util.logging.Logger and setting the level
is also delegated. As a result, the shared delegate's log level is
changed every time. We should probably change that logger behavior to
only change the level of each instance, but I'm not convinced that it's
safe to do so.
