### PR TITLE
Forward rtcStatsEnabled to Jibri invite

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
@@ -145,6 +145,11 @@ public class JibriSession
     private final String applicationData;
 
     /**
+     * Whether rtcstats is enabled for this conference.
+     */
+    private final boolean rtcStatsEnabled;
+
+    /**
      * The maximum amount of retries we'll attempt
      */
     private final int maxNumRetries;
@@ -197,6 +202,7 @@ public class JibriSession
             String youTubeBroadcastId,
             String sessionId,
             String applicationData,
+            boolean rtcStatsEnabled,
             Logger parentLogger)
     {
         this.stateListener = stateListener;
@@ -212,6 +218,7 @@ public class JibriSession
         this.youTubeBroadcastId = youTubeBroadcastId;
         this.sessionId = sessionId;
         this.applicationData = applicationData;
+        this.rtcStatsEnabled = rtcStatsEnabled;
         jibriDetector.addHandler(jibriEventHandler);
         logger = parentLogger.createChildLogger(getClass().getName());
     }
@@ -500,6 +507,7 @@ public class JibriSession
         }
         startIq.setSipAddress(sipAddress);
         startIq.setDisplayName(displayName);
+        startIq.setRtcStatsEnabled(rtcStatsEnabled);
 
         // Insert name of the room into Jibri START IQ
         startIq.setRoom(roomName);

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriRecorder.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriRecorder.kt
@@ -108,6 +108,7 @@ class JibriRecorder(
                     config.numRetries,
                     jibriDetector,
                     false, null, iq.displayName, iq.streamId, iq.youtubeBroadcastId, sessionId, iq.appData,
+                    conference.isRtcStatsEnabled,
                     logger
                 )
                 this.jibriSession = jibriSession

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriSipGateway.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriSipGateway.kt
@@ -83,6 +83,7 @@ class JibriSipGateway(
             false,
             iq.sipAddress,
             iq.displayName, null, null, sessionId, null,
+            conference.isRtcStatsEnabled,
             logger
         )
         sipSessions[iq.sipAddress] = jibriSession

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriSessionTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriSessionTest.kt
@@ -78,6 +78,7 @@ class JibriSessionTest : ShouldSpec({
         "youTubeBroadcastId",
         "sessionId",
         "applicationData",
+        true,
         logger
     )
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-106-g75c88a9</version>
+        <version>1.0-110-g00660c3</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
When jicofo invites a Jibri instance, include the conference-level `rtcStatsEnabled` flag in the start IQ.

- `JibriSession` accepts and forwards the flag via `JibriIq.setRtcStatsEnabled()`
- `JibriRecorder` and `JibriSipGateway` read the flag from `conference.isRtcStatsEnabled`

Depends on jitsi/jitsi-xmpp-extensions#138.