### PR TITLE
Replace json-simple with Jackson

### DIFF
--- a/jicofo-common/pom.xml
+++ b/jicofo-common/pom.xml
@@ -13,18 +13,6 @@
   <description>JItsi COnference FOcus is a server side focus component used in Jitsi Meet conferences.</description>
   <dependencies>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <!-- json-simple 1.1.1 incorrectly listed junit as a compile dependency rather than a test dependency.
-       This has been fixed in its github repo but a new release hasn't been pushed to maven. -->
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-tcp</artifactId>
     </dependency>

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/ConferenceSourceMap.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/ConferenceSourceMap.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
@@ -188,9 +189,9 @@ open class ConferenceSourceMap(
     }
 
     /** Expanded JSON format used for debugging */
-    fun toJson() = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
         synchronized(syncRoot) {
-            endpointSourceSets.forEach { (owner, sourceSet) -> put(owner, sourceSet.toJson()) }
+            endpointSourceSets.forEach { (owner, sourceSet) -> set<ObjectNode>(owner, sourceSet.toJson()) }
         }
     }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/ConferenceSourceMap.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/ConferenceSourceMap.kt
@@ -15,9 +15,9 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.jingle.ContentPacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
@@ -189,7 +189,7 @@ open class ConferenceSourceMap(
     }
 
     /** Expanded JSON format used for debugging */
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         synchronized(syncRoot) {
             endpointSourceSets.forEach { (owner, sourceSet) -> set<ObjectNode>(owner, sourceSet.toJson()) }
         }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
@@ -15,17 +15,19 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.MediaType.AUDIO
 import org.jitsi.utils.MediaType.VIDEO
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.jingle.ContentPacketExtension
 import org.jitsi.xmpp.extensions.jingle.RtpDescriptionPacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
-import org.json.simple.JSONArray
 import java.lang.IllegalArgumentException
 import kotlin.jvm.Throws
+
+private val jsonMapper = jacksonObjectMapper()
 
 /** A set of [Source]s and [SsrcGroup]s, usually associated with an endpoint. */
 data class EndpointSourceSet(
@@ -138,16 +140,16 @@ data class EndpointSourceSet(
     }
 
     /** Expanded JSON format used for debugging. */
-    fun toJson() = OrderedJsonObject().apply {
-        put(
+    fun toJson(): ObjectNode = jsonMapper.createObjectNode().apply {
+        set<ObjectNode>(
             "sources",
-            JSONArray().apply {
+            jsonMapper.createArrayNode().apply {
                 sources.forEach { add(it.toJson()) }
             }
         )
-        put(
+        set<ObjectNode>(
             "groups",
-            JSONArray().apply {
+            jsonMapper.createArrayNode().apply {
                 ssrcGroups.forEach { add(it.toJson()) }
             }
         )

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
@@ -15,8 +15,8 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.MediaType.AUDIO
 import org.jitsi.utils.MediaType.VIDEO
@@ -26,8 +26,6 @@ import org.jitsi.xmpp.extensions.jingle.RtpDescriptionPacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
 import java.lang.IllegalArgumentException
 import kotlin.jvm.Throws
-
-private val jsonMapper = jacksonObjectMapper()
 
 /** A set of [Source]s and [SsrcGroup]s, usually associated with an endpoint. */
 data class EndpointSourceSet(
@@ -140,16 +138,16 @@ data class EndpointSourceSet(
     }
 
     /** Expanded JSON format used for debugging. */
-    fun toJson(): ObjectNode = jsonMapper.createObjectNode().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>(
             "sources",
-            jsonMapper.createArrayNode().apply {
+            JsonNodeFactory.instance.arrayNode().apply {
                 sources.forEach { add(it.toJson()) }
             }
         )
         set<ObjectNode>(
             "groups",
-            jsonMapper.createArrayNode().apply {
+            JsonNodeFactory.instance.arrayNode().apply {
                 ssrcGroups.forEach { add(it.toJson()) }
             }
         )

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
@@ -15,8 +15,8 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.jingle.ParameterPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.SSRCInfoPacketExtension
@@ -90,7 +90,7 @@ data class Source(
     }
 
     /** Expanded JSON format used for debugging. */
-    fun toJson() = OrderedJsonObject().apply {
+    fun toJson() = JsonNodeFactory.instance.objectNode().apply {
         put("ssrc", ssrc)
         put("media_type", mediaType.toString())
         put("name", name ?: "null")

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/SsrcGroup.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/SsrcGroup.kt
@@ -15,15 +15,13 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.utils.MediaType
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
 import java.lang.IllegalArgumentException
 import kotlin.jvm.Throws
-
-private val jsonMapper = jacksonObjectMapper()
 
 /** The description of an SSRC grouping (i.e. an ssrc-group line in SDP) */
 data class SsrcGroup(
@@ -83,9 +81,9 @@ data class SsrcGroup(
     }
 
     /** Expanded JSON format used for debugging. */
-    fun toJson(): ObjectNode = jsonMapper.createObjectNode().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("semantics", semantics.toString())
         put("media_type", mediaType.toString())
-        set<ObjectNode>("ssrcs", jsonMapper.createArrayNode().apply { ssrcs.forEach { add(it) } })
+        set<ObjectNode>("ssrcs", JsonNodeFactory.instance.arrayNode().apply { ssrcs.forEach { add(it) } })
     }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/SsrcGroup.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/SsrcGroup.kt
@@ -15,13 +15,15 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
-import org.json.simple.JSONArray
 import java.lang.IllegalArgumentException
 import kotlin.jvm.Throws
+
+private val jsonMapper = jacksonObjectMapper()
 
 /** The description of an SSRC grouping (i.e. an ssrc-group line in SDP) */
 data class SsrcGroup(
@@ -81,9 +83,9 @@ data class SsrcGroup(
     }
 
     /** Expanded JSON format used for debugging. */
-    fun toJson() = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = jsonMapper.createObjectNode().apply {
         put("semantics", semantics.toString())
         put("media_type", mediaType.toString())
-        put("ssrcs", JSONArray().apply { ssrcs.forEach { add(it) } })
+        set<ObjectNode>("ssrcs", jsonMapper.createArrayNode().apply { ssrcs.forEach { add(it) } })
     }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppCapsStats.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppCapsStats.kt
@@ -18,9 +18,9 @@
 package org.jitsi.jicofo.xmpp
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 
 private val jsonMapper = jacksonObjectMapper()
@@ -37,7 +37,7 @@ class XmppCapsStats {
 
         @JvmStatic
         val stats: ObjectNode
-            get() = OrderedJsonObject().apply {
+            get() = JsonNodeFactory.instance.objectNode().apply {
                 synchronized(map) {
                     map.forEach { (nodeVer, e) ->
                         set<ObjectNode>(nodeVer, e.json())
@@ -61,7 +61,7 @@ class XmppCapsStats {
     private class FeaturesAndCount(val features: Set<Features>) {
         /** The number of participants seen with this set of features. */
         var count = 0
-        fun json(): ObjectNode = OrderedJsonObject().apply {
+        fun json(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             put("count", count)
             set<ArrayNode>("features", jsonMapper.valueToTree(features.map { it.name }))
         }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppCapsStats.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppCapsStats.kt
@@ -17,8 +17,13 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
+
+private val jsonMapper = jacksonObjectMapper()
 
 class XmppCapsStats {
     companion object {
@@ -31,11 +36,11 @@ class XmppCapsStats {
         private val logger = createLogger()
 
         @JvmStatic
-        val stats: OrderedJsonObject
+        val stats: ObjectNode
             get() = OrderedJsonObject().apply {
                 synchronized(map) {
                     map.forEach { (nodeVer, e) ->
-                        this[nodeVer] = e.json()
+                        set<ObjectNode>(nodeVer, e.json())
                     }
                 }
             }
@@ -56,9 +61,9 @@ class XmppCapsStats {
     private class FeaturesAndCount(val features: Set<Features>) {
         /** The number of participants seen with this set of features. */
         var count = 0
-        fun json() = OrderedJsonObject().apply {
-            this["count"] = count
-            this["features"] = features.map { it.name }
+        fun json(): ObjectNode = OrderedJsonObject().apply {
+            put("count", count)
+            set<ArrayNode>("features", jsonMapper.valueToTree(features.map { it.name }))
         }
     }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp.jingle
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.jicofo.xmpp.IqProcessingResult
@@ -283,7 +284,7 @@ class JingleSession(
         }
     }
 
-    fun debugState() = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = OrderedJsonObject().apply {
         put("sid", sid)
         put("remoteJid", remoteJid.toString())
         put("state", state.toString())

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp.jingle
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
@@ -26,7 +27,6 @@ import org.jitsi.jicofo.xmpp.createTransportReplace
 import org.jitsi.jicofo.xmpp.sendIqAndGetResponse
 import org.jitsi.jicofo.xmpp.tryToSendStanza
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.utils.queue.PacketQueue
 import org.jitsi.xmpp.extensions.jingle.ContentPacketExtension
@@ -284,7 +284,7 @@ class JingleSession(
         }
     }
 
-    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("sid", sid)
         put("remoteJid", remoteJid.toString())
         put("state", state.toString())

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleStats.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleStats.kt
@@ -18,6 +18,7 @@
 
 package org.jitsi.jicofo.xmpp.jingle
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
@@ -53,7 +54,7 @@ class JingleStats {
         }
 
         @JvmStatic
-        fun toJson(): ObjectNode = jsonMapper.createObjectNode().apply {
+        fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             set<ObjectNode>(
                 "sent",
                 jsonMapper.valueToTree(stanzasSentByAction.map { it.key to it.value.get() }.toMap())

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleStats.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleStats.kt
@@ -18,11 +18,14 @@
 
 package org.jitsi.jicofo.xmpp.jingle
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.metrics.CounterMetric
 import org.jitsi.xmpp.extensions.jingle.JingleAction
-import org.json.simple.JSONObject
 import java.util.concurrent.ConcurrentHashMap
+
+private val jsonMapper = jacksonObjectMapper()
 
 class JingleStats {
     companion object {
@@ -50,9 +53,15 @@ class JingleStats {
         }
 
         @JvmStatic
-        fun toJson() = JSONObject().apply {
-            this["sent"] = stanzasSentByAction.map { it.key to it.value.get() }.toMap()
-            this["received"] = stanzasReceivedByAction.map { it.key to it.value.get() }.toMap()
+        fun toJson(): ObjectNode = jsonMapper.createObjectNode().apply {
+            set<ObjectNode>(
+                "sent",
+                jsonMapper.valueToTree(stanzasSentByAction.map { it.key to it.value.get() }.toMap())
+            )
+            set<ObjectNode>(
+                "received",
+                jsonMapper.valueToTree(stanzasReceivedByAction.map { it.key to it.value.get() }.toMap())
+            )
         }
     }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
@@ -17,10 +17,10 @@
  */
 package org.jitsi.jicofo.xmpp.muc
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.MediaType
 import org.jitsi.jicofo.xmpp.RoomMetadata
 import org.jitsi.jicofo.xmpp.XmppProvider
-import org.jitsi.utils.OrderedJsonObject
 import org.jivesoftware.smack.SmackException
 import org.jivesoftware.smack.XMPPException
 import org.jivesoftware.smack.packet.ExtensionElement
@@ -69,7 +69,7 @@ interface ChatRoom {
     /** Transcription configuration from room metadata. */
     val transcription: RoomMetadata.Metadata.Transcription?
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
 
     /** Returns the number of members that currently have their audio sources unmuted. */
     var audioSendersCount: Int

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -17,6 +17,9 @@
  */
 package org.jitsi.jicofo.xmpp.muc
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.jicofo.JicofoConfig
 import org.jitsi.jicofo.MediaType
@@ -61,6 +64,8 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.logging.Level
+
+private val jsonMapper = jacksonObjectMapper()
 
 @SuppressFBWarnings(
     value = ["JLM_JSR166_UTILCONCURRENT_MONITORENTER"],
@@ -247,28 +252,31 @@ class ChatRoomImpl(
         eventEmitter.fireEvent { numVideoSendersChanged(newValue) }
     }
 
-    override val debugState: OrderedJsonObject
+    override val debugState: ObjectNode
         get() = OrderedJsonObject().apply {
-            this["room_jid"] = roomJid.toString()
-            this["my_occupant_jid"] = myOccupantJid.toString()
+            put("room_jid", roomJid.toString())
+            put("my_occupant_jid", myOccupantJid.toString())
             val membersJson = OrderedJsonObject()
             membersMap.values.forEach {
-                membersJson[it.name] = it.debugState
+                membersJson.set<ObjectNode>(it.name, it.debugState)
             }
-            this["members"] = membersJson
-            this["audio_senders_count"] = audioSendersCount
-            this["video_senders_count"] = videoSendersCount
-            this["lobby_enabled"] = lobbyEnabled
-            this["participants_soft_limit"] = participantsSoftLimit ?: -1
+            set<ObjectNode>("members", membersJson)
+            put("audio_senders_count", audioSendersCount)
+            put("video_senders_count", videoSendersCount)
+            put("lobby_enabled", lobbyEnabled)
+            put("participants_soft_limit", participantsSoftLimit ?: -1)
             participants?.let {
-                this["participants"] = it
+                set<ArrayNode>("participants", jsonMapper.valueToTree(it))
             }
-            this["moderators"] = moderators
-            this["visitors_enabled"] = visitorsEnabled?.toString() ?: "null"
-            this["visitors_live"] = visitorsLive
-            this["av_moderation"] = OrderedJsonObject().apply {
-                avModerationByMediaType.forEach { (k, v) -> this[k.toString()] = v.debugState }
-            }
+            set<ArrayNode>("moderators", jsonMapper.valueToTree(moderators))
+            put("visitors_enabled", visitorsEnabled?.toString() ?: "null")
+            put("visitors_live", visitorsLive)
+            set<ObjectNode>(
+                "av_moderation",
+                OrderedJsonObject().apply {
+                    avModerationByMediaType.forEach { (k, v) -> set<ObjectNode>(k.toString(), v.debugState) }
+                }
+            )
         }
 
     override fun addListener(listener: ChatRoomListener) = eventEmitter.addHandler(listener)
@@ -740,10 +748,10 @@ class ChatRoomImpl(
             logger.info("Setting whitelist for $mediaType: $newValue")
         }
 
-        val debugState: OrderedJsonObject
+        val debugState: ObjectNode
             get() = OrderedJsonObject().apply {
-                this["enabled"] = enabled
-                this["whitelist"] = whitelist
+                put("enabled", enabled)
+                set<ArrayNode>("whitelist", jsonMapper.valueToTree(whitelist))
             }
 
         fun isAllowedToUnmute(jid: Jid) = !enabled || whitelist.contains(jid.toString())

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -18,6 +18,7 @@
 package org.jitsi.jicofo.xmpp.muc
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
@@ -30,7 +31,6 @@ import org.jitsi.jicofo.xmpp.XmppProvider
 import org.jitsi.jicofo.xmpp.muc.MemberRole.Companion.fromSmack
 import org.jitsi.jicofo.xmpp.sendIqAndGetResponse
 import org.jitsi.jicofo.xmpp.tryToSendStanza
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.EventEmitter
 import org.jitsi.utils.event.SyncEventEmitter
 import org.jitsi.utils.logging2.createLogger
@@ -253,10 +253,10 @@ class ChatRoomImpl(
     }
 
     override val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("room_jid", roomJid.toString())
             put("my_occupant_jid", myOccupantJid.toString())
-            val membersJson = OrderedJsonObject()
+            val membersJson = JsonNodeFactory.instance.objectNode()
             membersMap.values.forEach {
                 membersJson.set<ObjectNode>(it.name, it.debugState)
             }
@@ -273,7 +273,7 @@ class ChatRoomImpl(
             put("visitors_live", visitorsLive)
             set<ObjectNode>(
                 "av_moderation",
-                OrderedJsonObject().apply {
+                JsonNodeFactory.instance.objectNode().apply {
                     avModerationByMediaType.forEach { (k, v) -> set<ObjectNode>(k.toString(), v.debugState) }
                 }
             )
@@ -749,7 +749,7 @@ class ChatRoomImpl(
         }
 
         val debugState: ObjectNode
-            get() = OrderedJsonObject().apply {
+            get() = JsonNodeFactory.instance.objectNode().apply {
                 put("enabled", enabled)
                 set<ArrayNode>("whitelist", jsonMapper.valueToTree(whitelist))
             }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMember.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMember.kt
@@ -17,8 +17,8 @@
  */
 package org.jitsi.jicofo.xmpp.muc
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.xmpp.Features
-import org.jitsi.utils.OrderedJsonObject
 import org.jivesoftware.smack.packet.Presence
 import org.jxmpp.jid.EntityFullJid
 import org.jxmpp.jid.Jid
@@ -74,5 +74,5 @@ interface ChatRoomMember {
      */
     val features: Set<Features>
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp.muc
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.xmpp.Features
@@ -254,7 +255,7 @@ class ChatRoomMemberImpl(
     }
 
     override val debugState: ObjectNode
-        get() = jsonMapper.createObjectNode().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("region", region.toString())
             put("occupant_jid", occupantJid.toString())
             put("jid", jid.toString())
@@ -264,7 +265,7 @@ class ChatRoomMemberImpl(
             put("role", role.toString())
             set<ObjectNode>(
                 "video_codecs",
-                jsonMapper.createArrayNode().apply { videoCodecs?.forEach { add(it) } }
+                JsonNodeFactory.instance.arrayNode().apply { videoCodecs?.forEach { add(it) } }
             )
             put("stats_id", statsId.toString())
             put("is_audio_muted", isAudioMuted)

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -17,12 +17,13 @@
  */
 package org.jitsi.jicofo.xmpp.muc
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.xmpp.Features
 import org.jitsi.jicofo.xmpp.XmppCapsStats
 import org.jitsi.jicofo.xmpp.XmppConfig
 import org.jitsi.jicofo.xmpp.muc.MemberRole.Companion.fromSmack
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.xmpp.extensions.jitsimeet.AudioMutedExtension
@@ -34,9 +35,10 @@ import org.jitsi.xmpp.extensions.jitsimeet.VideoMutedExtension
 import org.jivesoftware.smack.packet.Presence
 import org.jivesoftware.smack.packet.StandardExtensionElement
 import org.jivesoftware.smackx.caps.packet.CapsExtension
-import org.json.simple.JSONArray
 import org.jxmpp.jid.EntityFullJid
 import org.jxmpp.jid.Jid
+
+private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Stripped Smack implementation of [ChatRoomMember].
@@ -251,20 +253,23 @@ class ChatRoomMemberImpl(
         features
     }
 
-    override val debugState: OrderedJsonObject
-        get() = OrderedJsonObject().apply {
-            this["region"] = region.toString()
-            this["occupant_jid"] = occupantJid.toString()
-            this["jid"] = jid.toString()
-            this["is_jibri"] = isJibri
-            this["is_jigasi"] = isJigasi
-            this["is_transcriber"] = isTranscriber
-            this["role"] = role.toString()
-            this["video_codecs"] = JSONArray().apply { videoCodecs?.let { addAll(it) } }
-            this["stats_id"] = statsId.toString()
-            this["is_audio_muted"] = isAudioMuted
-            this["is_video_muted"] = isVideoMuted
-            this["features"] = features.map { it.name }
-            this["capsNodeVer"] = capsNodeVer.toString()
+    override val debugState: ObjectNode
+        get() = jsonMapper.createObjectNode().apply {
+            put("region", region.toString())
+            put("occupant_jid", occupantJid.toString())
+            put("jid", jid.toString())
+            put("is_jibri", isJibri)
+            put("is_jigasi", isJigasi)
+            put("is_transcriber", isTranscriber)
+            put("role", role.toString())
+            set<ObjectNode>(
+                "video_codecs",
+                jsonMapper.createArrayNode().apply { videoCodecs?.forEach { add(it) } }
+            )
+            put("stats_id", statsId.toString())
+            put("is_audio_muted", isAudioMuted)
+            put("is_video_muted", isVideoMuted)
+            set<ObjectNode>("features", jsonMapper.valueToTree(features.map { it.name }))
+            put("capsNodeVer", capsNodeVer.toString())
         }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/SourceInfo.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/SourceInfo.kt
@@ -15,10 +15,11 @@
  */
 package org.jitsi.jicofo.xmpp.muc
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.conference.source.VideoType
 import org.jitsi.utils.MediaType
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
 
 /** The information about a source contained in a jitsi-meet SourceInfo extension. */
 data class SourceInfo(
@@ -30,24 +31,28 @@ data class SourceInfo(
 
 /**
  *  Parse the JSON string encoded in a SourceInfo XML extension as a set of [SourceInfo]s.
- *  @throws ParseException if the string is not valid JSON.
- *  @throws IllegalArgumentException if the JSON in not in the expected format.
+ *  @throws IllegalArgumentException if the string is not valid JSON or not in the expected format.
  */
 @kotlin.jvm.Throws(IllegalArgumentException::class)
 fun parseSourceInfoJson(s: String): Set<SourceInfo> {
-    val json = JSONParser().parse(s) as? JSONObject ?: throw IllegalArgumentException("Illegal SourceInfo JSON: $s")
+    val json = try {
+        jacksonObjectMapper().readTree(s)
+    } catch (e: JsonProcessingException) {
+        throw IllegalArgumentException("Illegal SourceInfo JSON: $s", e)
+    }
+    if (json !is ObjectNode) throw IllegalArgumentException("Illegal SourceInfo JSON: $s")
 
-    return json.map {
-        val name = it.key as? String ?: throw IllegalArgumentException("Invalid source name ${it.key}")
-        val sourceJson = it.value as? JSONObject ?: throw IllegalArgumentException("Invalid source value: ${it.value}")
-        val muted = sourceJson["muted"] as? Boolean ?: true
-        val videoType = when (val videoTypeValue = sourceJson["videoType"]) {
-            null -> null
-            !is String -> throw IllegalArgumentException("Invalid videoType: $it")
-            else -> VideoType.parseString(videoTypeValue)
+    return json.fields().asSequence().map { (name, sourceNode) ->
+        val sourceJson = sourceNode as? ObjectNode
+            ?: throw IllegalArgumentException("Invalid source value: $sourceNode")
+        val muted = sourceJson.get("muted")?.asBoolean() ?: true
+        val videoTypeNode = sourceJson.get("videoType")
+        val videoType = when {
+            videoTypeNode == null || videoTypeNode.isNull -> null
+            !videoTypeNode.isTextual -> throw IllegalArgumentException("Invalid videoType: $videoTypeNode")
+            else -> VideoType.parseString(videoTypeNode.asText())
         }
-
-        val mediaTypeField = sourceJson["mediaType"] as? String
+        val mediaTypeField = sourceJson.get("mediaType")?.takeIf { it.isTextual }?.asText()
         val mediaType = when {
             "audio".equals(mediaTypeField, ignoreCase = true) -> MediaType.AUDIO
             "video".equals(mediaTypeField, ignoreCase = true) -> MediaType.VIDEO

--- a/jicofo-common/src/test/kotlin/org/jitsi/jicofo/xmpp/muc/SourceInfoTest.kt
+++ b/jicofo-common/src/test/kotlin/org/jitsi/jicofo/xmpp/muc/SourceInfoTest.kt
@@ -20,15 +20,14 @@ import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import org.jitsi.jicofo.conference.source.VideoType
 import org.jitsi.utils.MediaType
-import org.json.simple.parser.ParseException
 
 class SourceInfoTest : ShouldSpec() {
     init {
         context("Parsing invalid strings") {
-            shouldThrow<ParseException> {
+            shouldThrow<IllegalArgumentException> {
                 parseSourceInfoJson("")
             }
-            shouldThrow<ParseException> {
+            shouldThrow<IllegalArgumentException> {
                 parseSourceInfoJson("{")
             }
             shouldThrow<IllegalArgumentException> {

--- a/jicofo-selector/pom.xml
+++ b/jicofo-selector/pom.xml
@@ -18,18 +18,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <!-- json-simple 1.1.1 incorrectly listed junit as a compile dependency rather than a test dependency.
-       This has been fixed in its github repo but a new release hasn't been pushed to maven. -->
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-tcp</artifactId>
     </dependency>

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
@@ -17,8 +17,9 @@
  */
 package org.jitsi.jicofo.bridge
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.LoggerImpl
 import org.jitsi.utils.stats.RateTracker
@@ -31,6 +32,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 import org.jitsi.jicofo.bridge.BridgeConfig.Companion.config as config
+
+private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Represents a jitsi-videobridge instance, reachable at a certain JID, which
@@ -334,23 +337,23 @@ class Bridge @JvmOverloads internal constructor(
     val isOverloaded: Boolean
         get() = correctedStress >= config.stressThreshold
 
-    val debugState: OrderedJsonObject
-        get() = OrderedJsonObject().apply {
-            this["corrected-stress"] = correctedStress
-            this["drain"] = isDraining
-            this["endpoints"] = endpoints.get()
-            this["endpoint-restart-requests"] = endpointRestartRequestRate.getAccumulatedCount()
-            this["failing-ice"] = failingIce
-            this["graceful-shutdown"] = isInGracefulShutdown
-            this["healthy"] = isHealthy
-            this["operational"] = isOperational
-            this["overloaded"] = isOverloaded
-            this["region"] = region.toString()
-            this["relay-id"] = relayId.toString()
-            this["release"] = releaseId.toString()
-            this["shutting-down"] = isShuttingDown
-            this["stress"] = lastReportedStressLevel
-            this["version"] = version.toString()
+    val debugState: ObjectNode
+        get() = jsonMapper.createObjectNode().apply {
+            put("corrected-stress", correctedStress)
+            put("drain", isDraining)
+            put("endpoints", endpoints.get())
+            put("endpoint-restart-requests", endpointRestartRequestRate.getAccumulatedCount())
+            put("failing-ice", failingIce)
+            put("graceful-shutdown", isInGracefulShutdown)
+            put("healthy", isHealthy)
+            put("operational", isOperational)
+            put("overloaded", isOverloaded)
+            put("region", region.toString())
+            put("relay-id", relayId.toString())
+            put("release", releaseId.toString())
+            put("shutting-down", isShuttingDown)
+            put("stress", lastReportedStressLevel)
+            put("version", version.toString())
         }
 
     companion object {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
@@ -17,8 +17,8 @@
  */
 package org.jitsi.jicofo.bridge
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.LoggerImpl
@@ -32,8 +32,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 import org.jitsi.jicofo.bridge.BridgeConfig.Companion.config as config
-
-private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Represents a jitsi-videobridge instance, reachable at a certain JID, which
@@ -338,7 +336,7 @@ class Bridge @JvmOverloads internal constructor(
         get() = correctedStress >= config.stressThreshold
 
     val debugState: ObjectNode
-        get() = jsonMapper.createObjectNode().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("corrected-stress", correctedStress)
             put("drain", isDraining)
             put("endpoints", endpoints.get())

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -17,18 +17,20 @@
  */
 package org.jitsi.jicofo.bridge
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.concurrent.CustomizableThreadFactory
 import org.jitsi.utils.event.AsyncEventEmitter
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension
-import org.json.simple.JSONObject
 import org.jxmpp.jid.Jid
 import java.time.Clock
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+
+private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Class exposes methods for selecting best videobridge from all currently
@@ -221,25 +223,28 @@ class BridgeSelector @JvmOverloads constructor(
         )
     }
 
-    val stats: JSONObject
+    val stats: ObjectNode
         @Synchronized
-        get() = JSONObject().apply {
+        get() = jsonMapper.createObjectNode().apply {
             // We want to avoid exposing unnecessary hierarchy levels in the stats,
             // so we'll merge stats from different "child" objects here.
-            this["bridge_count"] = bridgeCount.get()
-            this["operational_bridge_count"] = operationalBridgeCountMetric.get()
-            this["in_shutdown_bridge_count"] = inShutdownBridgeCountMetric.get()
-            this["lost_bridges"] = lostBridges.get()
-            this["bridge_version_count"] = bridgeVersionCount.get()
+            put("bridge_count", bridgeCount.get())
+            put("operational_bridge_count", operationalBridgeCountMetric.get())
+            put("in_shutdown_bridge_count", inShutdownBridgeCountMetric.get())
+            put("lost_bridges", lostBridges.get())
+            put("bridge_version_count", bridgeVersionCount.get())
         }
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
         @Synchronized
-        get() = OrderedJsonObject().apply {
-            this["strategy"] = bridgeSelectionStrategy.javaClass.simpleName
-            this["bridge"] = OrderedJsonObject().apply {
-                bridges.values.forEach { put(it.jid.toString(), it.debugState) }
-            }
+        get() = jsonMapper.createObjectNode().apply {
+            put("strategy", bridgeSelectionStrategy.javaClass.simpleName)
+            set<ObjectNode>(
+                "bridge",
+                jsonMapper.createObjectNode().apply {
+                    bridges.values.forEach { set<ObjectNode>(it.jid.toString(), it.debugState) }
+                }
+            )
         }
 
     fun updateMetrics() {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -17,8 +17,8 @@
  */
 package org.jitsi.jicofo.bridge
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.utils.concurrent.CustomizableThreadFactory
@@ -29,8 +29,6 @@ import org.jxmpp.jid.Jid
 import java.time.Clock
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
-
-private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Class exposes methods for selecting best videobridge from all currently
@@ -225,7 +223,7 @@ class BridgeSelector @JvmOverloads constructor(
 
     val stats: ObjectNode
         @Synchronized
-        get() = jsonMapper.createObjectNode().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             // We want to avoid exposing unnecessary hierarchy levels in the stats,
             // so we'll merge stats from different "child" objects here.
             put("bridge_count", bridgeCount.get())
@@ -237,11 +235,11 @@ class BridgeSelector @JvmOverloads constructor(
 
     val debugState: ObjectNode
         @Synchronized
-        get() = jsonMapper.createObjectNode().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("strategy", bridgeSelectionStrategy.javaClass.simpleName)
             set<ObjectNode>(
                 "bridge",
-                jsonMapper.createObjectNode().apply {
+                JsonNodeFactory.instance.objectNode().apply {
                     bridges.values.forEach { set<ObjectNode>(it.jid.toString(), it.debugState) }
                 }
             )

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.bridge.colibri
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.TranscriptionConfig
@@ -28,7 +29,6 @@ import org.jitsi.jicofo.codec.Config
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.TemplatedUrl
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
@@ -410,14 +410,14 @@ class Colibri2Session(
 
     override fun toString() = "Colibri2Session[bridge=${bridge.jid.resourceOrNull}, id=$id]"
 
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>("bridge", bridge.debugState)
         put("id", id)
         set<ObjectNode>("feedback_sources", feedbackSources.toJson())
         put("created", created)
         set<ObjectNode>(
             "relays",
-            OrderedJsonObject().apply {
+            JsonNodeFactory.instance.objectNode().apply {
                 relays.values.forEach { set<ObjectNode>(it.relayId, it.toJson()) }
             }
         )
@@ -518,7 +518,7 @@ class Colibri2Session(
             sendRequest(request.build(), "Relay.setTransport")
         }
 
-        fun toJson() = OrderedJsonObject().apply {
+        fun toJson() = JsonNodeFactory.instance.objectNode().apply {
             put("id", relayId)
             put("use_unique_port", useUniquePort)
             put("ice_controlling", iceControlling)

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.bridge.colibri
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.TranscriptionConfig
 import org.jitsi.jicofo.bridge.Bridge
@@ -409,15 +410,15 @@ class Colibri2Session(
 
     override fun toString() = "Colibri2Session[bridge=${bridge.jid.resourceOrNull}, id=$id]"
 
-    fun toJson() = OrderedJsonObject().apply {
-        put("bridge", bridge.debugState)
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        set<ObjectNode>("bridge", bridge.debugState)
         put("id", id)
-        put("feedback_sources", feedbackSources.toJson())
+        set<ObjectNode>("feedback_sources", feedbackSources.toJson())
         put("created", created)
-        put(
+        set<ObjectNode>(
             "relays",
             OrderedJsonObject().apply {
-                relays.values.forEach { put(it.relayId, it.toJson()) }
+                relays.values.forEach { set<ObjectNode>(it.relayId, it.toJson()) }
             }
         )
     }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -17,11 +17,11 @@
  */
 package org.jitsi.jicofo.bridge.colibri
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.MediaType
 import org.jitsi.jicofo.bridge.Bridge
 import org.jitsi.jicofo.bridge.ConferenceBridgeProperties
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.TemplatedUrl
 import org.jitsi.xmpp.extensions.colibri2.InitialLastN
 import org.jitsi.xmpp.extensions.colibri2.Media
@@ -72,7 +72,7 @@ interface ColibriSessionManager {
      */
     fun removeBridge(bridge: Bridge): List<String>
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
 
     /**
      * Interface for events fired by [ColibriSessionManager].

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -18,6 +18,8 @@
 
 package org.jitsi.jicofo.bridge.colibri
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.jicofo.MediaType
 import org.jitsi.jicofo.OctoConfig
@@ -34,7 +36,6 @@ import org.jitsi.jicofo.bridge.getNodesBehind
 import org.jitsi.jicofo.bridge.getPathsFrom
 import org.jitsi.jicofo.bridge.removeNode
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.TemplatedUrl
 import org.jitsi.utils.event.AsyncEventEmitter
 import org.jitsi.utils.logging2.Logger
@@ -50,8 +51,9 @@ import org.jivesoftware.smack.packet.StanzaError.Condition.bad_request
 import org.jivesoftware.smack.packet.StanzaError.Condition.conflict
 import org.jivesoftware.smack.packet.StanzaError.Condition.item_not_found
 import org.jivesoftware.smack.packet.StanzaError.Condition.service_unavailable
-import org.json.simple.JSONArray
 import java.util.Collections.singletonList
+
+private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Implements [ColibriSessionManager] using colibri2.
@@ -675,22 +677,28 @@ class ColibriV2SessionManager(
         participantsToRemove.map { it.id }
     }
 
-    override val debugState
-        get() = OrderedJsonObject().apply {
+    override val debugState: ObjectNode
+        get() = jsonMapper.createObjectNode().apply {
             synchronized(syncRoot) {
-                val participantsJson = OrderedJsonObject()
-                participants.values.forEach { participantsJson[it.id] = it.toJson() }
-                put("participants", participantsJson)
+                val participantsJson = jsonMapper.createObjectNode()
+                participants.values.forEach { participantsJson.set<ObjectNode>(it.id, it.toJson()) }
+                set<ObjectNode>("participants", participantsJson)
 
-                val sessionsJson = OrderedJsonObject()
+                val sessionsJson = jsonMapper.createObjectNode()
                 sessions.values.forEach {
-                    sessionsJson[it.bridge.jid.resourceOrNull.toString()] = it.toJson().also { sessionJson ->
-                        sessionJson["participants"] = JSONArray().apply {
-                            getSessionParticipants(it).forEach { participant -> add(participant.id) }
+                    sessionsJson.set<ObjectNode>(
+                        it.bridge.jid.resourceOrNull.toString(),
+                        it.toJson().also { sessionJson ->
+                            sessionJson.set<ObjectNode>(
+                                "participants",
+                                jsonMapper.createArrayNode().apply {
+                                    getSessionParticipants(it).forEach { participant -> add(participant.id) }
+                                }
+                            )
                         }
-                    }
+                    )
                 }
-                put("sessions", sessionsJson)
+                set<ObjectNode>("sessions", sessionsJson)
             }
         }
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -18,8 +18,8 @@
 
 package org.jitsi.jicofo.bridge.colibri
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.jicofo.MediaType
 import org.jitsi.jicofo.OctoConfig
@@ -52,8 +52,6 @@ import org.jivesoftware.smack.packet.StanzaError.Condition.conflict
 import org.jivesoftware.smack.packet.StanzaError.Condition.item_not_found
 import org.jivesoftware.smack.packet.StanzaError.Condition.service_unavailable
 import java.util.Collections.singletonList
-
-private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Implements [ColibriSessionManager] using colibri2.
@@ -678,20 +676,20 @@ class ColibriV2SessionManager(
     }
 
     override val debugState: ObjectNode
-        get() = jsonMapper.createObjectNode().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             synchronized(syncRoot) {
-                val participantsJson = jsonMapper.createObjectNode()
+                val participantsJson = JsonNodeFactory.instance.objectNode()
                 participants.values.forEach { participantsJson.set<ObjectNode>(it.id, it.toJson()) }
                 set<ObjectNode>("participants", participantsJson)
 
-                val sessionsJson = jsonMapper.createObjectNode()
+                val sessionsJson = JsonNodeFactory.instance.objectNode()
                 sessions.values.forEach {
                     sessionsJson.set<ObjectNode>(
                         it.bridge.jid.resourceOrNull.toString(),
                         it.toJson().also { sessionJson ->
                             sessionJson.set<ObjectNode>(
                                 "participants",
-                                jsonMapper.createArrayNode().apply {
+                                JsonNodeFactory.instance.arrayNode().apply {
                                     getSessionParticipants(it).forEach { participant -> add(participant.id) }
                                 }
                             )

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.bridge.colibri
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.OrderedJsonObject
 
 /**
@@ -38,10 +39,10 @@ class ParticipantInfo(
     var videoMuted = parameters.forceMuteVideo
     var sources = parameters.sources
 
-    fun toJson() = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
         put("id", id)
         put("stats_id", statsId.toString())
-        put("sources", sources.toJson())
+        set<ObjectNode>("sources", sources.toJson())
         put("bridge", session.bridge.jid.resourceOrNull.toString())
         put("audio_muted", audioMuted)
         put("video_muted", videoMuted)

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
@@ -17,8 +17,8 @@
  */
 package org.jitsi.jicofo.bridge.colibri
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.utils.OrderedJsonObject
 
 /**
  * Represents the information for a specific participant/endpoint needed for colibri2.
@@ -39,7 +39,7 @@ class ParticipantInfo(
     var videoMuted = parameters.forceMuteVideo
     var sources = parameters.sources
 
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("id", id)
         put("stats_id", statsId.toString())
         set<ObjectNode>("sources", sources.toJson())

--- a/jicofo/pom.xml
+++ b/jicofo/pom.xml
@@ -23,18 +23,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <!-- json-simple 1.1.1 incorrectly listed junit as a compile dependency rather than a test dependency.
-       This has been fixed in its github repo but a new release hasn't been pushed to maven. -->
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConference.java
@@ -23,7 +23,7 @@ import org.jitsi.jicofo.bridge.*;
 import org.jitsi.jicofo.jibri.*;
 import org.jitsi.jicofo.xmpp.*;
 import org.jitsi.jicofo.xmpp.muc.*;
-import org.jitsi.utils.*;
+import com.fasterxml.jackson.databind.*;
 import org.jitsi.xmpp.extensions.jibri.*;
 import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.*;
@@ -151,11 +151,11 @@ public interface JitsiMeetConference extends XmppProvider.Listener
             @NotNull MediaType mediaType);
 
     @NotNull
-    OrderedJsonObject getDebugState();
+    JsonNode getDebugState();
 
     /** Get the stats for this conference that should be exported to rtcstats. */
     @NotNull
-    OrderedJsonObject getRtcstatsState();
+    JsonNode getRtcstatsState();
 
     /** Move (reinvite) an endpoint in this conference. Return true if the endpoint was moved. */
     boolean moveEndpoint(@NotNull String endpointId, Bridge bridge);

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -31,6 +31,8 @@ import org.jitsi.jicofo.visitors.*;
 import org.jitsi.jicofo.xmpp.*;
 import org.jitsi.jicofo.xmpp.UtilKt;
 import org.jitsi.jicofo.xmpp.muc.*;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.node.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.logging2.Logger;
@@ -79,6 +81,7 @@ import static org.jitsi.jicofo.xmpp.MuteIqHandlerKt.createMuteIq;
 public class JitsiMeetConferenceImpl
     implements JitsiMeetConference, XmppProvider.Listener
 {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Status used by participants when they are switching from a room to a breakout room.
@@ -1645,14 +1648,14 @@ public class JitsiMeetConferenceImpl
 
     @Override
     @NotNull
-    public OrderedJsonObject getRtcstatsState()
+    public JsonNode getRtcstatsState()
     {
         return getDebugState(false);
     }
 
     @Override
     @NotNull
-    public OrderedJsonObject getDebugState()
+    public JsonNode getDebugState()
     {
         return getDebugState(true);
     }
@@ -1660,40 +1663,52 @@ public class JitsiMeetConferenceImpl
     /**
      * @param full when false some high volume fields that aren't needed for rtcstats are suppressed.
      */
-    private OrderedJsonObject getDebugState(boolean full)
+    private ObjectNode getDebugState(boolean full)
     {
-        OrderedJsonObject o = new OrderedJsonObject();
+        ObjectNode o = MAPPER.createObjectNode();
         o.put("name", roomName.toString());
         String meetingId = this.meetingId;
         if (meetingId != null)
         {
             o.put("meeting_id", meetingId);
         }
-        o.put("config", config.getDebugState());
+        o.set("config", config.getDebugState());
         ChatRoom chatRoom = this.chatRoom;
-        o.put("chat_room", chatRoom == null ? "null" : chatRoom.getDebugState());
-        OrderedJsonObject participantsJson = new OrderedJsonObject();
+        if (chatRoom == null)
+        {
+            o.putNull("chat_room");
+        }
+        else
+        {
+            o.set("chat_room", chatRoom.getDebugState());
+        }
+        ObjectNode participantsJson = MAPPER.createObjectNode();
         for (Participant participant : participants.values())
         {
-            participantsJson.put(participant.getEndpointId(), participant.getDebugState(full));
+            participantsJson.set(participant.getEndpointId(), participant.getDebugState(full));
         }
-        o.put("participants", participantsJson);
-        //o.put("jibri_recorder", jibriRecorder.getDebugState());
-        //o.put("jibri_sip_gateway", jibriSipGateway.getDebugState());
+        o.set("participants", participantsJson);
+        //o.set("jibri_recorder", jibriRecorder.getDebugState());
+        //o.set("jibri_sip_gateway", jibriSipGateway.getDebugState());
         ChatRoomRoleManager chatRoomRoleManager = this.chatRoomRoleManager;
-        o.put("chat_room_role_manager", chatRoomRoleManager == null ? "null" : chatRoomRoleManager.getDebugState());
+        if (chatRoomRoleManager == null)
+        {
+            o.putNull("chat_room_role_manager");
+        }
+        else
+        {
+            o.set("chat_room_role_manager", chatRoomRoleManager.getDebugState());
+        }
         o.put("started", started.get());
         o.put("start_audio_muted", startAudioMuted);
         o.put("start_video_muted", startVideoMuted);
         if (colibriSessionManager != null)
         {
-            o.put("colibri_session_manager", colibriSessionManager.getDebugState());
+            o.set("colibri_session_manager", colibriSessionManager.getDebugState());
         }
-        OrderedJsonObject conferencePropertiesJson = new OrderedJsonObject();
-        conferencePropertiesJson.putAll(conferenceProperties);
-        o.put("conference_properties", conferencePropertiesJson);
+        o.set("conference_properties", MAPPER.valueToTree(conferenceProperties));
         o.put("include_in_statistics", includeInStatistics);
-        o.put("conference_sources", conferenceSources.toJson());
+        o.set("conference_sources", conferenceSources.toJson());
         o.put("audio_limit_reached", audioLimitReached);
         o.put("video_limit_reached", videoLimitReached);
 
@@ -1728,7 +1743,7 @@ public class JitsiMeetConferenceImpl
             }
         }
         o.put("visitor_count", visitorCount);
-        o.put("visitor_codecs", visitorCodecs.debugState());
+        o.set("visitor_codecs", visitorCodecs.debugState());
         o.put("participant_count", participantCount);
         o.put("jibri_count", jibriCount);
         o.put("jigasi_count", jigasiCount);

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1665,7 +1665,7 @@ public class JitsiMeetConferenceImpl
      */
     private ObjectNode getDebugState(boolean full)
     {
-        ObjectNode o = MAPPER.createObjectNode();
+        ObjectNode o = JsonNodeFactory.instance.objectNode();
         o.put("name", roomName.toString());
         String meetingId = this.meetingId;
         if (meetingId != null)
@@ -1682,7 +1682,7 @@ public class JitsiMeetConferenceImpl
         {
             o.set("chat_room", chatRoom.getDebugState());
         }
-        ObjectNode participantsJson = MAPPER.createObjectNode();
+        ObjectNode participantsJson = JsonNodeFactory.instance.objectNode();
         for (Participant participant : participants.values())
         {
             participantsJson.set(participant.getEndpointId(), participant.getDebugState(full));

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
@@ -17,8 +17,8 @@
  */
 package org.jitsi.jicofo
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.conference.ConferenceMetrics
 import org.jitsi.jicofo.conference.JitsiMeetConference
 import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl
@@ -38,8 +38,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.logging.Level
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer.Companion.instance as metricsContainer
-
-private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Manages the set of [JitsiMeetConference]s in this instance.
@@ -277,16 +275,16 @@ class FocusManager(
         get() {
             // We want to avoid exposing unnecessary hierarchy levels in the stats,
             // so we'll merge stats from different "child" objects here.
-            val stats = jsonMapper.createObjectNode()
+            val stats = JsonNodeFactory.instance.objectNode()
             stats.put("total_participants", ConferenceMetrics.participants.get())
             stats.put("total_conferences_created", ConferenceMetrics.conferencesCreated.get())
             stats.put("conferences", ConferenceMetrics.conferenceCount.get())
             stats.put("conferences_with_visitors", ConferenceMetrics.conferencesWithVisitors.get())
-            val bridgeFailures = jsonMapper.createObjectNode()
+            val bridgeFailures = JsonNodeFactory.instance.objectNode()
             bridgeFailures.put("participants_moved", ConferenceMetrics.participantsMoved.get())
             bridgeFailures.put("bridges_removed", ConferenceMetrics.bridgesRemoved.get())
             stats.set<ObjectNode>("bridge_failures", bridgeFailures)
-            val participantNotifications = jsonMapper.createObjectNode()
+            val participantNotifications = JsonNodeFactory.instance.objectNode()
             participantNotifications.put("ice_failed", ConferenceMetrics.participantsIceFailed.get())
             participantNotifications.put("request_restart", ConferenceMetrics.participantsRequestedRestart.get())
             stats.set<ObjectNode>("participant_notifications", participantNotifications)
@@ -297,7 +295,7 @@ class FocusManager(
             stats.put("endpoint_pairs", ConferenceMetrics.participantPairs.get())
             stats.set<ObjectNode>(
                 "jibri",
-                jsonMapper.createObjectNode().apply {
+                JsonNodeFactory.instance.objectNode().apply {
                     put("total_sip_call_failures", JibriStats.sipFailures.get())
                     put("total_live_streaming_failures", JibriStats.liveStreamingFailures.get())
                     put("total_recording_failures", JibriStats.recordingFailures.get())
@@ -310,7 +308,7 @@ class FocusManager(
             return stats
         }
 
-    fun getDebugState(full: Boolean): ObjectNode = jsonMapper.createObjectNode().apply {
+    fun getDebugState(full: Boolean): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         for (conference in getConferences()) {
             if (full) {
                 set<ObjectNode>(conference.roomName.toString(), conference.debugState)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/FocusManager.kt
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jicofo
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.conference.ConferenceMetrics
 import org.jitsi.jicofo.conference.JitsiMeetConference
 import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl
@@ -24,11 +26,9 @@ import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.ConferenceListener
 import org.jitsi.jicofo.jibri.JibriSession
 import org.jitsi.jicofo.jibri.JibriStats
 import org.jitsi.jicofo.xmpp.XmppProvider
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.utils.queue.QueueStatistics.Companion.getStatistics
 import org.jitsi.utils.stats.ConferenceSizeBuckets
-import org.json.simple.JSONObject
 import org.jxmpp.jid.EntityBareJid
 import java.time.Clock
 import java.time.Duration
@@ -38,6 +38,8 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.logging.Level
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer.Companion.instance as metricsContainer
+
+private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Manages the set of [JitsiMeetConference]s in this instance.
@@ -271,46 +273,49 @@ class FocusManager(
 
     // We want to avoid exposing unnecessary hierarchy levels in the stats,
     // so we'll merge stats from different "child" objects here.
-    val stats: OrderedJsonObject
+    val stats: ObjectNode
         get() {
             // We want to avoid exposing unnecessary hierarchy levels in the stats,
             // so we'll merge stats from different "child" objects here.
-            val stats = OrderedJsonObject()
-            stats["total_participants"] = ConferenceMetrics.participants.get()
-            stats["total_conferences_created"] = ConferenceMetrics.conferencesCreated.get()
-            stats["conferences"] = ConferenceMetrics.conferenceCount.get()
-            stats["conferences_with_visitors"] = ConferenceMetrics.conferencesWithVisitors.get()
-            val bridgeFailures = JSONObject()
-            bridgeFailures["participants_moved"] = ConferenceMetrics.participantsMoved.get()
-            bridgeFailures["bridges_removed"] = ConferenceMetrics.bridgesRemoved.get()
-            stats["bridge_failures"] = bridgeFailures
-            val participantNotifications = JSONObject()
-            participantNotifications["ice_failed"] = ConferenceMetrics.participantsIceFailed.get()
-            participantNotifications["request_restart"] = ConferenceMetrics.participantsRequestedRestart.get()
-            stats["participant_notifications"] = participantNotifications
-            stats["largest_conference"] = ConferenceMetrics.largestConference.get()
-            stats["participants"] = ConferenceMetrics.currentParticipants.get()
-            stats["visitors"] = ConferenceMetrics.currentVisitors.get()
-            stats["conference_sizes"] = ConferenceMetrics.conferenceSizes.toJson()
-            stats["endpoint_pairs"] = ConferenceMetrics.participantPairs.get()
-            stats["jibri"] = JSONObject().apply {
-                put("total_sip_call_failures", JibriStats.sipFailures.get())
-                put("total_live_streaming_failures", JibriStats.liveStreamingFailures.get())
-                put("total_recording_failures", JibriStats.recordingFailures.get())
-                put("live_streaming_active", JibriStats.liveStreamingActive.get())
-                put("recording_active", JibriStats.recordingActive.get())
-                put("sip_call_active", JibriStats.sipActive.get())
-            }
-            stats["queues"] = getStatistics()
+            val stats = jsonMapper.createObjectNode()
+            stats.put("total_participants", ConferenceMetrics.participants.get())
+            stats.put("total_conferences_created", ConferenceMetrics.conferencesCreated.get())
+            stats.put("conferences", ConferenceMetrics.conferenceCount.get())
+            stats.put("conferences_with_visitors", ConferenceMetrics.conferencesWithVisitors.get())
+            val bridgeFailures = jsonMapper.createObjectNode()
+            bridgeFailures.put("participants_moved", ConferenceMetrics.participantsMoved.get())
+            bridgeFailures.put("bridges_removed", ConferenceMetrics.bridgesRemoved.get())
+            stats.set<ObjectNode>("bridge_failures", bridgeFailures)
+            val participantNotifications = jsonMapper.createObjectNode()
+            participantNotifications.put("ice_failed", ConferenceMetrics.participantsIceFailed.get())
+            participantNotifications.put("request_restart", ConferenceMetrics.participantsRequestedRestart.get())
+            stats.set<ObjectNode>("participant_notifications", participantNotifications)
+            stats.put("largest_conference", ConferenceMetrics.largestConference.get())
+            stats.put("participants", ConferenceMetrics.currentParticipants.get())
+            stats.put("visitors", ConferenceMetrics.currentVisitors.get())
+            stats.set<ObjectNode>("conference_sizes", ConferenceMetrics.conferenceSizes.toJson())
+            stats.put("endpoint_pairs", ConferenceMetrics.participantPairs.get())
+            stats.set<ObjectNode>(
+                "jibri",
+                jsonMapper.createObjectNode().apply {
+                    put("total_sip_call_failures", JibriStats.sipFailures.get())
+                    put("total_live_streaming_failures", JibriStats.liveStreamingFailures.get())
+                    put("total_recording_failures", JibriStats.recordingFailures.get())
+                    put("live_streaming_active", JibriStats.liveStreamingActive.get())
+                    put("recording_active", JibriStats.recordingActive.get())
+                    put("sip_call_active", JibriStats.sipActive.get())
+                }
+            )
+            stats.set<ObjectNode>("queues", getStatistics())
             return stats
         }
 
-    fun getDebugState(full: Boolean) = OrderedJsonObject().apply {
+    fun getDebugState(full: Boolean): ObjectNode = jsonMapper.createObjectNode().apply {
         for (conference in getConferences()) {
             if (full) {
-                this[conference.roomName.toString()] = conference.debugState
+                set<ObjectNode>(conference.roomName.toString(), conference.debugState)
             } else {
-                this[conference.roomName.toString()] = conference.participantCount
+                put(conference.roomName.toString(), conference.participantCount)
             }
         }
     }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -17,6 +17,9 @@
  */
 package org.jitsi.jicofo
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.jicofo.auth.AbstractAuthAuthority
 import org.jitsi.jicofo.auth.AuthConfig
@@ -42,10 +45,11 @@ import org.jitsi.jicofo.xmpp.initializeSmack
 import org.jitsi.jicofo.xmpp.jingle.JingleStats
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
-import org.json.simple.JSONObject
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
 import org.jitsi.jicofo.auth.AuthConfig.Companion.config as authConfig
+
+private val jsonMapper = jacksonObjectMapper()
 
 /**
  * Start/stop jicofo-specific services.
@@ -203,48 +207,51 @@ class JicofoServices {
     }
 
     /** Gets statistics for the /stats HTTP interface. */
-    private fun getStats(): OrderedJsonObject = OrderedJsonObject().apply {
+    private fun getStats(): ObjectNode = OrderedJsonObject().apply {
         // Update the metrics that are usually updated periodically so we read the current values.
         JicofoMetricsContainer.instance.metricsUpdater.updateMetrics()
         // We want to avoid exposing unnecessary hierarchy levels in the stats,
         // so we merge the FocusManager and ColibriConference stats in the root object.
-        putAll(focusManager.stats)
+        setAll<ObjectNode>(focusManager.stats)
 
-        put("bridge_selector", bridgeSelector.stats)
+        set<ObjectNode>("bridge_selector", bridgeSelector.stats)
         JibriDetectorMetrics.appendStats(this)
-        xmppServices.jigasiDetector?.let { put("jigasi_detector", it.stats) }
-        put("jigasi", xmppServices.jigasiStats)
+        xmppServices.jigasiDetector?.let { set<ObjectNode>("jigasi_detector", it.stats) }
+        set<ObjectNode>("jigasi", xmppServices.jigasiStats)
         put("threads", GlobalMetrics.threadCount.get())
-        put("jingle", JingleStats.toJson())
+        set<ObjectNode>("jingle", JingleStats.toJson())
         put("version", CurrentVersionImpl.VERSION.toString())
         healthChecker?.let {
             val result = it.result
             put("slow_health_check", it.totalSlowHealthChecks)
             put("healthy", result.success)
-            put(
+            set<ObjectNode>(
                 "health",
-                JSONObject().apply {
-                    put("success", result.success)
-                    put("hardFailure", result.hardFailure)
-                    put("responseCode", result.responseCode)
-                    put("sticky", result.sticky)
-                    put("message", result.message)
-                }
+                jsonMapper.valueToTree(
+                    mapOf(
+                        "success" to result.success,
+                        "hardFailure" to result.hardFailure,
+                        "responseCode" to result.responseCode,
+                        "sticky" to result.sticky,
+                        "message" to result.message
+                    )
+                )
             )
         }
     }
 
-    private fun getDebugState(full: Boolean) = OrderedJsonObject().apply {
-        put("focus_manager", focusManager.getDebugState(full))
-        put("bridge_selector", bridgeSelector.debugState)
-        put("jibri_detector", jibriDetector?.debugState ?: "null")
-        put("sip_jibri_detector", sipJibriDetector?.debugState ?: "null")
-        put("jigasi_detector", xmppServices.jigasiDetector?.debugState ?: "null")
-        put("av_moderation", xmppServices.avModerationHandler.debugState)
-        put("conference_iq_handler", xmppServices.conferenceIqHandler.debugState)
+    private fun getDebugState(full: Boolean): ObjectNode = OrderedJsonObject().apply {
+        set<ObjectNode>("focus_manager", focusManager.getDebugState(full))
+        set<ObjectNode>("bridge_selector", bridgeSelector.debugState)
+        jibriDetector?.let { set<ObjectNode>("jibri_detector", it.debugState) } ?: putNull("jibri_detector")
+        sipJibriDetector?.let { set<ObjectNode>("sip_jibri_detector", it.debugState) } ?: putNull("sip_jibri_detector")
+        xmppServices.jigasiDetector?.let { set<ObjectNode>("jigasi_detector", it.debugState) }
+            ?: putNull("jigasi_detector")
+        set<ObjectNode>("av_moderation", xmppServices.avModerationHandler.debugState)
+        set<ObjectNode>("conference_iq_handler", xmppServices.conferenceIqHandler.debugState)
     }
 
-    private fun getConferenceDebugState(conferenceId: EntityBareJid) = OrderedJsonObject().apply {
+    private fun getConferenceDebugState(conferenceId: EntityBareJid): JsonNode {
         val conference = focusManager.getConference(JidCreate.entityBareFrom(conferenceId))
         return conference?.debugState ?: OrderedJsonObject()
     }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -18,6 +18,7 @@
 package org.jitsi.jicofo
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
@@ -43,7 +44,6 @@ import org.jitsi.jicofo.version.CurrentVersionImpl
 import org.jitsi.jicofo.xmpp.XmppServices
 import org.jitsi.jicofo.xmpp.initializeSmack
 import org.jitsi.jicofo.xmpp.jingle.JingleStats
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
@@ -207,7 +207,7 @@ class JicofoServices {
     }
 
     /** Gets statistics for the /stats HTTP interface. */
-    private fun getStats(): ObjectNode = OrderedJsonObject().apply {
+    private fun getStats(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         // Update the metrics that are usually updated periodically so we read the current values.
         JicofoMetricsContainer.instance.metricsUpdater.updateMetrics()
         // We want to avoid exposing unnecessary hierarchy levels in the stats,
@@ -240,7 +240,7 @@ class JicofoServices {
         }
     }
 
-    private fun getDebugState(full: Boolean): ObjectNode = OrderedJsonObject().apply {
+    private fun getDebugState(full: Boolean): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>("focus_manager", focusManager.getDebugState(full))
         set<ObjectNode>("bridge_selector", bridgeSelector.debugState)
         jibriDetector?.let { set<ObjectNode>("jibri_detector", it.debugState) } ?: putNull("jibri_detector")
@@ -253,7 +253,7 @@ class JicofoServices {
 
     private fun getConferenceDebugState(conferenceId: EntityBareJid): JsonNode {
         val conference = focusManager.getConference(JidCreate.entityBareFrom(conferenceId))
-        return conference?.debugState ?: OrderedJsonObject()
+        return conference?.debugState ?: JsonNodeFactory.instance.objectNode()
     }
 
     companion object {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/JitsiMeetConfig.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/JitsiMeetConfig.kt
@@ -17,8 +17,8 @@
  */
 package org.jitsi.jicofo.conference
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import java.lang.Boolean.parseBoolean
 
@@ -40,7 +40,7 @@ class JitsiMeetConfig(properties: Map<String, String>) {
     }
 
     val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("rtcstatsEnabled", rtcStatsEnabled)
             if (startAudioMuted != null) put("startAudioMuted", startAudioMuted) else putNull("startAudioMuted")
             if (startVideoMuted != null) put("startVideoMuted", startVideoMuted) else putNull("startVideoMuted")

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/JitsiMeetConfig.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/JitsiMeetConfig.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.conference
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import java.lang.Boolean.parseBoolean
@@ -38,11 +39,11 @@ class JitsiMeetConfig(properties: Map<String, String>) {
         }
     }
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
         get() = OrderedJsonObject().apply {
             put("rtcstatsEnabled", rtcStatsEnabled)
-            put("startAudioMuted", startAudioMuted ?: "null")
-            put("startVideoMuted", startVideoMuted ?: "null")
+            if (startAudioMuted != null) put("startAudioMuted", startAudioMuted) else putNull("startAudioMuted")
+            if (startVideoMuted != null) put("startVideoMuted", startVideoMuted) else putNull("startVideoMuted")
         }
 
     // Needed for createLogger() to work.

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.conference
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceConfig
 import org.jitsi.jicofo.TaskPools.Companion.scheduledPool
@@ -34,7 +35,6 @@ import org.jitsi.jicofo.xmpp.jingle.JingleSession
 import org.jitsi.jicofo.xmpp.muc.ChatRoomMember
 import org.jitsi.jicofo.xmpp.muc.MemberRole
 import org.jitsi.jicofo.xmpp.muc.hasModeratorRights
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.RateLimit
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.LoggerImpl
@@ -319,7 +319,7 @@ open class Participant @JvmOverloads constructor(
     fun hasModeratorRights() = chatMember.role.hasModeratorRights()
     override fun toString() = "Participant[$mucJid]"
 
-    fun getDebugState(full: Boolean): ObjectNode = OrderedJsonObject().apply {
+    fun getDebugState(full: Boolean): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("id", endpointId)
         if (full) {
             set<ObjectNode>("source_signaling", sourceSignaling.debugState)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.conference
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceConfig
 import org.jitsi.jicofo.TaskPools.Companion.scheduledPool
 import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.InvalidBridgeSessionIdException
@@ -318,14 +319,14 @@ open class Participant @JvmOverloads constructor(
     fun hasModeratorRights() = chatMember.role.hasModeratorRights()
     override fun toString() = "Participant[$mucJid]"
 
-    fun getDebugState(full: Boolean) = OrderedJsonObject().apply {
-        this["id"] = endpointId
+    fun getDebugState(full: Boolean): ObjectNode = OrderedJsonObject().apply {
+        put("id", endpointId)
         if (full) {
-            this["source_signaling"] = sourceSignaling.debugState
+            set<ObjectNode>("source_signaling", sourceSignaling.debugState)
         }
-        statId?.let { this["stats_id"] = it }
-        this["invite_runnable"] = if (inviteRunnable != null) "Running" else "Not running"
-        this["jingle_session"] = jingleSession?.debugState() ?: "null"
+        statId?.let { put("stats_id", it) }
+        put("invite_runnable", if (inviteRunnable != null) "Running" else "Not running")
+        jingleSession?.let { set<ObjectNode>("jingle_session", it.debugState()) } ?: putNull("jingle_session")
     }
 
     /**

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/SourceSignaling.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/SourceSignaling.kt
@@ -18,14 +18,12 @@
 package org.jitsi.jicofo.conference
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.conference.AddOrRemove.Add
 import org.jitsi.jicofo.conference.AddOrRemove.Remove
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.utils.MediaType
-
-private val jsonMapper = jacksonObjectMapper()
 
 class SourceSignaling(
     audio: Boolean = true,
@@ -79,12 +77,12 @@ class SourceSignaling(
     }
 
     val debugState: ObjectNode
-        get() = jsonMapper.createObjectNode().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             set<ObjectNode>("signaled_sources", signaledSources.toJson())
             set<ObjectNode>("sources", updatedSources.toJson())
             set<ArrayNode>(
                 "supported_media_types",
-                jsonMapper.createArrayNode().apply { supportedMediaTypes.forEach { add(it.toString()) } }
+                JsonNodeFactory.instance.arrayNode().apply { supportedMediaTypes.forEach { add(it.toString()) } }
             )
         }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/SourceSignaling.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/SourceSignaling.kt
@@ -17,12 +17,15 @@
  */
 package org.jitsi.jicofo.conference
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.jicofo.conference.AddOrRemove.Add
 import org.jitsi.jicofo.conference.AddOrRemove.Remove
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.utils.MediaType
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
+
+private val jsonMapper = jacksonObjectMapper()
 
 class SourceSignaling(
     audio: Boolean = true,
@@ -75,11 +78,14 @@ class SourceSignaling(
         }
     }
 
-    val debugState: JSONObject
-        get() = JSONObject().apply {
-            this["signaled_sources"] = signaledSources.toJson()
-            this["sources"] = updatedSources.toJson()
-            this["supported_media_types"] = JSONArray().apply { supportedMediaTypes.forEach { add(it.toString()) } }
+    val debugState: ObjectNode
+        get() = jsonMapper.createObjectNode().apply {
+            set<ObjectNode>("signaled_sources", signaledSources.toJson())
+            set<ObjectNode>("sources", updatedSources.toJson())
+            set<ArrayNode>(
+                "supported_media_types",
+                jsonMapper.createArrayNode().apply { supportedMediaTypes.forEach { add(it.toString()) } }
+            )
         }
 
     fun reset(s: ConferenceSourceMap): ConferenceSourceMap {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/SourcesToAddOrRemove.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/SourcesToAddOrRemove.kt
@@ -17,9 +17,9 @@
  */
 package org.jitsi.jicofo.conference
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
-import org.jitsi.utils.OrderedJsonObject
 
 /** An action -- add or remove. */
 enum class AddOrRemove {
@@ -33,7 +33,7 @@ data class SourcesToAddOrRemove(
     val sources: ConferenceSourceMap
 ) {
     val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("action", action.toString())
             set<ObjectNode>("sources", sources.toJson())
         }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/SourcesToAddOrRemove.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/SourcesToAddOrRemove.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.conference
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.utils.OrderedJsonObject
 
@@ -31,9 +32,9 @@ data class SourcesToAddOrRemove(
     val action: AddOrRemove,
     val sources: ConferenceSourceMap
 ) {
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
         get() = OrderedJsonObject().apply {
             put("action", action.toString())
-            put("sources", sources.toJson())
+            set<ObjectNode>("sources", sources.toJson())
         }
 }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriDetector.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriDetector.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.jibri
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.xmpp.BaseBrewery
 import org.jitsi.jicofo.xmpp.XmppProvider
 import org.jitsi.utils.OrderedJsonObject
@@ -129,21 +130,21 @@ class JibriDetector(
     fun addHandler(eventHandler: EventHandler) = eventEmitter.addHandler(eventHandler)
     fun removeHandler(eventHandler: EventHandler) = eventEmitter.removeHandler(eventHandler)
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
         get() = OrderedJsonObject().also { debugState ->
-            debugState["is_sip"] = isSip
-            debugState["brewery_jid"] = breweryJid.toString()
+            debugState.put("is_sip", isSip)
+            debugState.put("brewery_jid", breweryJid.toString())
             instances.forEach { instance ->
                 val instanceJson = OrderedJsonObject().apply {
-                    this["health_status"] = instance.status.healthStatus?.status.toString()
-                    this["busy_status"] = instance.status.busyStatus?.status.toString()
+                    put("health_status", instance.status.healthStatus?.status.toString())
+                    put("busy_status", instance.status.busyStatus?.status.toString())
                     jibriInstances[instance.jid]?.let {
-                        this["reports_available"] = it.reportsAvailable
-                        this["last_failed"] = it.lastFailed.toString()
-                        this["last_selected"] = it.lastSelected.toString()
+                        put("reports_available", it.reportsAvailable)
+                        put("last_failed", it.lastFailed.toString())
+                        put("last_selected", it.lastSelected.toString())
                     }
                 }
-                debugState[instance.jid.resourcepart.toString()] = instanceJson
+                debugState.set<ObjectNode>(instance.jid.resourcepart.toString(), instanceJson)
             }
         }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriDetector.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriDetector.kt
@@ -17,10 +17,10 @@
  */
 package org.jitsi.jicofo.jibri
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.xmpp.BaseBrewery
 import org.jitsi.jicofo.xmpp.XmppProvider
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.concurrent.CustomizableThreadFactory
 import org.jitsi.utils.event.AsyncEventEmitter
 import org.jitsi.utils.logging2.createLogger
@@ -131,11 +131,11 @@ class JibriDetector(
     fun removeHandler(eventHandler: EventHandler) = eventEmitter.removeHandler(eventHandler)
 
     val debugState: ObjectNode
-        get() = OrderedJsonObject().also { debugState ->
+        get() = JsonNodeFactory.instance.objectNode().also { debugState ->
             debugState.put("is_sip", isSip)
             debugState.put("brewery_jid", breweryJid.toString())
             instances.forEach { instance ->
-                val instanceJson = OrderedJsonObject().apply {
+                val instanceJson = JsonNodeFactory.instance.objectNode().apply {
                     put("health_status", instance.status.healthStatus?.status.toString())
                     put("busy_status", instance.status.busyStatus?.status.toString())
                     jibriInstances[instance.jid]?.let {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriDetectorMetrics.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriDetectorMetrics.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.jibri
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.utils.OrderedJsonObject
 
@@ -58,15 +59,21 @@ class JibriDetectorMetrics {
             }
         }
 
-        fun appendStats(o: OrderedJsonObject) {
-            o["jibri_detector"] = OrderedJsonObject().apply {
-                put("count", jibriInstanceCount.get())
-                put("available", jibriInstanceAvailableCount.get())
-            }
-            o["sip_jibri_detector"] = OrderedJsonObject().apply {
-                put("count", sipJibriInstanceCount.get())
-                put("available", sipJibriInstanceAvailableCount.get())
-            }
+        fun appendStats(o: ObjectNode) {
+            o.set<ObjectNode>(
+                "jibri_detector",
+                OrderedJsonObject().apply {
+                    put("count", jibriInstanceCount.get())
+                    put("available", jibriInstanceAvailableCount.get())
+                }
+            )
+            o.set<ObjectNode>(
+                "sip_jibri_detector",
+                OrderedJsonObject().apply {
+                    put("count", sipJibriInstanceCount.get())
+                    put("available", sipJibriInstanceAvailableCount.get())
+                }
+            )
         }
     }
 }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriDetectorMetrics.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriDetectorMetrics.kt
@@ -17,9 +17,9 @@
  */
 package org.jitsi.jicofo.jibri
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
-import org.jitsi.utils.OrderedJsonObject
 
 class JibriDetectorMetrics {
     companion object {
@@ -62,14 +62,14 @@ class JibriDetectorMetrics {
         fun appendStats(o: ObjectNode) {
             o.set<ObjectNode>(
                 "jibri_detector",
-                OrderedJsonObject().apply {
+                JsonNodeFactory.instance.objectNode().apply {
                     put("count", jibriInstanceCount.get())
                     put("available", jibriInstanceAvailableCount.get())
                 }
             )
             o.set<ObjectNode>(
                 "sip_jibri_detector",
-                OrderedJsonObject().apply {
+                JsonNodeFactory.instance.objectNode().apply {
                     put("count", sipJibriInstanceCount.get())
                     put("available", sipJibriInstanceAvailableCount.get())
                 }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jigasi/JigasiDetector.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jigasi/JigasiDetector.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.jigasi
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.JicofoConfig
 import org.jitsi.jicofo.bridge.BridgeConfig
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
@@ -25,7 +26,6 @@ import org.jitsi.jicofo.xmpp.XmppProvider
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension
-import org.json.simple.JSONObject
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.EntityFullJid
 import org.jxmpp.jid.Jid
@@ -71,25 +71,25 @@ open class JigasiDetector(
     fun selectSipJigasi(exclude: List<Jid> = emptyList(), preferredRegions: Collection<String> = emptySet()): Jid? =
         selectJigasi(instances, exclude, preferredRegions, localRegion, transcriber = false)
 
-    val stats: JSONObject
-        get() = JSONObject().apply {
-            this["sip_count"] = sipCount.get()
-            this["sip_in_graceful_shutdown_count"] = sipInGracefulShutdownCount.get()
-            this["transcriber_count"] = transcriberCount.get()
+    val stats: ObjectNode
+        get() = OrderedJsonObject().apply {
+            put("sip_count", sipCount.get())
+            put("sip_in_graceful_shutdown_count", sipInGracefulShutdownCount.get())
+            put("transcriber_count", transcriberCount.get())
         }
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
         get() = OrderedJsonObject().also { debugState ->
-            debugState["brewery_jid"] = breweryJid.toString()
+            debugState.put("brewery_jid", breweryJid.toString())
             instances.forEach { instance ->
                 val instanceJson = OrderedJsonObject().apply {
-                    this["supports_sip"] = instance.supportsSip()
-                    this["supports_transcription"] = instance.supportsTranscription()
-                    this["is_in_graceful_shutdown"] = instance.isInGracefulShutdown()
-                    this["participants"] = instance.getParticipantCount()
-                    this["region"] = instance.getRegion() ?: "null"
+                    put("supports_sip", instance.supportsSip())
+                    put("supports_transcription", instance.supportsTranscription())
+                    put("is_in_graceful_shutdown", instance.isInGracefulShutdown())
+                    put("participants", instance.getParticipantCount())
+                    put("region", instance.getRegion() ?: "null")
                 }
-                debugState[instance.jid.resourceOrEmpty.toString()] = instanceJson
+                debugState.set<ObjectNode>(instance.jid.resourceOrEmpty.toString(), instanceJson)
             }
         }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jigasi/JigasiDetector.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jigasi/JigasiDetector.kt
@@ -17,13 +17,13 @@
  */
 package org.jitsi.jicofo.jigasi
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.JicofoConfig
 import org.jitsi.jicofo.bridge.BridgeConfig
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jicofo.xmpp.BaseBrewery
 import org.jitsi.jicofo.xmpp.XmppProvider
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension
 import org.jxmpp.jid.EntityBareJid
@@ -72,17 +72,17 @@ open class JigasiDetector(
         selectJigasi(instances, exclude, preferredRegions, localRegion, transcriber = false)
 
     val stats: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("sip_count", sipCount.get())
             put("sip_in_graceful_shutdown_count", sipInGracefulShutdownCount.get())
             put("transcriber_count", transcriberCount.get())
         }
 
     val debugState: ObjectNode
-        get() = OrderedJsonObject().also { debugState ->
+        get() = JsonNodeFactory.instance.objectNode().also { debugState ->
             debugState.put("brewery_jid", breweryJid.toString())
             instances.forEach { instance ->
-                val instanceJson = OrderedJsonObject().apply {
+                val instanceJson = JsonNodeFactory.instance.objectNode().apply {
                     put("supports_sip", instance.supportsSip())
                     put("supports_transcription", instance.supportsTranscription())
                     put("is_in_graceful_shutdown", instance.isInGracefulShutdown())

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/ktor/Application.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/ktor/Application.kt
@@ -17,6 +17,9 @@
  */
 package org.jitsi.jicofo.ktor
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parseHeaderValue
@@ -58,26 +61,25 @@ import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jicofo.version.CurrentVersionImpl
 import org.jitsi.jicofo.xmpp.ConferenceIqHandler
 import org.jitsi.jicofo.xmpp.XmppCapsStats
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.jitsimeet.ConferenceIq
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.packet.StanzaError
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
 import org.jxmpp.stringprep.XmppStringprepException
 import java.time.Duration
 import org.jitsi.jicofo.ktor.RestConfig.Companion.config as config
 
+private val jsonMapper = jacksonObjectMapper()
+
 class Application(
     private val healthChecker: HealthCheckService?,
     private val conferenceIqHandler: ConferenceIqHandler,
     private val conferenceStore: ConferenceStore,
     private val loadRedistributor: LoadRedistributor,
-    private val getStatsJson: () -> OrderedJsonObject,
-    private val getDebugState: (full: Boolean, confId: EntityBareJid?) -> OrderedJsonObject
+    private val getStatsJson: () -> ObjectNode,
+    private val getDebugState: (full: Boolean, confId: EntityBareJid?) -> JsonNode
 ) {
     private val logger = createLogger()
     private val server = start()
@@ -189,11 +191,11 @@ class Application(
 
     private fun Route.rtcstats() {
         get("/rtcstats") {
-            val rtcstats = JSONObject()
+            val rtcstats = jsonMapper.createObjectNode()
             conferenceStore.getAllConferences().forEach { conference ->
                 if (conference.includeInStatistics() && conference.isRtcStatsEnabled) {
                     conference.meetingId?.let { meetingId ->
-                        rtcstats.put(meetingId, conference.rtcstatsState)
+                        rtcstats.set<ObjectNode>(meetingId, conference.rtcstatsState)
                     }
                 }
             }
@@ -250,17 +252,15 @@ class Application(
                     )
                 }
                 get("conferences") {
-                    val conferencesJson = JSONArray().apply {
-                        conferenceStore.getAllConferences().forEach {
-                            add(it.roomName.toString())
-                        }
+                    val conferencesJson = jsonMapper.createArrayNode().apply {
+                        conferenceStore.getAllConferences().forEach { add(it.roomName.toString()) }
                     }
                     call.respondJson(conferencesJson)
                 }
                 get("conferences-full") {
-                    val conferencesJson = JSONObject().apply {
+                    val conferencesJson = jsonMapper.createObjectNode().apply {
                         conferenceStore.getAllConferences().forEach {
-                            put(it.roomName.toString(), it.debugState)
+                            set<ObjectNode>(it.roomName.toString(), it.debugState)
                         }
                     }
                     call.respondJson(conferencesJson)
@@ -333,14 +333,8 @@ class Application(
     }
 }
 
-private suspend fun RoutingCall.respondJson(json: JSONArray) {
-    respondText(ContentType.Application.Json, HttpStatusCode.OK) { json.toJSONString() }
-}
-private suspend fun RoutingCall.respondJson(json: JSONObject) {
-    respondText(ContentType.Application.Json, HttpStatusCode.OK) { json.toJSONString() }
-}
-private suspend fun RoutingCall.respondJson(json: OrderedJsonObject) {
-    respondText(ContentType.Application.Json, HttpStatusCode.OK) { json.toJSONString() }
+private suspend fun RoutingCall.respondJson(json: JsonNode) {
+    respondText(ContentType.Application.Json, HttpStatusCode.OK) { json.toString() }
 }
 
 private fun translateException(block: () -> MoveResult): MoveResult {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/ktor/Application.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/ktor/Application.kt
@@ -18,8 +18,8 @@
 package org.jitsi.jicofo.ktor
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parseHeaderValue
@@ -70,8 +70,6 @@ import org.jxmpp.jid.impl.JidCreate
 import org.jxmpp.stringprep.XmppStringprepException
 import java.time.Duration
 import org.jitsi.jicofo.ktor.RestConfig.Companion.config as config
-
-private val jsonMapper = jacksonObjectMapper()
 
 class Application(
     private val healthChecker: HealthCheckService?,
@@ -191,7 +189,7 @@ class Application(
 
     private fun Route.rtcstats() {
         get("/rtcstats") {
-            val rtcstats = jsonMapper.createObjectNode()
+            val rtcstats = JsonNodeFactory.instance.objectNode()
             conferenceStore.getAllConferences().forEach { conference ->
                 if (conference.includeInStatistics() && conference.isRtcStatsEnabled) {
                     conference.meetingId?.let { meetingId ->
@@ -252,13 +250,13 @@ class Application(
                     )
                 }
                 get("conferences") {
-                    val conferencesJson = jsonMapper.createArrayNode().apply {
+                    val conferencesJson = JsonNodeFactory.instance.arrayNode().apply {
                         conferenceStore.getAllConferences().forEach { add(it.roomName.toString()) }
                     }
                     call.respondJson(conferencesJson)
                 }
                 get("conferences-full") {
-                    val conferencesJson = jsonMapper.createObjectNode().apply {
+                    val conferencesJson = JsonNodeFactory.instance.objectNode().apply {
                         conferenceStore.getAllConferences().forEach {
                             set<ObjectNode>(it.roomName.toString(), it.debugState)
                         }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
@@ -18,13 +18,11 @@
 package org.jitsi.jicofo.util
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
-
-private val jsonMapper = jacksonObjectMapper()
 
 /** Aggregate lists of preferences coming from a large group of people, such that the resulting aggregated
  * list consists of preference items supported by everyone, and in a rough consensus of preference order.
@@ -125,7 +123,7 @@ class PreferenceAggregator(
                         .forEach { set<ObjectNode>(it.key, it.value.debugState()) }
                 }
             )
-            set<ArrayNode>("aggregate", jsonMapper.createArrayNode().apply { aggregate.forEach { add(it) } })
+            set<ArrayNode>("aggregate", JsonNodeFactory.instance.arrayNode().apply { aggregate.forEach { add(it) } })
         }
     }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
@@ -17,10 +17,14 @@
  */
 package org.jitsi.jicofo.util
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
-import org.json.simple.JSONArray
+
+private val jsonMapper = jacksonObjectMapper()
 
 /** Aggregate lists of preferences coming from a large group of people, such that the resulting aggregated
  * list consists of preference items supported by everyone, and in a rough consensus of preference order.
@@ -110,18 +114,18 @@ class PreferenceAggregator(
         }
     }
 
-    fun debugState() = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = OrderedJsonObject().apply {
         synchronized(lock) {
             put("count", count)
-            put(
+            set<ObjectNode>(
                 "ranks",
                 OrderedJsonObject().apply {
                     this@PreferenceAggregator.values.asSequence()
                         .sortedBy { it.value.rankAggregate }
-                        .forEach { put(it.key, it.value.debugState()) }
+                        .forEach { set<ObjectNode>(it.key, it.value.debugState()) }
                 }
             )
-            put("aggregate", JSONArray().apply { addAll(aggregate) })
+            set<ArrayNode>("aggregate", jsonMapper.createArrayNode().apply { aggregate.forEach { add(it) } })
         }
     }
 
@@ -142,7 +146,7 @@ class PreferenceAggregator(
         var count = 0
         var rankAggregate = 0
 
-        fun debugState() = OrderedJsonObject().apply {
+        fun debugState(): ObjectNode = OrderedJsonObject().apply {
             put("count", count)
             put("rank_aggregate", rankAggregate)
         }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/util/PreferenceAggregator.kt
@@ -20,7 +20,6 @@ package org.jitsi.jicofo.util
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 
@@ -112,12 +111,12 @@ class PreferenceAggregator(
         }
     }
 
-    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         synchronized(lock) {
             put("count", count)
             set<ObjectNode>(
                 "ranks",
-                OrderedJsonObject().apply {
+                JsonNodeFactory.instance.objectNode().apply {
                     this@PreferenceAggregator.values.asSequence()
                         .sortedBy { it.value.rankAggregate }
                         .forEach { set<ObjectNode>(it.key, it.value.debugState()) }
@@ -144,7 +143,7 @@ class PreferenceAggregator(
         var count = 0
         var rankAggregate = 0
 
-        fun debugState(): ObjectNode = OrderedJsonObject().apply {
+        fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             put("count", count)
             put("rank_aggregate", rankAggregate)
         }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/AvModerationHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/AvModerationHandler.kt
@@ -17,9 +17,9 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceStore
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.jitsimeet.JsonMessageExtension
 import org.jivesoftware.smack.StanzaListener
@@ -48,7 +48,7 @@ class AvModerationHandler(
     }
 
     val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("address", avModerationAddress.toString())
         }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/AvModerationHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/AvModerationHandler.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceStore
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
@@ -46,9 +47,9 @@ class AvModerationHandler(
         componentsChanged(xmppProvider.components)
     }
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
         get() = OrderedJsonObject().apply {
-            this["address"] = avModerationAddress.toString()
+            put("address", avModerationAddress.toString())
         }
 
     override fun processStanza(stanza: Stanza) {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.TaskPools
@@ -24,7 +25,6 @@ import org.jitsi.jicofo.auth.AuthenticationAuthority
 import org.jitsi.jicofo.auth.ErrorFactory
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jwt.JitsiToken
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.jitsimeet.ConferenceIq
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler
@@ -64,7 +64,7 @@ class ConferenceIqHandler(
     }
 
     val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("breakout_address", breakoutAddress.toString())
             put("focus_auth_jid", focusAuthJid)
             put("jigasi_enabled", jigasiEnabled)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.auth.AuthenticationAuthority
@@ -62,12 +63,12 @@ class ConferenceIqHandler(
         componentsChanged(xmppProvider.components)
     }
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
         get() = OrderedJsonObject().apply {
-            this["breakout_address"] = breakoutAddress.toString()
-            this["focus_auth_jid"] = focusAuthJid
-            this["jigasi_enabled"] = jigasiEnabled
-            this["auth_authority"] = authAuthority?.javaClass?.simpleName ?: "null"
+            put("breakout_address", breakoutAddress.toString())
+            put("focus_auth_jid", focusAuthJid)
+            put("jigasi_enabled", jigasiEnabled)
+            put("auth_authority", authAuthority?.javaClass?.simpleName ?: "null")
         }
 
     /** Handle a [ConferenceIq] synchronously and return a response. */

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/JigasiIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/JigasiIqHandler.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceStore
 import org.jitsi.jicofo.TaskPools
@@ -25,7 +26,6 @@ import org.jitsi.jicofo.jigasi.JigasiDetector
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jicofo.xmpp.IqProcessingResult.AcceptedWithNoResponse
 import org.jitsi.jicofo.xmpp.IqProcessingResult.RejectedWithError
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.rayo.DialIq
 import org.jivesoftware.smack.AbstractXMPPConnection
@@ -244,7 +244,7 @@ class JigasiIqHandler(
                 "Timeouts for requests sent to jigasi instances."
             )
 
-            fun statsJson() = OrderedJsonObject().apply {
+            fun statsJson() = JsonNodeFactory.instance.objectNode().apply {
                 put("rejected_requests", rejectedRequests.get())
                 put("accepted_requests", acceptedRequests.get())
                 put("retries", retries.get())

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/JigasiIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/JigasiIqHandler.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceStore
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.conference.JitsiMeetConference
@@ -51,7 +52,7 @@ class JigasiIqHandler(
     private val stanzaIdSource = stanzaIdSourceFactory.constructStanzaIdSource()
 
     private val stats = Stats()
-    val statsJson: OrderedJsonObject
+    val statsJson: ObjectNode
         get() = stats.toJson()
 
     override fun handleRequest(request: IqRequest<DialIq>): IqProcessingResult {
@@ -216,8 +217,8 @@ class JigasiIqHandler(
         fun allInstancesFailed() = requestsFailedAllInstancesFailed.incrementAndGet()
 
         fun toJson() = statsJson().apply {
-            this["requests_failed_no_instance"] = requestsFailedNoInstanceAvailable.get()
-            this["requests_failed_xmpp_not_connected"] = requestsFailedXmppNotConnected.get()
+            put("requests_failed_no_instance", requestsFailedNoInstanceAvailable.get())
+            put("requests_failed_xmpp_not_connected", requestsFailedXmppNotConnected.get())
         }
 
         companion object {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/RoomMetadataHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/RoomMetadataHandler.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceStore
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
@@ -41,9 +42,9 @@ class RoomMetadataHandler(
         componentsChanged(xmppProvider.components)
     }
 
-    val debugState: OrderedJsonObject
+    val debugState: ObjectNode
         get() = OrderedJsonObject().apply {
-            this["address"] = componentAddress.toString()
+            put("address", componentAddress.toString())
         }
 
     private fun doProcess(jsonMessage: JsonMessageExtension) {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/RoomMetadataHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/RoomMetadataHandler.kt
@@ -17,9 +17,9 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceStore
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.jitsimeet.JsonMessageExtension
 import org.jivesoftware.smack.StanzaListener
@@ -43,7 +43,7 @@ class RoomMetadataHandler(
     }
 
     val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("address", componentAddress.toString())
         }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceStore
 import org.jitsi.jicofo.FocusManager
@@ -25,7 +26,6 @@ import org.jitsi.jicofo.jigasi.JigasiConfig
 import org.jitsi.jicofo.jigasi.JigasiDetector
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jicofo.xmpp.jingle.JingleIqRequestHandler
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 
 class XmppServices(
@@ -94,7 +94,7 @@ class XmppServices(
         null
     }
     val jigasiStats: ObjectNode
-        get() = jigasiIqHandler?.statsJson ?: OrderedJsonObject()
+        get() = jigasiIqHandler?.statsJson ?: JsonNodeFactory.instance.objectNode()
 
     val avModerationHandler = AvModerationHandler(clientConnection, conferenceStore)
     val roomMetadataHandler = RoomMetadataHandler(clientConnection, conferenceStore)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/XmppServices.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceStore
 import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.auth.AbstractAuthAuthority
@@ -92,7 +93,7 @@ class XmppServices(
     } else {
         null
     }
-    val jigasiStats: OrderedJsonObject
+    val jigasiStats: ObjectNode
         get() = jigasiIqHandler?.statsJson ?: OrderedJsonObject()
 
     val avModerationHandler = AvModerationHandler(clientConnection, conferenceStore)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomRoleManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomRoleManager.kt
@@ -17,11 +17,11 @@
  */
 package org.jitsi.jicofo.xmpp.muc
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.auth.AuthenticationAuthority
 import org.jitsi.jicofo.auth.AuthenticationListener
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.utils.queue.PacketQueue
 
@@ -41,7 +41,7 @@ sealed class ChatRoomRoleManager(
     open fun stop() {}
     open fun grantOwnership() {}
 
-    open val debugState: ObjectNode = OrderedJsonObject()
+    open val debugState: ObjectNode = JsonNodeFactory.instance.objectNode()
 
     protected val queue = PacketQueue<Runnable>(
         Integer.MAX_VALUE,
@@ -107,7 +107,7 @@ class AutoOwnerRoleManager(chatRoom: ChatRoom) : ChatRoomRoleManager(chatRoom) {
     }
 
     override val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("class", this@AutoOwnerRoleManager.javaClass.simpleName)
             put("owner", owner?.jid?.toString() ?: "null")
         }
@@ -165,7 +165,7 @@ class AuthenticationRoleManager(
 
     override fun stop() = authenticationAuthority.removeAuthenticationListener(authenticationListener)
 
-    override val debugState: ObjectNode = OrderedJsonObject().apply {
+    override val debugState: ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("class", this@AuthenticationRoleManager.javaClass.simpleName)
     }
 }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomRoleManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomRoleManager.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.xmpp.muc
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.auth.AuthenticationAuthority
 import org.jitsi.jicofo.auth.AuthenticationListener
@@ -40,7 +41,7 @@ sealed class ChatRoomRoleManager(
     open fun stop() {}
     open fun grantOwnership() {}
 
-    open val debugState: OrderedJsonObject = OrderedJsonObject()
+    open val debugState: ObjectNode = OrderedJsonObject()
 
     protected val queue = PacketQueue<Runnable>(
         Integer.MAX_VALUE,
@@ -105,7 +106,7 @@ class AutoOwnerRoleManager(chatRoom: ChatRoom) : ChatRoomRoleManager(chatRoom) {
         }
     }
 
-    override val debugState
+    override val debugState: ObjectNode
         get() = OrderedJsonObject().apply {
             put("class", this@AutoOwnerRoleManager.javaClass.simpleName)
             put("owner", owner?.jid?.toString() ?: "null")
@@ -164,7 +165,7 @@ class AuthenticationRoleManager(
 
     override fun stop() = authenticationAuthority.removeAuthenticationListener(authenticationListener)
 
-    override val debugState = OrderedJsonObject().apply {
+    override val debugState: ObjectNode = OrderedJsonObject().apply {
         put("class", this@AuthenticationRoleManager.javaClass.simpleName)
     }
 }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/DebugStateTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/DebugStateTest.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.fasterxml.jackson.databind.JsonNode
 import io.kotest.core.spec.style.ShouldSpec
 import io.mockk.every
 import io.mockk.mockk
@@ -24,9 +25,7 @@ import org.jitsi.jicofo.jigasi.JigasiDetector
 import org.jitsi.jicofo.xmpp.muc.ChatRoomImpl
 import org.jitsi.jicofo.xmpp.muc.ChatRoomMember
 import org.jitsi.jicofo.xmpp.muc.ChatRoomMemberImpl
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension
-import org.json.simple.parser.JSONParser
 import org.jxmpp.jid.EntityFullJid
 import org.jxmpp.jid.impl.JidCreate
 import java.util.logging.Level
@@ -70,7 +69,7 @@ class DebugStateTest : ShouldSpec() {
                 jigasiChatMember(JidCreate.entityFullFrom("JigasiBrewery@example.com/jigasi-1"))
             )
             jigasiDetector.debugState.shouldBeValidJson()
-            println(jigasiDetector.debugState.toJSONString())
+            println(jigasiDetector.debugState.toString())
         }
         context("Jibri detector") {
             val jibriDetector = JibriDetector(
@@ -85,13 +84,13 @@ class DebugStateTest : ShouldSpec() {
                 jibriDetector
             )
             jibriDetector.debugState.shouldBeValidJson()
-            println(jibriDetector.debugState.toJSONString())
+            println(jibriDetector.debugState.toString())
         }
     }
 }
 
-fun OrderedJsonObject.shouldBeValidJson() {
-    JSONParser().parse(this.toJSONString())
+fun JsonNode.shouldBeValidJson() {
+    this.toString()
 }
 
 private fun jigasiChatMember(jid: EntityFullJid) = mockk<ChatRoomMember> {

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranscriptionTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranscriptionTest.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo.bridge.colibri
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.core.test.TestCase
@@ -34,7 +35,6 @@ import org.jitsi.jicofo.conference.inPlaceScheduledExecutor
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
 import org.jitsi.jicofo.mock.MockXmppConnection
 import org.jitsi.jicofo.mock.TestColibri2Server
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.TemplatedUrl
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifyIQ
@@ -65,7 +65,7 @@ class ColibriTranscriptionTest : ShouldSpec() {
         every { jid } returns JidCreate.from("jvb@example.com/jvb1")
         every { relayId } returns null
         every { isOperational } returns true
-        every { debugState } returns OrderedJsonObject()
+        every { debugState } returns JsonNodeFactory.instance.objectNode()
         every { region } returns "us-east"
     }
 

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/ConferenceTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/ConferenceTest.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.jicofo.conference
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
@@ -38,7 +39,6 @@ import org.jitsi.jicofo.xmpp.jingle.JingleSession
 import org.jitsi.jicofo.xmpp.muc.ChatRoomMember
 import org.jitsi.jicofo.xmpp.muc.MemberRole
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifyIQ
 import org.jitsi.xmpp.extensions.jingle.ContentPacketExtension
 import org.jitsi.xmpp.extensions.jingle.DtlsFingerprintPacketExtension
@@ -84,7 +84,7 @@ class ConferenceTest : ShouldSpec() {
                 every { bridgeSelector } returns mockk(relaxed = true) {
                     every { selectBridge(any(), any(), any()) } returns mockk(relaxed = true) {
                         every { jid } returns JidCreate.from("jvb@example.com/jvb1")
-                        every { debugState } returns OrderedJsonObject()
+                        every { debugState } returns JsonNodeFactory.instance.objectNode()
                     }
                 }
                 every { jingleHandler } returns mockk(relaxed = true) {

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/source/ConferenceSourceMapTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/source/ConferenceSourceMapTest.kt
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
@@ -28,9 +30,6 @@ import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.jingle.RtpDescriptionPacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
 import org.jitsi.xmpp.extensions.jitsimeet.SSRCInfoPacketExtension
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
-import shouldBeValidJson
 import java.lang.UnsupportedOperationException
 
 @Suppress("NAME_SHADOWING")
@@ -245,10 +244,10 @@ class ConferenceSourceMapTest : ShouldSpec() {
                 jvb to jvbEndpointSourceSet
             )
             val jsonString = conferenceSourceMap.compactJson()
-            val json = JSONParser().parse(jsonString)
-            json.shouldBeInstanceOf<JSONObject>()
-            json.size shouldBe 3
-            json.keys shouldBe setOf(endpointId1, endpointId2, "jvb")
+            val json = jacksonObjectMapper().readTree(jsonString)
+            json.shouldBeInstanceOf<ObjectNode>()
+            json.size() shouldBe 3
+            json.fieldNames().asSequence().toSet() shouldBe setOf(endpointId1, endpointId2, "jvb")
         }
         context("Debug json") {
             val conferenceSourceMap = ConferenceSourceMap(

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSetTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSetTest.kt
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
@@ -26,9 +28,6 @@ import org.jitsi.utils.MediaType.VIDEO
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.jingle.RtpDescriptionPacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
 
 @Suppress("NAME_SHADOWING")
 class EndpointSourceSetTest : ShouldSpec() {
@@ -92,12 +91,12 @@ class EndpointSourceSetTest : ShouldSpec() {
             }
             context("Compact JSON") {
                 // See the documentation of [EndpointSourceSet.compactJson] for the expected JSON format.
-                val json = JSONParser().parse(sourceSet.compactJson)
-                json.shouldBeInstanceOf<JSONArray>()
+                val json = jacksonObjectMapper().readTree(sourceSet.compactJson)
+                json.shouldBeInstanceOf<ArrayNode>()
 
                 val videoSourceList = json[0]
-                videoSourceList.shouldBeInstanceOf<JSONArray>()
-                videoSourceList.map { (it as JSONObject).toMap() }.toSet() shouldBe setOf(
+                videoSourceList.shouldBeInstanceOf<ArrayNode>()
+                videoSourceList.map { node -> mapOf("s" to node["s"].asLong()) }.toSet() shouldBe setOf(
                     mapOf("s" to 1L),
                     mapOf("s" to 2L),
                     mapOf("s" to 3L),
@@ -107,8 +106,10 @@ class EndpointSourceSetTest : ShouldSpec() {
                 )
 
                 val videoSsrcGroups = json[1]
-                videoSsrcGroups.shouldBeInstanceOf<JSONArray>()
-                videoSsrcGroups.map { (it as JSONArray).toList() }.toSet() shouldBe setOf(
+                videoSsrcGroups.shouldBeInstanceOf<ArrayNode>()
+                videoSsrcGroups.map { groupNode ->
+                    groupNode.map { if (it.isTextual) it.asText() else it.asInt() }
+                }.toSet() shouldBe setOf(
                     listOf("s", 1, 2, 3),
                     listOf("f", 1, 4),
                     listOf("f", 2, 5),
@@ -116,13 +117,13 @@ class EndpointSourceSetTest : ShouldSpec() {
                 )
 
                 val audioSourceList = json[2]
-                audioSourceList.shouldBeInstanceOf<JSONArray>()
-                audioSourceList.map { (it as JSONObject).toMap() }.toSet() shouldBe setOf(
+                audioSourceList.shouldBeInstanceOf<ArrayNode>()
+                audioSourceList.map { node -> mapOf("s" to node["s"].asLong()) }.toSet() shouldBe setOf(
                     mapOf("s" to 7L)
                 )
 
                 // No audio source groups encoded.
-                json.size shouldBe 3
+                json.size() shouldBe 3
             }
         }
     }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/source/SourceSignalingTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/source/SourceSignalingTest.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.jicofo.conference.source
 
+import com.fasterxml.jackson.databind.JsonNode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -23,8 +24,6 @@ import org.jitsi.jicofo.conference.AddOrRemove.Add
 import org.jitsi.jicofo.conference.AddOrRemove.Remove
 import org.jitsi.jicofo.conference.SourceSignaling
 import org.jitsi.utils.MediaType
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
 
 class SourceSignalingTest : ShouldSpec() {
     override fun isolationMode() = IsolationMode.InstancePerLeaf
@@ -164,4 +163,4 @@ class SourceSignalingTest : ShouldSpec() {
     }
 }
 
-fun JSONObject.shouldBeValidJson() = JSONParser().parse(this.toJSONString())
+fun JsonNode.shouldBeValidJson() = this.toString()

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.jicofo.jibri
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
@@ -29,7 +30,6 @@ import org.jitsi.jicofo.xmpp.muc.ChatRoom
 import org.jitsi.jicofo.xmpp.muc.ChatRoomMember
 import org.jitsi.jicofo.xmpp.muc.MemberRole
 import org.jitsi.jicofo.xmpp.muc.SourceInfo
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.mins
 import org.jitsi.utils.ms
 import org.jitsi.utils.time.FakeClock
@@ -145,7 +145,7 @@ class JibriChatRoomMember(
     override val statsId: String? get() = TODO("Not yet implemented")
     override val videoCodecs: List<String>? get() = TODO("Not yet implemented")
     override val features: Set<Features> get() = TODO("Not yet implemented")
-    override val debugState: OrderedJsonObject get() = TODO("Not yet implemented")
+    override val debugState: ObjectNode get() = TODO("Not yet implemented")
 
     var idle: Boolean = true
     var healthy: Boolean = true

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/mock/MockChatRoom.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/mock/MockChatRoom.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.jicofo.mock
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.mockk.every
 import io.mockk.mockk
 import org.jitsi.jicofo.xmpp.Features
@@ -22,7 +23,6 @@ import org.jitsi.jicofo.xmpp.XmppProvider
 import org.jitsi.jicofo.xmpp.muc.ChatRoom
 import org.jitsi.jicofo.xmpp.muc.ChatRoomListener
 import org.jitsi.jicofo.xmpp.muc.ChatRoomMember
-import org.jitsi.utils.OrderedJsonObject
 import org.jivesoftware.smack.packet.ExtensionElement
 import java.lang.IllegalArgumentException
 import javax.xml.namespace.QName
@@ -35,7 +35,7 @@ class MockChatRoom(val xmppProvider: XmppProvider) {
         every { members } returns memberList
         every { memberCount } answers { memberList.size }
         every { xmppProvider } returns this@MockChatRoom.xmppProvider
-        every { debugState } returns OrderedJsonObject()
+        every { debugState } returns JsonNodeFactory.instance.objectNode()
         every { getChatMember(any()) } answers { memberList.find { it.occupantJid == arg(0) } }
     }
 
@@ -44,7 +44,7 @@ class MockChatRoom(val xmppProvider: XmppProvider) {
             every { name } returns id
             every { chatRoom } returns this@MockChatRoom.chatRoom
             every { features } returns Features.defaultFeatures
-            every { debugState } returns OrderedJsonObject()
+            every { debugState } returns JsonNodeFactory.instance.objectNode()
             every { presence } returns mockk {
                 every { status } returns null
                 every { getExtension(any<String>()) } returns null

--- a/pom.xml
+++ b/pom.xml
@@ -83,19 +83,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.googlecode.json-simple</groupId>
-        <artifactId>json-simple</artifactId>
-        <version>1.1.1</version>
-        <!-- json-simple 1.1.1 incorrectly listed junit as a compile dependency rather than a test dependency.
-       This has been fixed in its github repo but a new release hasn't been pushed to maven. -->
-        <exclusions>
-          <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.12.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <kotest.version>5.7.2</kotest.version>
     <slf4j.version>1.7.32</slf4j.version>
     <jackson.version>2.19.0</jackson.version>
-    <jitsi.utils.version>1.0-147-g12d0b20</jitsi.utils.version>
-    <jicoco.version>1.1-170-g3f48c50</jicoco.version>
+    <jitsi.utils.version>1.0-150-g4ab9a3b</jitsi.utils.version>
+    <jicoco.version>1.1-171-gb3b9e1f</jicoco.version>
     <ktlint-maven-plugin.version>3.0.0</ktlint-maven-plugin.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-106-g75c88a9</version>
+        <version>1.0-112-gfe4b514</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Replace the `org.json.simple` dependency with Jackson (`jackson-databind`, `jackson-module-kotlin`).

- Debug state methods now return `JsonNode`
- Update `jitsi-utils` to `1.0-SNAPSHOT`