### PR TITLE
Remove agafua-syslog dependency

### DIFF
--- a/jicofo-common/pom.xml
+++ b/jicofo-common/pom.xml
@@ -79,11 +79,6 @@
     </dependency>
     <!-- runtime -->
     <dependency>
-      <groupId>rusv</groupId>
-      <artifactId>agafua-syslog</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
       <scope>runtime</scope>

--- a/jicofo-selector/pom.xml
+++ b/jicofo-selector/pom.xml
@@ -79,11 +79,6 @@
     </dependency>
     <!-- runtime -->
     <dependency>
-      <groupId>rusv</groupId>
-      <artifactId>agafua-syslog</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
       <scope>runtime</scope>

--- a/jicofo/pom.xml
+++ b/jicofo/pom.xml
@@ -129,11 +129,6 @@
     </dependency>
     <!-- runtime -->
     <dependency>
-      <groupId>rusv</groupId>
-      <artifactId>agafua-syslog</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
       <scope>runtime</scope>

--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -4,8 +4,7 @@ handlers= java.util.logging.ConsoleHandler
 # Handlers with XMPP debug enabled:
 #handlers= java.util.logging.ConsoleHandler, org.jitsi.impl.protocol.xmpp.log.XmppPacketsFileHandler
 
-# Handlers with syslog enabled:
-#handlers= java.util.logging.ConsoleHandler, com.agafua.syslog.SyslogHandler
+# Handlers with sentry enabled:
 #handlers= java.util.logging.ConsoleHandler, io.sentry.jul.SentryHandler
 
 java.util.logging.ConsoleHandler.level = ALL
@@ -21,15 +20,6 @@ org.jitsi.impl.protocol.xmpp.log.XmppPacketsFileHandler.pattern=/var/log/jitsi/j
 org.jitsi.impl.protocol.xmpp.log.XmppPacketsFileHandler.append=true
 org.jitsi.impl.protocol.xmpp.log.XmppPacketsFileHandler.limit=200000000
 org.jitsi.impl.protocol.xmpp.log.XmppPacketsFileHandler.count=3
-
-# Syslog (uncomment handler to use)
-com.agafua.syslog.SyslogHandler.transport = udp
-com.agafua.syslog.SyslogHandler.facility = local0
-com.agafua.syslog.SyslogHandler.port = 514
-com.agafua.syslog.SyslogHandler.hostname = localhost
-com.agafua.syslog.SyslogHandler.formatter = org.jitsi.utils.logging2.JitsiLogFormatter
-com.agafua.syslog.SyslogHandler.escapeNewlines = false
-com.agafua.syslog.SyslogHandler.filter = org.jitsi.impl.protocol.xmpp.log.ExcludeXmppPackets
 
 # Sentry (uncomment handler to use)
 io.sentry.jul.SentryHandler.level=WARNING

--- a/pom.xml
+++ b/pom.xml
@@ -201,12 +201,6 @@
       </dependency>
       <!-- runtime -->
       <dependency>
-        <groupId>rusv</groupId>
-        <artifactId>agafua-syslog</artifactId>
-        <version>0.4</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
         <groupId>io.sentry</groupId>
         <artifactId>sentry</artifactId>
         <version>5.4.0</version>


### PR DESCRIPTION
The syslog handler was already commented out in `logging.properties` — remove the unused dependency and the related dead config.