### PR TITLE
fix: Fix redirection when participantSoftLimit=1.

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -895,11 +895,7 @@ public class JitsiMeetConferenceImpl
             boolean added = (participants.put(chatRoomMember.getOccupantJid(), participant) == null);
             if (added)
             {
-                if (participant.isUserParticipant())
-                {
-                    userParticipantAdded();
-                }
-                else if (participant.getChatMember().getRole() == MemberRole.VISITOR)
+                if (participant.getChatMember().getRole() == MemberRole.VISITOR)
                 {
                     visitorAdded(participant.getChatMember().getVideoCodecs());
                 }
@@ -1123,11 +1119,7 @@ public class JitsiMeetConferenceImpl
                 {
                     ConferenceMetrics.endpointSeconds.addAndGet(participant.durationSeconds());
                 }
-                if (removed.isUserParticipant())
-                {
-                    userParticipantRemoved();
-                }
-                else if (removed.getChatMember().getRole() == MemberRole.VISITOR)
+                if (removed.getChatMember().getRole() == MemberRole.VISITOR)
                 {
                     visitorRemoved(removed.getChatMember().getVideoCodecs());
                 }
@@ -1940,42 +1932,22 @@ public class JitsiMeetConferenceImpl
         return null;
     }
 
-    private long userParticipantCount = 0;
-
-    private void userParticipantAdded()
-    {
-        synchronized (participantLock)
-        {
-            userParticipantCount++;
-        }
-    }
-
-    private void userParticipantRemoved()
-    {
-        synchronized(participantLock)
-        {
-            if (userParticipantCount <= 0)
-            {
-                logger.error("userParticipantCount out of sync - trying to reduce when value is " +
-                    userParticipantCount);
-            }
-            else
-            {
-                userParticipantCount--;
-            }
-        }
-    }
-
     /**
-     * Get the number of participants for the purpose of visitor node selection. Exclude participants for jibri and
-     * transcribers, because they shouldn't count towards the max participant limit.
+     * Get the number of participants in the main room for the purpose of visitor node selection. Exclude participants
+     * for jibri and transcribers, because they shouldn't count towards the max participant limit.
      */
     private long getUserParticipantCount()
     {
-        synchronized (participantLock)
+        ChatRoom chatRoom = this.chatRoom;
+        if (chatRoom == null)
         {
-            return userParticipantCount;
+            return 0;
         }
+
+        return chatRoom.getMembers()
+                .stream()
+                .filter(m -> !m.isJibri() && !m.isTranscriber())
+                .count();
     }
 
     /**

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -135,13 +135,6 @@ open class Participant @JvmOverloads constructor(
     private val signalQueuedSourcesTaskSyncRoot = Any()
 
     /**
-     * Whether this participant is a "user participant" for the purposes of
-     * [JitsiMeetConferenceImpl.getUserParticipantCount].
-     * Needs to be unchanging so counts don't get out of sync.
-     */
-    val isUserParticipant = !chatMember.isJibri && !chatMember.isTranscriber && chatMember.role != MemberRole.VISITOR
-
-    /**
      * Replaces the channel allocator thread, which is currently allocating channels for this participant (if any)
      * with the specified channel allocator (if any).
      * @param inviteRunnable the channel allocator to set, or `null` to clear it.


### PR DESCRIPTION
When there's only one chat room member and the jingle session isn't
initiated yet, there's no Participant so the count is of. Also, just
simplify to counting members in the main room.
