### PR TITLE
feat: Live audio translation support

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
@@ -34,7 +34,13 @@ data class Source(
     /** Optional msid */
     val msid: String? = null,
     /** Optional video type (camera or desktop) */
-    val videoType: VideoType? = null
+    val videoType: VideoType? = null,
+    /**
+     * Whether this source is synthetic, i.e. injected by the server (e.g. a translated audio stream). Synthetic
+     * sources are created by jicofo (not parsed from client Jingle); the flag is carried to the bridge on the
+     * Colibri2 media-source element (see [org.jitsi.jicofo.bridge.colibri.toColibriMediaSources]).
+     */
+    val synthetic: Boolean = false
 ) {
     /** Create a [Source] from an XML extension. */
     constructor(mediaType: MediaType, sourcePacketExtension: SourcePacketExtension) : this(

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
@@ -102,6 +102,9 @@ data class Source(
         put("name", name ?: "null")
         put("msid", msid ?: "null")
         put("videoType", videoType.toString())
+        if (synthetic) {
+            put("synthetic", true)
+        }
     }
 
     companion object {

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
@@ -80,7 +80,9 @@ data class RoomMetadata(val metadata: Metadata?) : JsonMessage(TYPE) {
         val participantsSoftLimit: Int? = null,
         val visitorsEnabled: Boolean? = null,
         val lobbyEnabled: Boolean? = null,
-        val transcription: Transcription? = null
+        val transcription: Transcription? = null,
+        /** Aggregated live-translation requests: sender endpoint id -> set of requested language codes. */
+        val audioTranslationRequests: Map<String, List<String>>? = null
     ) {
         @JsonIgnoreProperties(ignoreUnknown = true)
         data class Visitors(val live: Boolean?)

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
@@ -81,6 +81,11 @@ data class RoomMetadata(val metadata: Metadata?) : JsonMessage(TYPE) {
         val visitorsEnabled: Boolean? = null,
         val lobbyEnabled: Boolean? = null,
         val transcription: Transcription? = null,
+        /**
+         * Per-room live-translation connect config (e.g. a per-customer usage token as an HTTP header,
+         * delivered to jicofo on the admin-only metadata path). Mirrors [transcription].
+         */
+        val translation: Translation? = null,
         /** Aggregated live-translation requests: sender endpoint id -> set of requested language codes. */
         val audioTranslationRequests: Map<String, List<String>>? = null
     ) {
@@ -96,6 +101,11 @@ data class RoomMetadata(val metadata: Metadata?) : JsonMessage(TYPE) {
         @JsonIgnoreProperties(ignoreUnknown = true)
         data class Transcription(
             val urlParams: Map<String, String>? = null,
+            val httpHeaders: Map<String, String>? = null
+        )
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        data class Translation(
             val httpHeaders: Map<String, String>? = null
         )
     }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
@@ -69,6 +69,9 @@ interface ChatRoom {
     /** Transcription configuration from room metadata. */
     val transcription: RoomMetadata.Metadata.Transcription?
 
+    /** Translation configuration from room metadata (e.g. per-customer connect headers). */
+    val translation: RoomMetadata.Metadata.Translation?
+
     val debugState: ObjectNode
 
     /** Returns the number of members that currently have their audio sources unmuted. */

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -405,6 +405,9 @@ class ChatRoomImpl(
                     roomMetadata.metadata.asyncTranscription == true
             )
         }
+        eventEmitter.fireEvent {
+            audioTranslationRequestsChanged(roomMetadata.metadata?.audioTranslationRequests ?: emptyMap())
+        }
         roomMetadataLatch.countDown()
     }
 

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -202,6 +202,10 @@ class ChatRoomImpl(
     override var transcription: RoomMetadata.Metadata.Transcription? = null
         private set
 
+    /** Translation configuration from room metadata. */
+    override var translation: RoomMetadata.Metadata.Translation? = null
+        private set
+
     /**
      * List of user IDs which the room is configured to allow to be moderators.
      */
@@ -399,6 +403,7 @@ class ChatRoomImpl(
             eventEmitter.fireEvent { startMutedChanged(it.audio == true, it.video == true) }
         }
         transcription = roomMetadata.metadata?.transcription
+        translation = roomMetadata.metadata?.translation
         eventEmitter.fireEvent {
             transcribingEnabledChanged(
                 roomMetadata.metadata?.recording?.isTranscribingEnabled == true &&

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomListener.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomListener.kt
@@ -30,6 +30,11 @@ interface ChatRoomListener {
     fun numAudioSendersChanged(numAudioSenders: Int) {}
     fun numVideoSendersChanged(numVideoSenders: Int) {}
     fun transcribingEnabledChanged(enabled: Boolean) {}
+
+    /**
+     * The aggregated live-translation request map changed: sender endpoint id -> set of requested language codes.
+     */
+    fun audioTranslationRequestsChanged(requests: Map<String, List<String>>) {}
 }
 
 /** A class with the default kotlin method implementations (to avoid using @JvmDefault) **/

--- a/jicofo-common/src/test/kotlin/org/jitsi/jicofo/xmpp/JsonMessageTest.kt
+++ b/jicofo-common/src/test/kotlin/org/jitsi/jicofo/xmpp/JsonMessageTest.kt
@@ -108,6 +108,38 @@ class JsonMessageTest : ShouldSpec() {
                         type shouldBe "room_metadata"
                     }
                 }
+                context("With audioTranslationRequests") {
+                    JsonMessage.parse(
+                        """
+                            {
+                                "type": "room_metadata",
+                                "metadata": {
+                                    "audioTranslationRequests": {
+                                        "aaaaaaaa": ["en", "es"],
+                                        "bbbbbbbb": ["fr"]
+                                    }
+                                }
+                            }
+                        """.trimIndent()
+                    ).apply {
+                        shouldBeInstanceOf<RoomMetadata>()
+                        metadata!!.audioTranslationRequests.apply {
+                            shouldNotBeNull()
+                            this!!["aaaaaaaa"] shouldBe listOf("en", "es")
+                            this["bbbbbbbb"] shouldBe listOf("fr")
+                        }
+                    }
+                }
+                context("Without audioTranslationRequests") {
+                    JsonMessage.parse(
+                        """
+                            { "type": "room_metadata", "metadata": {} }
+                        """.trimIndent()
+                    ).apply {
+                        shouldBeInstanceOf<RoomMetadata>()
+                        metadata!!.audioTranslationRequests shouldBe null
+                    }
+                }
             }
             context("Invalid") {
                 context("Missing type") {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
@@ -23,6 +23,7 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.TemplatedUrl
 import org.jitsi.utils.logging2.createLogger
+import java.time.Duration
 
 /** Configuration for live audio translation (the websocket endpoint a bridge connects to). */
 class TranslationConfig private constructor() {
@@ -67,6 +68,19 @@ class TranslationConfig private constructor() {
      */
     val maxLanguagesPerConnect: Int by config {
         "jicofo.translation.max-languages-per-connect".from(JitsiConfig.newConfig)
+    }
+
+    /** Whether the bridge should send keepalive pings on the translator connect (to avoid idle-timeout). */
+    val pingEnabled: Boolean by config {
+        "jicofo.translation.ping.enabled".from(JitsiConfig.newConfig)
+    }
+
+    val pingInterval: Duration by config {
+        "jicofo.translation.ping.interval".from(JitsiConfig.newConfig)
+    }
+
+    val pingTimeout: Duration by config {
+        "jicofo.translation.ping.timeout".from(JitsiConfig.newConfig)
     }
 
     fun getUrl(meetingId: String): TemplatedUrl? = urlTemplate?.let {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
@@ -17,6 +17,7 @@
  */
 package org.jitsi.jicofo
 
+import com.typesafe.config.ConfigObject
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.TemplatedUrl
@@ -34,6 +35,19 @@ class TranslationConfig private constructor() {
             it
         }
     }
+
+    private val httpHeadersProp: Map<String, String>? by optionalconfig {
+        "jicofo.translation.http-headers".from(JitsiConfig.newConfig)
+            .convertFrom<ConfigObject> { cfg ->
+                cfg.entries.associate { entry ->
+                    entry.key to entry.value.unwrapped().toString()
+                }
+            }
+    }
+
+    /** Static HTTP headers added to the translator connect (e.g. Cloudflare Access service-token credentials). */
+    val httpHeaders: Map<String, String>
+        get() = httpHeadersProp ?: emptyMap()
 
     /** Whether live translation is configured (an URL template is set). */
     val enabled: Boolean

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
@@ -1,0 +1,55 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2024 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo
+
+import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.optionalconfig
+import org.jitsi.utils.TemplatedUrl
+import org.jitsi.utils.logging2.createLogger
+
+/** Configuration for live audio translation (the websocket endpoint a bridge connects to). */
+class TranslationConfig private constructor() {
+    val logger = createLogger()
+
+    private val urlTemplate: String? by optionalconfig {
+        "jicofo.translation.url-template".from(JitsiConfig.newConfig).transformedBy {
+            if (!it.contains("{{$MEETING_ID_TEMPLATE}}")) {
+                logger.warn("Translator URL template does not contain $MEETING_ID_TEMPLATE")
+            }
+            it
+        }
+    }
+
+    /** Whether live translation is configured (an URL template is set). */
+    val enabled: Boolean
+        get() = urlTemplate != null
+
+    fun getUrl(meetingId: String): TemplatedUrl? = urlTemplate?.let {
+        TemplatedUrl(it, requiredKeys = setOf(REGION_TEMPLATE)).apply {
+            set(MEETING_ID_TEMPLATE, meetingId)
+        }
+    }
+
+    companion object {
+        @JvmField
+        val config = TranslationConfig()
+
+        const val MEETING_ID_TEMPLATE = "MEETING_ID"
+        const val REGION_TEMPLATE = "REGION"
+    }
+}

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
@@ -104,5 +104,24 @@ class TranslationConfig private constructor() {
 
         const val MEETING_ID_TEMPLATE = "MEETING_ID"
         const val REGION_TEMPLATE = "REGION"
+
+        /**
+         * Merge per-room translation headers (from room metadata) over the static config headers, with the
+         * per-room values taking precedence. Mirrors [TranscriptionConfig.processTranscriptionMetadata].
+         *
+         * Returns null when there are no per-room headers, so callers fall back to the static config headers
+         * (i.e. `merged ?: TranslationConfig.config.httpHeaders`).
+         *
+         * @param translation the translation metadata from room metadata (e.g. a per-customer usage token)
+         * @param baseHeaders the static headers from configuration
+         */
+        @JvmStatic
+        fun processTranslationMetadata(
+            translation: org.jitsi.jicofo.xmpp.RoomMetadata.Metadata.Translation?,
+            baseHeaders: Map<String, String>
+        ): Map<String, String>? {
+            val customHeaders = translation?.httpHeaders ?: return null
+            return baseHeaders.toMutableMap().apply { putAll(customHeaders) }
+        }
     }
 }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
@@ -19,6 +19,7 @@ package org.jitsi.jicofo
 
 import com.typesafe.config.ConfigObject
 import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.TemplatedUrl
 import org.jitsi.utils.logging2.createLogger
@@ -53,10 +54,34 @@ class TranslationConfig private constructor() {
     val enabled: Boolean
         get() = urlTemplate != null
 
+    /** How translation connects are placed on bridges. */
+    val mode: Mode by config {
+        "jicofo.translation.mode".from(JitsiConfig.newConfig).convertFrom<String> {
+            Mode.valueOf(it.uppercase().replace('-', '_'))
+        }
+    }
+
+    /**
+     * The maximum number of target languages handled by a single translation connect. Only applies in [Mode.PER_SOURCE]
+     * (a sender requesting more is split across multiple connects on its bridge); ignored in [Mode.SINGLE_BRIDGE].
+     */
+    val maxLanguagesPerConnect: Int by config {
+        "jicofo.translation.max-languages-per-connect".from(JitsiConfig.newConfig)
+    }
+
     fun getUrl(meetingId: String): TemplatedUrl? = urlTemplate?.let {
         TemplatedUrl(it, requiredKeys = setOf(REGION_TEMPLATE)).apply {
             set(MEETING_ID_TEMPLATE, meetingId)
         }
+    }
+
+    /** How translation connects are placed on bridges. */
+    enum class Mode {
+        /** Each sender's audio is translated on its own (local) bridge, split by [maxLanguagesPerConnect]. */
+        PER_SOURCE,
+
+        /** A single connect on one selected bridge handles all sources and languages. */
+        SINGLE_BRIDGE
     }
 
     companion object {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -67,9 +67,9 @@ class Colibri2Session(
     private var transcriberUrlParams: Map<String, String>? = null,
     /** The live-translation websocket URL template, or null when translation is disabled on this session. */
     private var translatorUrl: TemplatedUrl? = null,
-    /** Source names the translator should receive (the senders' audio to translate). */
+    /** Source names requested from the translator (the synthetic, language-encoded sources it produces). */
     private var translatorRequests: List<String> = emptyList(),
-    /** Source names the translator produces (the synthetic, language-encoded sources). */
+    /** Source names exported to the translator (the senders' audio to translate). */
     private var translatorExports: List<String> = emptyList()
 ) : CascadeNode<Colibri2Session, Colibri2Session.Relay> {
     private val logger = createChildLogger(parentLogger).apply {
@@ -684,8 +684,8 @@ private fun createConnect(
 }
 
 /**
- * Build a translator [Connect]: it receives the senders' audio ([requests]) and produces the synthetic,
- * language-encoded translated sources ([exports]).
+ * Build a translator [Connect]: the bridge exports the senders' audio to it ([exports]) and requests back the
+ * synthetic, language-encoded translated sources it produces ([requests]).
  */
 private fun createTranslatorConnect(url: URI, requests: List<String>, exports: List<String>) = Connect(
     url = url,

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.TranscriptionConfig
+import org.jitsi.jicofo.TranslationConfig
 import org.jitsi.jicofo.bridge.Bridge
 import org.jitsi.jicofo.bridge.CascadeLink
 import org.jitsi.jicofo.bridge.CascadeNode
@@ -63,7 +64,13 @@ class Colibri2Session(
     private var transcriberUrl: TemplatedUrl?,
     parentLogger: Logger,
     private var transcriberCustomHeaders: Map<String, String>? = null,
-    private var transcriberUrlParams: Map<String, String>? = null
+    private var transcriberUrlParams: Map<String, String>? = null,
+    /** The live-translation websocket URL template, or null when translation is disabled on this session. */
+    private var translatorUrl: TemplatedUrl? = null,
+    /** Source names the translator should receive (the senders' audio to translate). */
+    private var translatorRequests: List<String> = emptyList(),
+    /** Source names the translator produces (the synthetic, language-encoded sources). */
+    private var translatorExports: List<String> = emptyList()
 ) : CascadeNode<Colibri2Session, Colibri2Session.Relay> {
     private val logger = createChildLogger(parentLogger).apply {
         bridge.jid.resourceOrNull?.toString()?.let { addContext("bridge", it) }
@@ -224,11 +231,19 @@ class Colibri2Session(
                     )
                 )
             }
+            translatorUrl?.let {
+                logger.info("Adding connect for translator")
+                addConnect(createTranslatorConnect(resolveTranslatorUrl(it), translatorRequests, translatorExports))
+            }
         }
     }
 
     private fun resolveTranscriberUrl(urlTemplate: TemplatedUrl): URI {
         return urlTemplate.resolve(TranscriptionConfig.REGION_TEMPLATE, bridge.region ?: "")
+    }
+
+    private fun resolveTranslatorUrl(urlTemplate: TemplatedUrl): URI {
+        return urlTemplate.resolve(TranslationConfig.REGION_TEMPLATE, bridge.region ?: "")
     }
 
     fun setTranscriberUrl(
@@ -270,6 +285,30 @@ class Colibri2Session(
         } else {
             logger.info("No change in audio record URL.")
         }
+    }
+
+    /**
+     * Enable, update, or disable the live-translation connect on this session.
+     *
+     * Unlike the transcriber, the request list changes over the lifetime of the connection, so the connect is
+     * (re)sent on every call when [url] is non-null. Passing a null [url] disables translation.
+     *
+     * Note: translation and transcription are managed independently here; the bridge treats the <connects> element as
+     * authoritative, so a session is not expected to run both a transcriber and a translator connect simultaneously.
+     */
+    fun setTranslator(url: TemplatedUrl?, requests: List<String>, exports: List<String>) {
+        translatorUrl = url
+        translatorRequests = requests
+        translatorExports = exports
+        val request = createRequest(create = false)
+        if (url != null) {
+            logger.info("Setting translator connect, requests=$requests exports=$exports")
+            request.addConnect(createTranslatorConnect(resolveTranslatorUrl(url), requests, exports))
+        } else {
+            logger.info("Removing translator connect")
+            request.setEmptyConnects()
+        }
+        sendRequest(request.build(), "setTranslator")
     }
 
     /**
@@ -642,4 +681,18 @@ private fun createConnect(
     if (pingEnabled) {
         setPing(pingInterval, pingTimeout)
     }
+}
+
+/**
+ * Build a translator [Connect]: it receives the senders' audio ([requests]) and produces the synthetic,
+ * language-encoded translated sources ([exports]).
+ */
+private fun createTranslatorConnect(url: URI, requests: List<String>, exports: List<String>) = Connect(
+    url = url,
+    type = Connect.Types.TRANSLATOR,
+    protocol = Connect.Protocols.MEDIAJSON,
+    audio = true
+).apply {
+    setRequests(requests)
+    setExports(exports)
 }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -695,4 +695,7 @@ private fun createTranslatorConnect(url: URI, requests: List<String>, exports: L
 ).apply {
     setRequests(requests)
     setExports(exports)
+    TranslationConfig.config.httpHeaders.forEach { (name, value) ->
+        addHttpHeader(name, value)
+    }
 }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -20,8 +20,6 @@ package org.jitsi.jicofo.bridge.colibri
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.OctoConfig
-import org.jitsi.jicofo.TranscriptionConfig
-import org.jitsi.jicofo.TranslationConfig
 import org.jitsi.jicofo.bridge.Bridge
 import org.jitsi.jicofo.bridge.CascadeLink
 import org.jitsi.jicofo.bridge.CascadeNode
@@ -30,7 +28,6 @@ import org.jitsi.jicofo.codec.Config
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.TemplatedUrl
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.xmpp.extensions.colibri.WebSocketPacketExtension
@@ -39,7 +36,6 @@ import org.jitsi.xmpp.extensions.colibri2.Colibri2Error
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Relay
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifiedIQ
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifyIQ
-import org.jitsi.xmpp.extensions.colibri2.Connect
 import org.jitsi.xmpp.extensions.colibri2.Endpoints
 import org.jitsi.xmpp.extensions.colibri2.InitialLastN
 import org.jitsi.xmpp.extensions.colibri2.Media
@@ -51,7 +47,6 @@ import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 import org.jivesoftware.smack.StanzaCollector
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smackx.muc.MUCRole
-import java.net.URI
 import java.util.Collections.singletonList
 import java.util.UUID
 
@@ -61,22 +56,19 @@ class Colibri2Session(
     val bridge: Bridge,
     // Whether the session was constructed for the purpose of visitor nodes
     val visitor: Boolean,
-    private var transcriberUrl: TemplatedUrl?,
-    parentLogger: Logger,
-    private var transcriberCustomHeaders: Map<String, String>? = null,
-    private var transcriberUrlParams: Map<String, String>? = null,
-    /** The live-translation websocket URL template, or null when translation is disabled on this session. */
-    private var translatorUrl: TemplatedUrl? = null,
-    /** Source names requested from the translator (the synthetic, language-encoded sources it produces). */
-    private var translatorRequests: List<String> = emptyList(),
-    /** Source names exported to the translator (the senders' audio to translate). */
-    private var translatorExports: List<String> = emptyList()
+    parentLogger: Logger
 ) : CascadeNode<Colibri2Session, Colibri2Session.Relay> {
     private val logger = createChildLogger(parentLogger).apply {
         bridge.jid.resourceOrNull?.toString()?.let { addContext("bridge", it) }
     }
     private val xmppConnection = colibriSessionManager.xmppConnection
     val id = UUID.randomUUID().toString()
+
+    /**
+     * The colibri2 `<connect>`s currently active on this session, by id (the last set signaled to the bridge).
+     * Managed via [setInitialConnects] (for the create request) and [setConnects] (delta updates).
+     */
+    private val connects = LinkedHashMap<String, ConnectSpec>()
 
     /**
      * Save the relay ID locally since it is possible for the relay ID of the Bridge to change and we don't want it to
@@ -209,106 +201,56 @@ class Colibri2Session(
             setCreate(true)
             setConferenceName(colibriSessionManager.conferenceName)
             setRtcstatsEnabled(colibriSessionManager.rtcStatsEnabled)
-            transcriberUrl?.let {
-                var url = resolveTranscriberUrl(it)
-                val urlParams = transcriberUrlParams
-                if (urlParams != null && urlParams.isNotEmpty()) {
-                    val queryString = urlParams.entries.joinToString("&") { (key, value) ->
-                        "${java.net.URLEncoder.encode(key, "UTF-8")}=${java.net.URLEncoder.encode(value, "UTF-8")}"
-                    }
-                    val separator = if (url.query == null) "?" else "&"
-                    url = java.net.URI(url.toString() + separator + queryString)
-                }
-                val headers = transcriberCustomHeaders ?: TranscriptionConfig.config.httpHeaders
-                logger.info("Adding connect for transcriber, url=$url")
-                addConnect(
-                    createConnect(
-                        url,
-                        headers,
-                        TranscriptionConfig.config.pingEnabled,
-                        TranscriptionConfig.config.pingInterval.toMillis().toInt(),
-                        TranscriptionConfig.config.pingTimeout.toMillis().toInt()
-                    )
-                )
-            }
-            translatorUrl?.let {
-                logger.info("Adding connect for translator")
-                addConnect(createTranslatorConnect(resolveTranslatorUrl(it), translatorRequests, translatorExports))
-            }
-        }
-    }
-
-    private fun resolveTranscriberUrl(urlTemplate: TemplatedUrl): URI {
-        return urlTemplate.resolve(TranscriptionConfig.REGION_TEMPLATE, bridge.region ?: "")
-    }
-
-    private fun resolveTranslatorUrl(urlTemplate: TemplatedUrl): URI {
-        return urlTemplate.resolve(TranslationConfig.REGION_TEMPLATE, bridge.region ?: "")
-    }
-
-    fun setTranscriberUrl(
-        urlTemplate: TemplatedUrl?,
-        customHeaders: Map<String, String>?,
-        urlParams: Map<String, String>?
-    ) {
-        if (transcriberUrl != urlTemplate) {
-            transcriberUrl = urlTemplate
-            transcriberCustomHeaders = customHeaders
-            transcriberUrlParams = urlParams
-            val request = createRequest(create = false)
-            if (urlTemplate != null) {
-                var url = resolveTranscriberUrl(urlTemplate)
-                // Append URL params if provided
-                if (urlParams != null && urlParams.isNotEmpty()) {
-                    val queryString = urlParams.entries.joinToString("&") { (key, value) ->
-                        "${java.net.URLEncoder.encode(key, "UTF-8")}=${java.net.URLEncoder.encode(value, "UTF-8")}"
-                    }
-                    val separator = if (url.query == null) "?" else "&"
-                    url = java.net.URI(url.toString() + separator + queryString)
-                }
-                val headers = customHeaders ?: TranscriptionConfig.config.httpHeaders
-                logger.info("Adding connect, url=$url")
-                request.addConnect(
-                    createConnect(
-                        url,
-                        headers,
-                        TranscriptionConfig.config.pingEnabled,
-                        TranscriptionConfig.config.pingInterval.toMillis().toInt(),
-                        TranscriptionConfig.config.pingTimeout.toMillis().toInt()
-                    )
-                )
-            } else {
-                logger.info("Removing connects")
-                request.setEmptyConnects()
-            }
-            sendRequest(request.build(), "setTranscriberUrl")
-        } else {
-            logger.info("No change in audio record URL.")
+            // Include the session's connects in the create request so they don't need a separate update IQ.
+            connects.values.forEach { addConnect(it.toConnect(create = true)) }
         }
     }
 
     /**
-     * Enable, update, or disable the live-translation connect on this session.
-     *
-     * Unlike the transcriber, the request list changes over the lifetime of the connection, so the connect is
-     * (re)sent on every call when [url] is non-null. Passing a null [url] disables translation.
-     *
-     * Note: translation and transcription are managed independently here; the bridge treats the <connects> element as
-     * authoritative, so a session is not expected to run both a transcriber and a translator connect simultaneously.
+     * Pre-populate the set of connects to include in this session's create request, without sending anything. Used
+     * when a session is created while connects are already desired for it.
      */
-    fun setTranslator(url: TemplatedUrl?, requests: List<String>, exports: List<String>) {
-        translatorUrl = url
-        translatorRequests = requests
-        translatorExports = exports
-        val request = createRequest(create = false)
-        if (url != null) {
-            logger.info("Setting translator connect, requests=$requests exports=$exports")
-            request.addConnect(createTranslatorConnect(resolveTranslatorUrl(url), requests, exports))
-        } else {
-            logger.info("Removing translator connect")
-            request.setEmptyConnects()
+    fun setInitialConnects(specs: List<ConnectSpec>) {
+        connects.clear()
+        specs.forEach { connects[it.id] = it }
+    }
+
+    /**
+     * Apply [desired] as the full set of connects for this session, signaling only the delta to the bridge:
+     * connects with a new id are added with create=true, connects no longer present are expired, and connects whose
+     * parameters changed are re-signaled as an update. Connects whose parameters are unchanged are left alone.
+     */
+    fun setConnects(desired: List<ConnectSpec>) {
+        val desiredById = desired.associateBy { it.id }
+        val request = createRequest()
+        var hasDelta = false
+
+        (connects.keys - desiredById.keys).toList().forEach { id ->
+            logger.info("Expiring connect id=$id")
+            request.addConnect(connects.getValue(id).toConnect(expire = true))
+            hasDelta = true
         }
-        sendRequest(request.build(), "setTranslator")
+        desiredById.forEach { (id, spec) ->
+            val current = connects[id]
+            when {
+                current == null -> {
+                    logger.info("Adding connect id=$id")
+                    request.addConnect(spec.toConnect(create = true))
+                    hasDelta = true
+                }
+                !current.sameAs(spec) -> {
+                    logger.info("Updating connect id=$id")
+                    request.addConnect(spec.toConnect())
+                    hasDelta = true
+                }
+            }
+        }
+
+        connects.clear()
+        connects.putAll(desiredById)
+        if (hasDelta) {
+            sendRequest(request.build(), "setConnects")
+        }
     }
 
     /**
@@ -662,40 +604,3 @@ private fun ConferenceModifyIQ.Builder.addExpire(endpointId: String) = addEndpoi
         setExpire(true)
     }.build()
 )
-
-private fun createConnect(
-    url: URI,
-    httpHeaders: Map<String, String> = emptyMap(),
-    pingEnabled: Boolean = false,
-    pingInterval: Int = 0,
-    pingTimeout: Int = 0
-) = Connect(
-    url = url,
-    type = Connect.Types.TRANSCRIBER,
-    protocol = Connect.Protocols.MEDIAJSON,
-    audio = true
-).apply {
-    httpHeaders.forEach { (name, value) ->
-        addHttpHeader(name, value)
-    }
-    if (pingEnabled) {
-        setPing(pingInterval, pingTimeout)
-    }
-}
-
-/**
- * Build a translator [Connect]: the bridge exports the senders' audio to it ([exports]) and requests back the
- * synthetic, language-encoded translated sources it produces ([requests]).
- */
-private fun createTranslatorConnect(url: URI, requests: List<String>, exports: List<String>) = Connect(
-    url = url,
-    type = Connect.Types.TRANSLATOR,
-    protocol = Connect.Protocols.MEDIAJSON,
-    audio = true
-).apply {
-    setRequests(requests)
-    setExports(exports)
-    TranslationConfig.config.httpHeaders.forEach { (name, value) ->
-        addHttpHeader(name, value)
-    }
-}

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -67,6 +67,15 @@ interface ColibriSessionManager {
     )
 
     /**
+     * Enable, update, or disable live translation on the selected bridge.
+     *
+     * @param url the websocket URL template the bridge should connect to, or null to disable translation.
+     * @param requests source names the translator should receive (the senders' audio to translate).
+     * @param exports source names the translator produces (the synthetic, language-encoded sources).
+     */
+    fun setTranslator(url: TemplatedUrl?, requests: List<String> = emptyList(), exports: List<String> = emptyList())
+
+    /**
      * Stop using [bridge], expiring all endpoints on it (e.g. because it was detected to have failed).
      * @return the list of participant IDs which were on the removed bridge and now need to be re-invited.
      */

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -73,7 +73,11 @@ interface ColibriSessionManager {
      * @param requests the per-sender translation requests. How these are placed on bridges depends on the configured
      * [org.jitsi.jicofo.TranslationConfig.mode].
      */
-    fun setTranslator(url: TemplatedUrl?, requests: List<TranslationRequest> = emptyList())
+    fun setTranslator(
+        url: TemplatedUrl?,
+        requests: List<TranslationRequest> = emptyList(),
+        customHeaders: Map<String, String>? = null
+    )
 
     /**
      * Stop using [bridge], expiring all endpoints on it (e.g. because it was detected to have failed).

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -70,8 +70,8 @@ interface ColibriSessionManager {
      * Enable, update, or disable live translation on the selected bridge.
      *
      * @param url the websocket URL template the bridge should connect to, or null to disable translation.
-     * @param requests source names the translator should receive (the senders' audio to translate).
-     * @param exports source names the translator produces (the synthetic, language-encoded sources).
+     * @param requests source names requested from the translator (the synthetic, language-encoded sources).
+     * @param exports source names exported to the translator (the senders' audio to translate).
      */
     fun setTranslator(url: TemplatedUrl?, requests: List<String> = emptyList(), exports: List<String> = emptyList())
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -67,13 +67,13 @@ interface ColibriSessionManager {
     )
 
     /**
-     * Enable, update, or disable live translation on the selected bridge.
+     * Enable, update, or disable live translation.
      *
-     * @param url the websocket URL template the bridge should connect to, or null to disable translation.
-     * @param requests source names requested from the translator (the synthetic, language-encoded sources).
-     * @param exports source names exported to the translator (the senders' audio to translate).
+     * @param url the websocket URL template the bridge(s) should connect to, or null to disable translation.
+     * @param requests the per-sender translation requests. How these are placed on bridges depends on the configured
+     * [org.jitsi.jicofo.TranslationConfig.mode].
      */
-    fun setTranslator(url: TemplatedUrl?, requests: List<String> = emptyList(), exports: List<String> = emptyList())
+    fun setTranslator(url: TemplatedUrl?, requests: List<TranslationRequest> = emptyList())
 
     /**
      * Stop using [bridge], expiring all endpoints on it (e.g. because it was detected to have failed).
@@ -118,4 +118,17 @@ data class ParticipantAllocationParameters(
     val visitor: Boolean,
     val supportsPrivateAddresses: Boolean,
     val medias: Set<Media>
+)
+
+/**
+ * A request to translate one sender's audio into one or more languages.
+ *
+ * @param senderEndpointId the endpoint id of the sender whose audio is translated (used to find its local bridge).
+ * @param sourceName the sender's base audio source name, exported to the translator.
+ * @param syntheticSourceNames the synthetic, language-encoded source names requested back from the translator.
+ */
+data class TranslationRequest(
+    val senderEndpointId: String,
+    val sourceName: String,
+    val syntheticSourceNames: List<String>
 )

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -138,6 +138,9 @@ class ColibriV2SessionManager(
     /** The current per-sender translation requests. */
     private var translatorRequests: List<TranslationRequest> = emptyList()
 
+    /** Per-room translator connect headers (merged config + room metadata), or null to use config headers. */
+    private var translatorCustomHeaders: Map<String, String>? = null
+
     /**
      * The colibri2 sessions that are currently active, mapped by the relayId of the [Bridge] that they use.
      */
@@ -391,7 +394,7 @@ class ColibriV2SessionManager(
         type = Connect.Types.TRANSLATOR,
         exports = translatorRequests.map { it.sourceName },
         requests = translatorRequests.flatMap { it.syntheticSourceNames },
-        httpHeaders = TranslationConfig.config.httpHeaders,
+        httpHeaders = translatorCustomHeaders ?: TranslationConfig.config.httpHeaders,
         ping = translatorPing()
     )
 
@@ -408,7 +411,7 @@ class ColibriV2SessionManager(
                     request,
                     url,
                     TranslationConfig.config.maxLanguagesPerConnect,
-                    TranslationConfig.config.httpHeaders,
+                    translatorCustomHeaders ?: TranslationConfig.config.httpHeaders,
                     translatorPing()
                 ).also { specs ->
                     // Detect the at-risk condition for the positional-chunking glitch noted on perSourceTranslatorSpecs:
@@ -450,9 +453,14 @@ class ColibriV2SessionManager(
         )
     }
 
-    override fun setTranslator(url: TemplatedUrl?, requests: List<TranslationRequest>) = synchronized(syncRoot) {
+    override fun setTranslator(
+        url: TemplatedUrl?,
+        requests: List<TranslationRequest>,
+        customHeaders: Map<String, String>?
+    ) = synchronized(syncRoot) {
         translatorUrl = url
         translatorRequests = requests
+        translatorCustomHeaders = customHeaders
         updateConnects()
     }
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -65,6 +65,27 @@ private const val TRANSCRIBER_CONNECT_ID = "transcriber"
 private const val TRANSLATOR_CONNECT_ID = "translator"
 
 /**
+ * The per-source translator connect specs for a single [request]: one connect per chunk of at most
+ * [maxLanguagesPerConnect] requested languages, each exporting the sender's source and requesting its chunk of
+ * synthetic outputs. Connect ids are "translator-<senderEndpointId>-<chunkIndex>" so they are stable across updates.
+ */
+internal fun perSourceTranslatorSpecs(
+    request: TranslationRequest,
+    url: URI,
+    maxLanguagesPerConnect: Int,
+    httpHeaders: Map<String, String>
+): List<ConnectSpec> = request.syntheticSourceNames.chunked(maxLanguagesPerConnect).mapIndexed { index, chunk ->
+    ConnectSpec(
+        id = "$TRANSLATOR_CONNECT_ID-${request.senderEndpointId}-$index",
+        url = url,
+        type = Connect.Types.TRANSLATOR,
+        exports = listOf(request.sourceName),
+        requests = chunk,
+        httpHeaders = httpHeaders
+    )
+}
+
+/**
  * Implements [ColibriSessionManager] using colibri2.
  */
 @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
@@ -106,11 +127,8 @@ class ColibriV2SessionManager(
     /** The translator URL template */
     private var translatorUrl: TemplatedUrl? = null
 
-    /** Source names requested from the translator (the synthetic, language-encoded sources it produces). */
-    private var translatorRequests: List<String> = emptyList()
-
-    /** Source names exported to the translator (the senders' audio to translate). */
-    private var translatorExports: List<String> = emptyList()
+    /** The current per-sender translation requests. */
+    private var translatorRequests: List<TranslationRequest> = emptyList()
 
     /**
      * The colibri2 sessions that are currently active, mapped by the relayId of the [Bridge] that they use.
@@ -177,9 +195,12 @@ class ColibriV2SessionManager(
             sessions.values.forEach { otherSession -> otherSession.expireRelay(removedRelayId) }
         }
         if (session == connectSession) {
-            // The session hosting the transcriber/translator connects went away; reselect another one.
-            logger.info("Removing connect session: $session")
+            // The session hosting the transcriber/single-bridge translator connect went away; force reselection.
             connectSession = null
+        }
+        // Reconcile connects across the remaining sessions (re-place transcriber/translator as needed). Safe because
+        // the removed session is already out of [sessions].
+        if (transcriberUrl != null || translatorUrl != null) {
             updateConnects()
         }
         return participants.toSet()
@@ -287,10 +308,11 @@ class ColibriV2SessionManager(
             session = Colibri2Session(this, bridge, visitor, logger)
             // If connects are already desired but no session hosts them yet, this new session becomes the host;
             // pre-populate them so they go out in the create (allocation) request rather than a separate update.
+            // Set connectSession first, since computeConnectSpecsFor checks it.
             if (connectSession == null && (transcriberUrl != null || translatorUrl != null)) {
-                session.setInitialConnects(computeConnectSpecsFor(session))
                 connectSession = session
             }
+            session.setInitialConnects(computeConnectSpecsFor(session))
             return Pair(session, true)
         }
 
@@ -312,26 +334,64 @@ class ColibriV2SessionManager(
         updateConnects()
     }
 
-    /** Recompute and (re)signal the transcriber/translator connects to the session that should host them. */
+    /** Recompute and (re)signal the connects (transcriber/translator) to every session. */
     private fun updateConnects() {
-        if (transcriberUrl == null && translatorUrl == null) {
-            connectSession?.setConnects(emptyList())
-            connectSession = null
-            return
+        // The transcriber, and the translator in single-bridge mode, are hosted on a single chosen session.
+        val needsConnectSession = transcriberUrl != null ||
+            (translatorUrl != null && TranslationConfig.config.mode == TranslationConfig.Mode.SINGLE_BRIDGE)
+        connectSession = if (needsConnectSession) {
+            (connectSession ?: sessions.values.firstOrNull()).also {
+                if (it == null) logger.info("No session available yet for transcriber/translator connects.")
+            }
+        } else {
+            null
         }
-        val session = connectSession ?: sessions.values.firstOrNull()
-        if (session == null) {
-            logger.info("No session available yet for transcriber/translator connects.")
-            return
-        }
-        connectSession = session
-        session.setConnects(computeConnectSpecsFor(session))
+
+        // Apply to every session, so connects that are no longer desired on a session are expired.
+        sessions.values.forEach { it.setConnects(computeConnectSpecsFor(it)) }
     }
 
     /** The connects desired on [session] (transcriber and/or translator), with urls resolved for its bridge. */
     private fun computeConnectSpecsFor(session: Colibri2Session): List<ConnectSpec> = buildList {
-        transcriberUrl?.let { add(buildTranscriberSpec(session, it)) }
-        translatorUrl?.let { add(buildTranslatorSpec(session, it)) }
+        if (session == connectSession) {
+            transcriberUrl?.let { add(buildTranscriberSpec(session, it)) }
+        }
+        translatorUrl?.let { url ->
+            when (TranslationConfig.config.mode) {
+                TranslationConfig.Mode.SINGLE_BRIDGE ->
+                    if (session == connectSession) add(buildSingleBridgeTranslatorSpec(session, url))
+                TranslationConfig.Mode.PER_SOURCE ->
+                    addAll(buildPerSourceTranslatorSpecs(session, url))
+            }
+        }
+    }
+
+    /** A single translator connect on [session] carrying all senders' sources (single-bridge mode). */
+    private fun buildSingleBridgeTranslatorSpec(session: Colibri2Session, urlTemplate: TemplatedUrl) = ConnectSpec(
+        id = TRANSLATOR_CONNECT_ID,
+        url = urlTemplate.resolve(TranslationConfig.REGION_TEMPLATE, session.bridge.region ?: ""),
+        type = Connect.Types.TRANSLATOR,
+        exports = translatorRequests.map { it.sourceName },
+        requests = translatorRequests.flatMap { it.syntheticSourceNames },
+        httpHeaders = TranslationConfig.config.httpHeaders
+    )
+
+    /**
+     * The translator connects for the senders located on [session] (per-source mode). Each sender gets one connect per
+     * chunk of at most [TranslationConfig.maxLanguagesPerConnect] requested languages.
+     */
+    private fun buildPerSourceTranslatorSpecs(session: Colibri2Session, urlTemplate: TemplatedUrl): List<ConnectSpec> {
+        val url = urlTemplate.resolve(TranslationConfig.REGION_TEMPLATE, session.bridge.region ?: "")
+        return translatorRequests
+            .filter { participants[it.senderEndpointId]?.session == session }
+            .flatMap {
+                perSourceTranslatorSpecs(
+                    it,
+                    url,
+                    TranslationConfig.config.maxLanguagesPerConnect,
+                    TranslationConfig.config.httpHeaders
+                )
+            }
     }
 
     private fun buildTranscriberSpec(session: Colibri2Session, urlTemplate: TemplatedUrl): ConnectSpec {
@@ -360,22 +420,11 @@ class ColibriV2SessionManager(
         )
     }
 
-    private fun buildTranslatorSpec(session: Colibri2Session, urlTemplate: TemplatedUrl) = ConnectSpec(
-        id = TRANSLATOR_CONNECT_ID,
-        url = urlTemplate.resolve(TranslationConfig.REGION_TEMPLATE, session.bridge.region ?: ""),
-        type = Connect.Types.TRANSLATOR,
-        exports = translatorExports,
-        requests = translatorRequests,
-        httpHeaders = TranslationConfig.config.httpHeaders
-    )
-
-    override fun setTranslator(url: TemplatedUrl?, requests: List<String>, exports: List<String>) =
-        synchronized(syncRoot) {
-            translatorUrl = url
-            translatorRequests = requests
-            translatorExports = exports
-            updateConnects()
-        }
+    override fun setTranslator(url: TemplatedUrl?, requests: List<TranslationRequest>) = synchronized(syncRoot) {
+        translatorUrl = url
+        translatorRequests = requests
+        updateConnects()
+    }
 
     /** Get the bridge-to-bridge-properties map needed for bridge selection. */
     override fun getBridges(): Map<Bridge, ConferenceBridgeProperties> = synchronized(syncRoot) {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -79,7 +79,8 @@ internal fun perSourceTranslatorSpecs(
     request: TranslationRequest,
     url: URI,
     maxLanguagesPerConnect: Int,
-    httpHeaders: Map<String, String>
+    httpHeaders: Map<String, String>,
+    ping: ConnectSpec.Ping? = null
 ): List<ConnectSpec> = request.syntheticSourceNames.chunked(maxLanguagesPerConnect).mapIndexed { index, chunk ->
     ConnectSpec(
         id = "$TRANSLATOR_CONNECT_ID-${request.sourceName}-$index",
@@ -87,7 +88,8 @@ internal fun perSourceTranslatorSpecs(
         type = Connect.Types.TRANSLATOR,
         exports = listOf(request.sourceName),
         requests = chunk,
-        httpHeaders = httpHeaders
+        httpHeaders = httpHeaders,
+        ping = ping
     )
 }
 
@@ -372,6 +374,16 @@ class ColibriV2SessionManager(
         }
     }
 
+    /** The keepalive ping for translator connects, or null when disabled (mirrors the transcriber). */
+    private fun translatorPing(): ConnectSpec.Ping? = if (TranslationConfig.config.pingEnabled) {
+        ConnectSpec.Ping(
+            TranslationConfig.config.pingInterval.toMillis().toInt(),
+            TranslationConfig.config.pingTimeout.toMillis().toInt()
+        )
+    } else {
+        null
+    }
+
     /** A single translator connect on [session] carrying all senders' sources (single-bridge mode). */
     private fun buildSingleBridgeTranslatorSpec(session: Colibri2Session, urlTemplate: TemplatedUrl) = ConnectSpec(
         id = TRANSLATOR_CONNECT_ID,
@@ -379,7 +391,8 @@ class ColibriV2SessionManager(
         type = Connect.Types.TRANSLATOR,
         exports = translatorRequests.map { it.sourceName },
         requests = translatorRequests.flatMap { it.syntheticSourceNames },
-        httpHeaders = TranslationConfig.config.httpHeaders
+        httpHeaders = TranslationConfig.config.httpHeaders,
+        ping = translatorPing()
     )
 
     /**
@@ -395,7 +408,8 @@ class ColibriV2SessionManager(
                     request,
                     url,
                     TranslationConfig.config.maxLanguagesPerConnect,
-                    TranslationConfig.config.httpHeaders
+                    TranslationConfig.config.httpHeaders,
+                    translatorPing()
                 ).also { specs ->
                     // Detect the at-risk condition for the positional-chunking glitch noted on perSourceTranslatorSpecs:
                     // a source split across multiple connects can have languages move between connects on a removal.

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -88,6 +88,18 @@ class ColibriV2SessionManager(
     /** Custom URL parameters for transcription */
     private var transcriberUrlParams: Map<String, String>? = null
 
+    /** The session currently used for translation, if any */
+    private var translatorSession: Colibri2Session? = null
+
+    /** The translator URL template */
+    private var translatorUrl: TemplatedUrl? = null
+
+    /** Source names the translator should receive (the senders' audio). */
+    private var translatorRequests: List<String> = emptyList()
+
+    /** Source names the translator produces (the synthetic, language-encoded sources). */
+    private var translatorExports: List<String> = emptyList()
+
     /**
      * The colibri2 sessions that are currently active, mapped by the relayId of the [Bridge] that they use.
      */
@@ -162,6 +174,18 @@ class ColibriV2SessionManager(
                 val savedParams = transcriberUrlParams
                 transcriberUrl = null
                 setTranscriberUrl(savedUrl, savedHeaders, savedParams)
+            }
+        }
+        if (session == translatorSession) {
+            logger.info("Removing translator session: $session")
+            translatorSession = null
+            translatorUrl?.let {
+                // Trigger selection of a new session for translation.
+                val savedUrl = it
+                val savedRequests = translatorRequests
+                val savedExports = translatorExports
+                translatorUrl = null
+                setTranslator(savedUrl, savedRequests, savedExports)
             }
         }
         return participants.toSet()
@@ -267,6 +291,7 @@ class ColibriV2SessionManager(
             }
 
             val enableTranscriber = transcriberUrl != null && transcriberSession == null
+            val enableTranslator = translatorUrl != null && translatorSession == null
             session = Colibri2Session(
                 this,
                 bridge,
@@ -274,10 +299,16 @@ class ColibriV2SessionManager(
                 if (enableTranscriber) transcriberUrl else null,
                 logger,
                 if (enableTranscriber) transcriberCustomHeaders else null,
-                if (enableTranscriber) transcriberUrlParams else null
+                if (enableTranscriber) transcriberUrlParams else null,
+                if (enableTranslator) translatorUrl else null,
+                if (enableTranslator) translatorRequests else emptyList(),
+                if (enableTranslator) translatorExports else emptyList()
             )
             if (enableTranscriber) {
                 transcriberSession = session
+            }
+            if (enableTranslator) {
+                translatorSession = session
             }
             return Pair(session, true)
         }
@@ -320,6 +351,32 @@ class ColibriV2SessionManager(
 
         Unit
     }
+
+    override fun setTranslator(url: TemplatedUrl?, requests: List<String>, exports: List<String>) =
+        synchronized(syncRoot) {
+            val enable = url != null
+            translatorUrl = url
+            translatorRequests = requests
+            translatorExports = exports
+
+            if (enable) {
+                if (translatorSession == null) {
+                    if (sessions.isEmpty()) {
+                        logger.info("No session available for translation, will enable it once a session is created")
+                        return@synchronized
+                    }
+                    // Use the first session, mirroring transcriber selection.
+                    translatorSession = sessions.values.first()
+                    logger.info("Using ${translatorSession?.bridge} for translation")
+                }
+                translatorSession?.setTranslator(url, requests, exports)
+            } else {
+                translatorSession?.setTranslator(null, emptyList(), emptyList())
+                translatorSession = null
+            }
+
+            Unit
+        }
 
     /** Get the bridge-to-bridge-properties map needed for bridge selection. */
     override fun getBridges(): Map<Bridge, ConferenceBridgeProperties> = synchronized(syncRoot) {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -94,10 +94,10 @@ class ColibriV2SessionManager(
     /** The translator URL template */
     private var translatorUrl: TemplatedUrl? = null
 
-    /** Source names the translator should receive (the senders' audio). */
+    /** Source names requested from the translator (the synthetic, language-encoded sources it produces). */
     private var translatorRequests: List<String> = emptyList()
 
-    /** Source names the translator produces (the synthetic, language-encoded sources). */
+    /** Source names exported to the translator (the senders' audio to translate). */
     private var translatorExports: List<String> = emptyList()
 
     /**

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -67,7 +67,13 @@ private const val TRANSLATOR_CONNECT_ID = "translator"
 /**
  * The per-source translator connect specs for a single [request]: one connect per chunk of at most
  * [maxLanguagesPerConnect] requested languages, each exporting the sender's source and requesting its chunk of
- * synthetic outputs. Connect ids are "translator-<senderEndpointId>-<chunkIndex>" so they are stable across updates.
+ * synthetic outputs. Connect ids are "translator-<sourceName>-<chunkIndex>". The source name (not the endpoint id) keys
+ * the connect so that an endpoint with more than one translated audio source does not collide.
+ *
+ * Note: the chunking is positional, so when [maxLanguagesPerConnect] is exceeded and a language in an earlier chunk is
+ * removed, the first language of the next chunk shifts into the previous connect (a brief glitch for that language). A
+ * stable mapping would require persisting the language->connect assignment; this is not worth it for the rare case of a
+ * single source translated into more than [maxLanguagesPerConnect] languages. See [buildPerSourceTranslatorSpecs].
  */
 internal fun perSourceTranslatorSpecs(
     request: TranslationRequest,
@@ -76,7 +82,7 @@ internal fun perSourceTranslatorSpecs(
     httpHeaders: Map<String, String>
 ): List<ConnectSpec> = request.syntheticSourceNames.chunked(maxLanguagesPerConnect).mapIndexed { index, chunk ->
     ConnectSpec(
-        id = "$TRANSLATOR_CONNECT_ID-${request.senderEndpointId}-$index",
+        id = "$TRANSLATOR_CONNECT_ID-${request.sourceName}-$index",
         url = url,
         type = Connect.Types.TRANSLATOR,
         exports = listOf(request.sourceName),
@@ -384,13 +390,23 @@ class ColibriV2SessionManager(
         val url = urlTemplate.resolve(TranslationConfig.REGION_TEMPLATE, session.bridge.region ?: "")
         return translatorRequests
             .filter { participants[it.senderEndpointId]?.session == session }
-            .flatMap {
+            .flatMap { request ->
                 perSourceTranslatorSpecs(
-                    it,
+                    request,
                     url,
                     TranslationConfig.config.maxLanguagesPerConnect,
                     TranslationConfig.config.httpHeaders
-                )
+                ).also { specs ->
+                    // Detect the at-risk condition for the positional-chunking glitch noted on perSourceTranslatorSpecs:
+                    // a source split across multiple connects can have languages move between connects on a removal.
+                    if (specs.size > 1) {
+                        logger.warn(
+                            "Source ${request.sourceName} is translated into ${request.syntheticSourceNames.size} " +
+                                "languages, split across ${specs.size} translator connects; removing a language may " +
+                                "move others between connects (possible brief glitch)."
+                        )
+                    }
+                }
             }
     }
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -24,6 +24,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.jicofo.MediaType
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.TaskPools
+import org.jitsi.jicofo.TranscriptionConfig
+import org.jitsi.jicofo.TranslationConfig
 import org.jitsi.jicofo.bridge.Bridge
 import org.jitsi.jicofo.bridge.BridgeConfig.Companion.config
 import org.jitsi.jicofo.bridge.BridgeSelector
@@ -42,6 +44,7 @@ import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Error
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifiedIQ
+import org.jitsi.xmpp.extensions.colibri2.Connect
 import org.jitsi.xmpp.extensions.colibri2.InitialLastN
 import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 import org.jivesoftware.smack.AbstractXMPPConnection
@@ -51,7 +54,15 @@ import org.jivesoftware.smack.packet.StanzaError.Condition.bad_request
 import org.jivesoftware.smack.packet.StanzaError.Condition.conflict
 import org.jivesoftware.smack.packet.StanzaError.Condition.item_not_found
 import org.jivesoftware.smack.packet.StanzaError.Condition.service_unavailable
+import java.net.URI
+import java.net.URLEncoder
 import java.util.Collections.singletonList
+
+/** The fixed connect id used for the (single) transcriber connect. */
+private const val TRANSCRIBER_CONNECT_ID = "transcriber"
+
+/** The connect id used for the single-bridge translator connect. */
+private const val TRANSLATOR_CONNECT_ID = "translator"
 
 /**
  * Implements [ColibriSessionManager] using colibri2.
@@ -76,8 +87,12 @@ class ColibriV2SessionManager(
     override fun addListener(listener: ColibriSessionManager.Listener) = eventEmitter.addHandler(listener)
     override fun removeListener(listener: ColibriSessionManager.Listener) = eventEmitter.removeHandler(listener)
 
-    /** The session currently used for transcription, if any */
-    private var transcriberSession: Colibri2Session? = null
+    /**
+     * The single session that currently hosts the transcriber and/or translator connects. Selected as the first
+     * available session and reselected if it is removed. (The per-source translation mode signals connects to each
+     * source's own session instead; see [updateConnects].)
+     */
+    private var connectSession: Colibri2Session? = null
 
     /** The transcriber URL template */
     private var transcriberUrl: TemplatedUrl? = null
@@ -87,9 +102,6 @@ class ColibriV2SessionManager(
 
     /** Custom URL parameters for transcription */
     private var transcriberUrlParams: Map<String, String>? = null
-
-    /** The session currently used for translation, if any */
-    private var translatorSession: Colibri2Session? = null
 
     /** The translator URL template */
     private var translatorUrl: TemplatedUrl? = null
@@ -164,29 +176,11 @@ class ColibriV2SessionManager(
         session.relayId?.let { removedRelayId ->
             sessions.values.forEach { otherSession -> otherSession.expireRelay(removedRelayId) }
         }
-        if (session == transcriberSession) {
-            logger.info("Removing transcriber session: $session")
-            transcriberSession = null
-            transcriberUrl?.let {
-                // Trigger selection of a new session for transcribing.
-                val savedUrl = it
-                val savedHeaders = transcriberCustomHeaders
-                val savedParams = transcriberUrlParams
-                transcriberUrl = null
-                setTranscriberUrl(savedUrl, savedHeaders, savedParams)
-            }
-        }
-        if (session == translatorSession) {
-            logger.info("Removing translator session: $session")
-            translatorSession = null
-            translatorUrl?.let {
-                // Trigger selection of a new session for translation.
-                val savedUrl = it
-                val savedRequests = translatorRequests
-                val savedExports = translatorExports
-                translatorUrl = null
-                setTranslator(savedUrl, savedRequests, savedExports)
-            }
+        if (session == connectSession) {
+            // The session hosting the transcriber/translator connects went away; reselect another one.
+            logger.info("Removing connect session: $session")
+            connectSession = null
+            updateConnects()
         }
         return participants.toSet()
     }
@@ -290,25 +284,12 @@ class ColibriV2SessionManager(
                 return Pair(session, false)
             }
 
-            val enableTranscriber = transcriberUrl != null && transcriberSession == null
-            val enableTranslator = translatorUrl != null && translatorSession == null
-            session = Colibri2Session(
-                this,
-                bridge,
-                visitor,
-                if (enableTranscriber) transcriberUrl else null,
-                logger,
-                if (enableTranscriber) transcriberCustomHeaders else null,
-                if (enableTranscriber) transcriberUrlParams else null,
-                if (enableTranslator) translatorUrl else null,
-                if (enableTranslator) translatorRequests else emptyList(),
-                if (enableTranslator) translatorExports else emptyList()
-            )
-            if (enableTranscriber) {
-                transcriberSession = session
-            }
-            if (enableTranslator) {
-                translatorSession = session
+            session = Colibri2Session(this, bridge, visitor, logger)
+            // If connects are already desired but no session hosts them yet, this new session becomes the host;
+            // pre-populate them so they go out in the create (allocation) request rather than a separate update.
+            if (connectSession == null && (transcriberUrl != null || translatorUrl != null)) {
+                session.setInitialConnects(computeConnectSpecsFor(session))
+                connectSession = session
             }
             return Pair(session, true)
         }
@@ -319,63 +300,81 @@ class ColibriV2SessionManager(
         urlParams: Map<String, String>?
     ) = synchronized(syncRoot) {
         if (transcriberUrl == url) {
-            return
+            return@synchronized
         }
         if (transcriberUrl != null && url != null) {
-            logger.error("Changing to a different URL is not supported")
-            return
+            logger.error("Changing to a different transcriber URL is not supported")
+            return@synchronized
         }
-
-        val enable = url != null
         transcriberUrl = url
         transcriberCustomHeaders = customHeaders
         transcriberUrlParams = urlParams
-
-        if (enable) {
-            if (transcriberSession != null) {
-                transcriberSession?.setTranscriberUrl(url, customHeaders, urlParams)
-            } else {
-                if (sessions.isEmpty()) {
-                    logger.info("No session available for transcribing, will enable it once a session is created")
-                } else {
-                    // Use the first session.
-                    transcriberSession = sessions.values.first()
-                    logger.info("Using ${transcriberSession?.bridge} for transcribing")
-                    transcriberSession?.setTranscriberUrl(url, customHeaders, urlParams)
-                }
-            }
-        } else {
-            transcriberSession?.setTranscriberUrl(null, null, null)
-            transcriberSession = null
-        }
-
-        Unit
+        updateConnects()
     }
+
+    /** Recompute and (re)signal the transcriber/translator connects to the session that should host them. */
+    private fun updateConnects() {
+        if (transcriberUrl == null && translatorUrl == null) {
+            connectSession?.setConnects(emptyList())
+            connectSession = null
+            return
+        }
+        val session = connectSession ?: sessions.values.firstOrNull()
+        if (session == null) {
+            logger.info("No session available yet for transcriber/translator connects.")
+            return
+        }
+        connectSession = session
+        session.setConnects(computeConnectSpecsFor(session))
+    }
+
+    /** The connects desired on [session] (transcriber and/or translator), with urls resolved for its bridge. */
+    private fun computeConnectSpecsFor(session: Colibri2Session): List<ConnectSpec> = buildList {
+        transcriberUrl?.let { add(buildTranscriberSpec(session, it)) }
+        translatorUrl?.let { add(buildTranslatorSpec(session, it)) }
+    }
+
+    private fun buildTranscriberSpec(session: Colibri2Session, urlTemplate: TemplatedUrl): ConnectSpec {
+        var url = urlTemplate.resolve(TranscriptionConfig.REGION_TEMPLATE, session.bridge.region ?: "")
+        val params = transcriberUrlParams
+        if (!params.isNullOrEmpty()) {
+            val queryString = params.entries.joinToString("&") { (key, value) ->
+                "${URLEncoder.encode(key, "UTF-8")}=${URLEncoder.encode(value, "UTF-8")}"
+            }
+            val separator = if (url.query == null) "?" else "&"
+            url = URI(url.toString() + separator + queryString)
+        }
+        return ConnectSpec(
+            id = TRANSCRIBER_CONNECT_ID,
+            url = url,
+            type = Connect.Types.TRANSCRIBER,
+            httpHeaders = transcriberCustomHeaders ?: TranscriptionConfig.config.httpHeaders,
+            ping = if (TranscriptionConfig.config.pingEnabled) {
+                ConnectSpec.Ping(
+                    TranscriptionConfig.config.pingInterval.toMillis().toInt(),
+                    TranscriptionConfig.config.pingTimeout.toMillis().toInt()
+                )
+            } else {
+                null
+            }
+        )
+    }
+
+    private fun buildTranslatorSpec(session: Colibri2Session, urlTemplate: TemplatedUrl) = ConnectSpec(
+        id = TRANSLATOR_CONNECT_ID,
+        url = urlTemplate.resolve(TranslationConfig.REGION_TEMPLATE, session.bridge.region ?: ""),
+        type = Connect.Types.TRANSLATOR,
+        exports = translatorExports,
+        requests = translatorRequests,
+        httpHeaders = TranslationConfig.config.httpHeaders
+    )
 
     override fun setTranslator(url: TemplatedUrl?, requests: List<String>, exports: List<String>) =
         synchronized(syncRoot) {
-            val enable = url != null
             translatorUrl = url
             translatorRequests = requests
             translatorExports = exports
-
-            if (enable) {
-                if (translatorSession == null) {
-                    if (sessions.isEmpty()) {
-                        logger.info("No session available for translation, will enable it once a session is created")
-                        return@synchronized
-                    }
-                    // Use the first session, mirroring transcriber selection.
-                    translatorSession = sessions.values.first()
-                    logger.info("Using ${translatorSession?.bridge} for translation")
-                }
-                translatorSession?.setTranslator(url, requests, exports)
-            } else {
-                translatorSession?.setTranslator(null, emptyList(), emptyList())
-                translatorSession = null
-            }
-
-            Unit
+            updateConnects()
         }
 
     /** Get the bridge-to-bridge-properties map needed for bridge selection. */

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ConnectSpec.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ConnectSpec.kt
@@ -1,0 +1,69 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2024 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.bridge.colibri
+
+import org.jitsi.xmpp.extensions.colibri2.Connect
+import java.net.URI
+
+/**
+ * A description of a single desired colibri2 `<connect>` on a bridge, with its [url] already resolved for that bridge.
+ * The identity is [id]; a session keeps its connects keyed by it and signals add/update/remove as deltas. This is the
+ * jicofo-side desired state, separate from the wire [Connect] (which also carries the create/expire delta markers).
+ */
+data class ConnectSpec(
+    val id: String,
+    val url: URI,
+    val type: Connect.Types,
+    val audio: Boolean = true,
+    /** Source names exported to (sent to) the peer. */
+    val exports: List<String> = emptyList(),
+    /** Source names requested from (received from) the peer. */
+    val requests: List<String> = emptyList(),
+    val httpHeaders: Map<String, String> = emptyMap(),
+    val ping: Ping? = null
+) {
+    data class Ping(val interval: Int, val timeout: Int)
+
+    /** Build the wire [Connect] for this spec with the given delta markers. */
+    fun toConnect(create: Boolean = false, expire: Boolean = false): Connect = Connect(
+        id = id,
+        url = url,
+        protocol = Connect.Protocols.MEDIAJSON,
+        type = type,
+        audio = audio,
+        create = create,
+        expire = expire
+    ).apply {
+        httpHeaders.forEach { (name, value) -> addHttpHeader(name, value) }
+        if (exports.isNotEmpty()) setExports(exports)
+        if (requests.isNotEmpty()) setRequests(requests)
+        ping?.let { setPing(it.interval, it.timeout) }
+    }
+
+    /**
+     * Whether [other] (which must have the same [id]) describes the same connect, so no update needs to be signaled.
+     * Source-name lists are compared as sets, since their order is not significant.
+     */
+    fun sameAs(other: ConnectSpec): Boolean = url == other.url &&
+        type == other.type &&
+        audio == other.audio &&
+        httpHeaders == other.httpHeaders &&
+        ping == other.ping &&
+        exports.toSet() == other.exports.toSet() &&
+        requests.toSet() == other.requests.toSet()
+}

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
@@ -70,6 +70,9 @@ fun EndpointSourceSet.toColibriMediaSources(endpointId: String): Sources {
             MediaSource.getBuilder()
                 .setType(source.mediaType)
                 .setId(sourceId)
+                // Synthetic sources (e.g. translated audio) are injected by the server and the bridge must only
+                // forward them to endpoints explicitly subscribed to them.
+                .setSynthetic(source.synthetic)
         }
         mediaSource.addSource(source.toPacketExtension(encodeMsid = false))
     }

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -458,6 +458,30 @@ jicofo {
     }
   }
 
+  translation {
+    # A templated URL for the live-translation websocket. "{{MEETING_ID}}" and "{{REGION}}" are substituted (REGION is
+    # optional, set to the bridge's region). When unset, live translation is disabled. No whitespace in the templates.
+    // url-template = "wss://{{REGION}}.example.com/translate/{{MEETING_ID}}"
+
+    # HTTP headers to include when connecting to the translation service.
+    http-headers {
+      // "Authorization" = "Bearer your-api-key"
+    }
+
+    # How translation connects are placed on bridges:
+    #   per-source    - each sender's audio is translated by a connect on its own (local) bridge. A sender requesting
+    #                   more than max-languages-per-connect target languages is split across multiple connects on that
+    #                   bridge, so a bridge has one or more websockets per source.
+    #   single-bridge - a single connect on one selected bridge handles all sources and languages (mirrors the
+    #                   transcriber selection).
+    mode = "per-source"
+
+    # The maximum number of target languages handled by a single translation connect. ONLY applies in "per-source"
+    # mode; a sender requesting more languages is split across multiple connects on its bridge. Ignored in
+    # "single-bridge" mode.
+    max-languages-per-connect = 5
+  }
+
   xmpp {
     // Whether to use JitsiXmppStringprep to validate JIDs. If set to false uses the default validation in Smack.
     use-jitsi-jid-validation = true

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -480,6 +480,16 @@ jicofo {
     # mode; a sender requesting more languages is split across multiple connects on its bridge. Ignored in
     # "single-bridge" mode.
     max-languages-per-connect = 5
+
+    # Ping configuration for the translation service connection (keepalive to avoid idle-timeout).
+    ping {
+      # Whether to enable ping messages
+      enabled = true
+      # Interval between ping messages
+      interval = 10 seconds
+      # Timeout for ping responses
+      timeout = 3 seconds
+    }
   }
 
   xmpp {

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/TranslationConfigTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/TranslationConfigTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2024 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.config.withNewConfig
+import org.jitsi.jicofo.xmpp.RoomMetadata
+
+class TranslationConfigTest : ShouldSpec() {
+    init {
+        context("http-headers") {
+            context("With no headers configured") {
+                withNewConfig("") {
+                    TranslationConfig.config.httpHeaders shouldBe emptyMap()
+                }
+            }
+
+            context("With headers configured") {
+                withNewConfig(
+                    """
+                    jicofo.translation.http-headers {
+                        "Authorization" = "Bearer token123"
+                        "X-API-Key" = "secret-key"
+                    }
+                    """.trimIndent()
+                ) {
+                    TranslationConfig.config.httpHeaders shouldBe mapOf(
+                        "Authorization" to "Bearer token123",
+                        "X-API-Key" to "secret-key"
+                    )
+                }
+            }
+        }
+
+        context("processTranslationMetadata") {
+            val baseHeaders = mapOf("Base-Header" to "base-value", "Shared-Header" to "base-shared")
+
+            context("With null translation") {
+                should("return null so callers fall back to config headers") {
+                    TranslationConfig.processTranslationMetadata(null, baseHeaders) shouldBe null
+                }
+            }
+
+            context("With translation having no headers") {
+                should("return null so callers fall back to config headers") {
+                    TranslationConfig.processTranslationMetadata(
+                        RoomMetadata.Metadata.Translation(),
+                        baseHeaders
+                    ) shouldBe null
+                }
+            }
+
+            context("With custom headers") {
+                val customHeaders = mapOf("X-Custom" to "custom-value", "Shared-Header" to "custom-shared")
+                should("return base headers merged with custom, custom taking precedence") {
+                    TranslationConfig.processTranslationMetadata(
+                        RoomMetadata.Metadata.Translation(httpHeaders = customHeaders),
+                        baseHeaders
+                    ) shouldBe mapOf(
+                        "Base-Header" to "base-value",
+                        "Shared-Header" to "custom-shared",
+                        "X-Custom" to "custom-value"
+                    )
+                }
+            }
+
+            context("With empty custom headers") {
+                should("return the base headers unchanged") {
+                    TranslationConfig.processTranslationMetadata(
+                        RoomMetadata.Metadata.Translation(httpHeaders = emptyMap()),
+                        baseHeaders
+                    ) shouldBe baseHeaders
+                }
+            }
+        }
+    }
+}

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ConnectSpecTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ConnectSpecTest.kt
@@ -64,8 +64,8 @@ class ConnectSpecTest : ShouldSpec() {
                 spec.sameAs(spec.copy()) shouldBe true
             }
             should("ignore source-name ordering") {
-                spec.sameAs(spec.copy(exports = listOf("b-a0", "a-a0"), requests = listOf("b-a0.fr", "a-a0.es"))) shouldBe
-                    true
+                val reordered = spec.copy(exports = listOf("b-a0", "a-a0"), requests = listOf("b-a0.fr", "a-a0.es"))
+                spec.sameAs(reordered) shouldBe true
             }
             should("differ when the exported source set changes") {
                 spec.sameAs(spec.copy(exports = listOf("a-a0"))) shouldBe false

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ConnectSpecTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ConnectSpecTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2024 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.bridge.colibri
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.xmpp.extensions.colibri2.Connect
+import java.net.URI
+
+class ConnectSpecTest : ShouldSpec() {
+    init {
+        val spec = ConnectSpec(
+            id = "c1",
+            url = URI("wss://example.com/t"),
+            type = Connect.Types.TRANSLATOR,
+            exports = listOf("a-a0", "b-a0"),
+            requests = listOf("a-a0.es", "b-a0.fr"),
+            httpHeaders = mapOf("Authorization" to "Bearer x"),
+            ping = ConnectSpec.Ping(1000, 2000)
+        )
+
+        context("toConnect") {
+            should("carry all fields and default to no create/expire") {
+                val connect = spec.toConnect()
+                connect.id shouldBe "c1"
+                connect.url shouldBe URI("wss://example.com/t")
+                connect.type shouldBe Connect.Types.TRANSLATOR
+                connect.audio shouldBe true
+                connect.create shouldBe false
+                connect.expire shouldBe false
+                connect.getExports() shouldBe listOf("a-a0", "b-a0")
+                connect.getRequests() shouldBe listOf("a-a0.es", "b-a0.fr")
+                connect.getHttpHeaders().associate { it.name to it.value } shouldBe mapOf("Authorization" to "Bearer x")
+                connect.getPing()!!.let {
+                    it.interval shouldBe 1000
+                    it.timeout shouldBe 2000
+                }
+            }
+            should("set the create marker") {
+                spec.toConnect(create = true).create shouldBe true
+            }
+            should("set the expire marker") {
+                spec.toConnect(expire = true).expire shouldBe true
+            }
+        }
+
+        context("sameAs") {
+            should("be true for an identical spec") {
+                spec.sameAs(spec.copy()) shouldBe true
+            }
+            should("ignore source-name ordering") {
+                spec.sameAs(spec.copy(exports = listOf("b-a0", "a-a0"), requests = listOf("b-a0.fr", "a-a0.es"))) shouldBe
+                    true
+            }
+            should("differ when the exported source set changes") {
+                spec.sameAs(spec.copy(exports = listOf("a-a0"))) shouldBe false
+            }
+            should("differ when the requested source set changes") {
+                spec.sameAs(spec.copy(requests = listOf("a-a0.es"))) shouldBe false
+            }
+            should("differ when the url changes") {
+                spec.sameAs(spec.copy(url = URI("wss://example.com/other"))) shouldBe false
+            }
+            should("differ when the headers change") {
+                spec.sameAs(spec.copy(httpHeaders = emptyMap())) shouldBe false
+            }
+            should("differ when the ping changes") {
+                spec.sameAs(spec.copy(ping = ConnectSpec.Ping(1, 2))) shouldBe false
+            }
+        }
+    }
+}

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/PerSourceTranslatorSpecsTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/PerSourceTranslatorSpecsTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2024 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.bridge.colibri
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.jitsi.xmpp.extensions.colibri2.Connect
+import java.net.URI
+
+class PerSourceTranslatorSpecsTest : ShouldSpec() {
+    private val url = URI("wss://example.com/t")
+
+    init {
+        context("A sender within the per-connect limit") {
+            val request = TranslationRequest("aaaaaaaa", "aaaaaaaa-a0", listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.es"))
+            val specs = perSourceTranslatorSpecs(request, url, maxLanguagesPerConnect = 5, httpHeaders = emptyMap())
+
+            should("produce a single connect with all languages") {
+                specs.size shouldBe 1
+                specs[0].id shouldBe "translator-aaaaaaaa-0"
+                specs[0].type shouldBe Connect.Types.TRANSLATOR
+                specs[0].exports shouldContainExactly listOf("aaaaaaaa-a0")
+                specs[0].requests shouldContainExactly listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.es")
+            }
+        }
+
+        context("A sender exceeding the per-connect limit") {
+            val languages = (1..7).map { "aaaaaaaa-a0.l$it" }
+            val request = TranslationRequest("aaaaaaaa", "aaaaaaaa-a0", languages)
+            val specs = perSourceTranslatorSpecs(request, url, maxLanguagesPerConnect = 3, httpHeaders = emptyMap())
+
+            should("split into ceil(n / max) connects with stable ids") {
+                specs.map { it.id } shouldContainExactly listOf(
+                    "translator-aaaaaaaa-0",
+                    "translator-aaaaaaaa-1",
+                    "translator-aaaaaaaa-2"
+                )
+            }
+            should("chunk the languages, each connect exporting the same source") {
+                specs[0].requests shouldContainExactly languages.subList(0, 3)
+                specs[1].requests shouldContainExactly languages.subList(3, 6)
+                specs[2].requests shouldContainExactly languages.subList(6, 7)
+                specs.forEach { it.exports shouldContainExactly listOf("aaaaaaaa-a0") }
+            }
+        }
+
+        context("A sender with no requested languages") {
+            should("produce no connects") {
+                perSourceTranslatorSpecs(
+                    TranslationRequest("aaaaaaaa", "aaaaaaaa-a0", emptyList()),
+                    url,
+                    maxLanguagesPerConnect = 5,
+                    httpHeaders = emptyMap()
+                ) shouldBe emptyList()
+            }
+        }
+    }
+}

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/PerSourceTranslatorSpecsTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/PerSourceTranslatorSpecsTest.kt
@@ -33,7 +33,7 @@ class PerSourceTranslatorSpecsTest : ShouldSpec() {
 
             should("produce a single connect with all languages") {
                 specs.size shouldBe 1
-                specs[0].id shouldBe "translator-aaaaaaaa-0"
+                specs[0].id shouldBe "translator-aaaaaaaa-a0-0"
                 specs[0].type shouldBe Connect.Types.TRANSLATOR
                 specs[0].exports shouldContainExactly listOf("aaaaaaaa-a0")
                 specs[0].requests shouldContainExactly listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.es")
@@ -47,9 +47,9 @@ class PerSourceTranslatorSpecsTest : ShouldSpec() {
 
             should("split into ceil(n / max) connects with stable ids") {
                 specs.map { it.id } shouldContainExactly listOf(
-                    "translator-aaaaaaaa-0",
-                    "translator-aaaaaaaa-1",
-                    "translator-aaaaaaaa-2"
+                    "translator-aaaaaaaa-a0-0",
+                    "translator-aaaaaaaa-a0-1",
+                    "translator-aaaaaaaa-a0-2"
                 )
             }
             should("chunk the languages, each connect exporting the same source") {

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/PerSourceTranslatorSpecsTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/PerSourceTranslatorSpecsTest.kt
@@ -60,6 +60,33 @@ class PerSourceTranslatorSpecsTest : ShouldSpec() {
             }
         }
 
+        context("A ping passed through") {
+            val request = TranslationRequest("aaaaaaaa", "aaaaaaaa-a0", listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.fr"))
+            val specs = perSourceTranslatorSpecs(
+                request,
+                url,
+                maxLanguagesPerConnect = 1,
+                httpHeaders = emptyMap(),
+                ping = ConnectSpec.Ping(10000, 3000)
+            )
+
+            should("set the ping on every connect") {
+                specs.size shouldBe 2
+                specs.forEach { it.ping shouldBe ConnectSpec.Ping(10000, 3000) }
+            }
+        }
+
+        context("No ping by default") {
+            should("leave ping null") {
+                perSourceTranslatorSpecs(
+                    TranslationRequest("aaaaaaaa", "aaaaaaaa-a0", listOf("aaaaaaaa-a0.en")),
+                    url,
+                    maxLanguagesPerConnect = 5,
+                    httpHeaders = emptyMap()
+                ).single().ping shouldBe null
+            }
+        }
+
         context("A sender with no requested languages") {
             should("produce no connects") {
                 perSourceTranslatorSpecs(

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -25,6 +25,7 @@ import org.jitsi.jicofo.auth.*;
 import org.jitsi.jicofo.bridge.*;
 import org.jitsi.jicofo.bridge.colibri.*;
 import org.jitsi.jicofo.conference.source.*;
+import org.jitsi.jicofo.conference.translation.*;
 import org.jitsi.jicofo.util.*;
 import org.jitsi.jicofo.version.*;
 import org.jitsi.jicofo.visitors.*;
@@ -247,6 +248,12 @@ public class JitsiMeetConferenceImpl
     );
 
     /**
+     * Manages live-translation synthetic sources and the translator connect, driven by the
+     * {@code audioTranslationRequests} room metadata.
+     */
+    private final ConferenceTranslationManager translationManager;
+
+    /**
      * Whether the limit on the number of audio senders is currently hit.
      */
     private boolean audioLimitReached = false;
@@ -298,6 +305,8 @@ public class JitsiMeetConferenceImpl
     {
         logger = new LoggerImpl(JitsiMeetConferenceImpl.class.getName(), logLevel);
         logger.addContext("room", roomName.toString());
+
+        translationManager = new ConferenceTranslationManager(conferenceSources, logger);
 
         this.config = new JitsiMeetConfig(properties);
 
@@ -380,6 +389,9 @@ public class JitsiMeetConferenceImpl
                         transcriptionParams.getSecond());
                 }
             }
+
+            // Apply any live-translation requests received before colibri was initialized.
+            translationManager.reapply(colibriSessionManager, meetingId);
         }
         return colibriSessionManager;
     }
@@ -1433,6 +1445,9 @@ public class JitsiMeetConferenceImpl
                 false);
 
         sendSourceRemove(new ConferenceSourceMap(participantId, sourcesAcceptedToBeRemoved), participant);
+
+        // A sender may have removed the audio source being translated; re-evaluate synthetic translation sources.
+        translationManager.reapply(colibriSessionManager, meetingId);
     }
 
     /**
@@ -1506,6 +1521,9 @@ public class JitsiMeetConferenceImpl
                 sendSourceRemove(new ConferenceSourceMap(participantId, sourcesRemoved), participant);
             }
         }
+
+        // The participant (a potential translation sender) is gone; drop any synthetic translation sources for it.
+        translationManager.reapply(colibriSessionManager, meetingId);
     }
 
     /**
@@ -2739,6 +2757,16 @@ public class JitsiMeetConferenceImpl
         public void transcribingEnabledChanged(boolean enabled)
         {
             setEnableTranscribing(enabled);
+        }
+
+        @Override
+        public void audioTranslationRequestsChanged(@NotNull Map<String, ? extends List<String>> requests)
+        {
+            //noinspection unchecked
+            translationManager.setRequests(
+                    (Map<String, List<String>>) (Map<String, ?>) requests,
+                    colibriSessionManager,
+                    meetingId);
         }
     }
 

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -2768,9 +2768,15 @@ public class JitsiMeetConferenceImpl
         @Override
         public void audioTranslationRequestsChanged(@NotNull Map<String, ? extends List<String>> requests)
         {
+            // Merge any per-room translator headers (e.g. a per-customer usage token delivered on the
+            // admin-only metadata path) over the static config headers; null falls back to config headers.
+            Map<String, String> translationHeaders = TranslationConfig.processTranslationMetadata(
+                    chatRoom != null ? chatRoom.getTranslation() : null,
+                    TranslationConfig.config.getHttpHeaders());
             //noinspection unchecked
             translationManager.setRequests(
                     (Map<String, List<String>>) (Map<String, ?>) requests,
+                    translationHeaders,
                     colibriSessionManager,
                     meetingId);
         }

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1409,6 +1409,9 @@ public class JitsiMeetConferenceImpl
                 null,
                 false);
         propagateNewSources(participant, sourcesAccepted);
+
+        // A newly-added audio source may be the base source for a pending translation request.
+        translationManager.reapply(colibriSessionManager, meetingId);
     }
 
     /**
@@ -1485,6 +1488,9 @@ public class JitsiMeetConferenceImpl
         {
             logger.debug("Session accepted with no sources.");
         }
+
+        // The initial sources may include the base audio source for a pending translation request.
+        translationManager.reapply(colibriSessionManager, meetingId);
 
         // Now that the Jingle session is ready, signal any sources from other participants to [participant].
         participant.sendQueuedRemoteSources();

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
@@ -17,6 +17,7 @@ package org.jitsi.jicofo.conference.translation
 
 import org.jitsi.jicofo.TranslationConfig
 import org.jitsi.jicofo.bridge.colibri.ColibriSessionManager
+import org.jitsi.jicofo.bridge.colibri.TranslationRequest
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
 import org.jitsi.jicofo.conference.source.Source
 import org.jitsi.jicofo.conference.source.ValidatingConferenceSourceMap
@@ -94,12 +95,17 @@ class ConferenceTranslationManager(
             colibriSessionManager.updateParticipant(sender, sources = conferenceSources[sender])
         }
 
-        // Enable/update/disable the translator connect on the selected bridge.
+        // Enable/update/disable the translator connect(s). The colibri layer decides placement (per-source or
+        // single-bridge) based on configuration.
         val url = if (result.isEmpty) null else TranslationConfig.config.getUrl(meetingId)
-        colibriSessionManager.setTranslator(url, result.requestNames.toList(), result.exportNames.toList())
+        val translationRequests = result.sourcesBySender.mapNotNull { (sender, sources) ->
+            val baseName = baseName(sender) ?: return@mapNotNull null
+            TranslationRequest(sender, baseName, sources.map { it.name!! }.sorted())
+        }
+        colibriSessionManager.setTranslator(url, translationRequests)
 
         logger.info(
-            "Applied audio translation: requests=$requests, syntheticSources=${result.requestNames}, " +
+            "Applied audio translation: requests=$requests, translationRequests=$translationRequests, " +
                 "signaledBridgesFor=$affected, translator=${if (url != null) "enabled" else "disabled"}"
         )
     }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
@@ -99,7 +99,7 @@ class ConferenceTranslationManager(
         colibriSessionManager.setTranslator(url, result.requestNames.toList(), result.exportNames.toList())
 
         logger.info(
-            "Applied audio translation: requests=$requests, syntheticExports=${result.exportNames}, " +
+            "Applied audio translation: requests=$requests, syntheticSources=${result.requestNames}, " +
                 "signaledBridgesFor=$affected, translator=${if (url != null) "enabled" else "disabled"}"
         )
     }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
@@ -97,6 +97,11 @@ class ConferenceTranslationManager(
         // Enable/update/disable the translator connect on the selected bridge.
         val url = if (result.isEmpty) null else TranslationConfig.config.getUrl(meetingId)
         colibriSessionManager.setTranslator(url, result.requestNames.toList(), result.exportNames.toList())
+
+        logger.info(
+            "Applied audio translation: requests=$requests, syntheticExports=${result.exportNames}, " +
+                "signaledBridgesFor=$affected, translator=${if (url != null) "enabled" else "disabled"}"
+        )
     }
 
     /** The base (first non-synthetic audio) source name for a sender, or null if it has none / is not present. */

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
@@ -44,14 +44,22 @@ class ConferenceTranslationManager(
     private val sourceManager = TranslationSourceManager()
     private var requests: Map<String, List<String>> = emptyMap()
 
-    /** Update the aggregated request map and re-apply. */
+    /**
+     * Per-room translator connect headers (config headers merged with room metadata, e.g. a per-customer usage
+     * token), or null to use the static config headers. Stored so [reapply] reuses the last value.
+     */
+    private var customHeaders: Map<String, String>? = null
+
+    /** Update the aggregated request map (and per-room connect headers) and re-apply. */
     @Synchronized
     fun setRequests(
         requests: Map<String, List<String>>,
+        customHeaders: Map<String, String>?,
         colibriSessionManager: ColibriSessionManager?,
         meetingId: String?
     ) {
         this.requests = requests
+        this.customHeaders = customHeaders
         apply(colibriSessionManager, meetingId)
     }
 
@@ -102,7 +110,7 @@ class ConferenceTranslationManager(
             val baseName = baseName(sender) ?: return@mapNotNull null
             TranslationRequest(sender, baseName, sources.map { it.name!! }.sorted())
         }
-        colibriSessionManager.setTranslator(url, translationRequests)
+        colibriSessionManager.setTranslator(url, translationRequests, customHeaders)
 
         logger.info(
             "Applied audio translation: requests=$requests, translationRequests=$translationRequests, " +

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright @ 2024 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.conference.translation
+
+import org.jitsi.jicofo.TranslationConfig
+import org.jitsi.jicofo.bridge.colibri.ColibriSessionManager
+import org.jitsi.jicofo.conference.source.EndpointSourceSet
+import org.jitsi.jicofo.conference.source.Source
+import org.jitsi.jicofo.conference.source.ValidatingConferenceSourceMap
+import org.jitsi.utils.MediaType
+import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.logging2.createChildLogger
+
+/**
+ * Ties the aggregated live-translation request map (from RoomMetadata) to the conference: it maintains the synthetic
+ * audio [Source]s in the conference source map, signals them to the bridges, and drives the translator `<connect>`.
+ *
+ * Synthetic sources are owned by the sender endpoint and survive the sender's unrelated source add/remove (they are
+ * only removed when the request is dropped, the sender's audio source disappears, or the sender leaves — reflected via
+ * [reapply], which the conference calls on the relevant events).
+ *
+ * All side effects on the conference source map and colibri session manager happen here; the pure naming/SSRC logic
+ * lives in [TranslationSourceManager].
+ */
+class ConferenceTranslationManager(
+    private val conferenceSources: ValidatingConferenceSourceMap,
+    parentLogger: Logger
+) {
+    private val logger = createChildLogger(parentLogger)
+    private val sourceManager = TranslationSourceManager()
+    private var requests: Map<String, List<String>> = emptyMap()
+
+    /** Update the aggregated request map and re-apply. */
+    @Synchronized
+    fun setRequests(
+        requests: Map<String, List<String>>,
+        colibriSessionManager: ColibriSessionManager?,
+        meetingId: String?
+    ) {
+        this.requests = requests
+        apply(colibriSessionManager, meetingId)
+    }
+
+    /** Re-apply the last request map (e.g. after a participant left or removed a source, or once colibri is ready). */
+    @Synchronized
+    fun reapply(colibriSessionManager: ColibriSessionManager?, meetingId: String?) =
+        apply(colibriSessionManager, meetingId)
+
+    private fun apply(colibriSessionManager: ColibriSessionManager?, meetingId: String?) {
+        if (colibriSessionManager == null || meetingId == null) {
+            // Not ready yet; will be applied from JitsiMeetConferenceImpl once colibri is initialized.
+            return
+        }
+
+        val result = sourceManager.update(requests, ::baseName, ::ssrcInUse)
+
+        // Diff the desired synthetic sources against what is currently in the conference source map and apply the delta.
+        val affected = mutableSetOf<String>()
+        for (sender in conferenceSources.unmodifiable().keys.toList()) {
+            val existingSynthetic = conferenceSources[sender]?.sources?.filter { it.synthetic }?.toSet() ?: emptySet()
+            val desired = result.sourcesBySender[sender] ?: emptySet()
+            val toRemove = existingSynthetic - desired
+            val toAdd = desired - existingSynthetic
+
+            try {
+                if (toRemove.isNotEmpty()) {
+                    conferenceSources.tryToRemove(sender, EndpointSourceSet(toRemove))
+                    affected += sender
+                }
+                if (toAdd.isNotEmpty()) {
+                    conferenceSources.tryToAdd(sender, EndpointSourceSet(toAdd))
+                    affected += sender
+                }
+            } catch (e: Exception) {
+                logger.error("Failed to update synthetic translation sources for $sender", e)
+            }
+        }
+
+        // Signal the updated source sets to the bridges.
+        affected.forEach { sender ->
+            colibriSessionManager.updateParticipant(sender, sources = conferenceSources[sender])
+        }
+
+        // Enable/update/disable the translator connect on the selected bridge.
+        val url = if (result.isEmpty) null else TranslationConfig.config.getUrl(meetingId)
+        colibriSessionManager.setTranslator(url, result.requestNames.toList(), result.exportNames.toList())
+    }
+
+    /** The base (first non-synthetic audio) source name for a sender, or null if it has none / is not present. */
+    private fun baseName(senderId: String): String? {
+        val audio = conferenceSources[senderId]?.sources?.firstOrNull {
+            it.mediaType == MediaType.AUDIO && !it.synthetic
+        } ?: return null
+        return audio.name ?: Source.nameForIdAndMediaType(senderId, MediaType.AUDIO, 0)
+    }
+
+    /** Whether an SSRC is already used by a non-synthetic source in the conference. */
+    private fun ssrcInUse(ssrc: Long): Boolean = conferenceSources.unmodifiable().values.any { set ->
+        set.sources.any { !it.synthetic && it.ssrc == ssrc }
+    }
+}

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManager.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright @ 2024 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.conference.translation
+
+import org.jitsi.jicofo.conference.source.Source
+import org.jitsi.utils.MediaType
+import java.util.concurrent.ThreadLocalRandom
+
+/**
+ * The result of recomputing the set of synthetic translation sources.
+ *
+ * @param sourcesBySender for each sender endpoint id, the set of synthetic audio sources (one per requested language).
+ * @param requestNames the names of the (real) source the translator should receive, i.e. the senders' base audio
+ * sources to be translated.
+ * @param exportNames the names of the synthetic sources the translator produces (each encodes the language as a
+ * "<baseName>.<lang>" suffix).
+ */
+data class TranslationSources(
+    val sourcesBySender: Map<String, Set<Source>>,
+    val requestNames: Set<String>,
+    val exportNames: Set<String>
+) {
+    val isEmpty: Boolean
+        get() = sourcesBySender.isEmpty()
+}
+
+/**
+ * Computes and tracks the synthetic audio [Source]s used for live translation.
+ *
+ * Given the aggregated request map (sender endpoint id -> requested language codes), it produces one synthetic audio
+ * source per `<sender, language>`, named `<baseName>.<language>` where `baseName` is the sender's first audio source
+ * name. SSRCs are minted to avoid collisions with the conference and are kept stable across updates: an existing
+ * `<sender, language>` keeps its SSRC, so the map is only ever extended or pruned, never churned.
+ *
+ * This class holds the allocation state but performs no side effects (it does not touch the conference source map or
+ * signal anything). The caller applies the returned [TranslationSources] to the conference.
+ */
+class TranslationSourceManager(
+    /** Mints a candidate SSRC. Overridable for tests; defaults to a random 32-bit value. */
+    private val ssrcGenerator: () -> Long = { ThreadLocalRandom.current().nextLong(1, MAX_SSRC) }
+) {
+    /** sender endpoint id -> (language -> synthetic source). */
+    private val allocated = mutableMapOf<String, MutableMap<String, Source>>()
+
+    /**
+     * Recompute the synthetic sources for [requests].
+     *
+     * @param requests sender endpoint id -> requested language codes.
+     * @param baseNameResolver returns the base (first audio) source name for a sender, or null when the sender is not
+     * present or has no audio source — such entries are skipped (and any existing synthetic sources for them dropped).
+     * @param ssrcInUse returns true when an SSRC is already used in the conference (by non-synthetic sources). Newly
+     * minted SSRCs avoid these as well as any already-allocated synthetic SSRC.
+     */
+    @Synchronized
+    fun update(
+        requests: Map<String, List<String>>,
+        baseNameResolver: (String) -> String?,
+        ssrcInUse: (Long) -> Boolean
+    ): TranslationSources {
+        val next = mutableMapOf<String, MutableMap<String, Source>>()
+
+        for ((sender, languages) in requests) {
+            if (languages.isEmpty()) continue
+            val baseName = baseNameResolver(sender) ?: continue
+            val existingForSender = allocated[sender]
+            val nextForSender = mutableMapOf<String, Source>()
+
+            for (language in languages.toSet()) {
+                val existing = existingForSender?.get(language)
+                nextForSender[language] = if (existing != null) {
+                    // Keep the SSRC stable; refresh the name in case the base source name changed.
+                    val expectedName = nameFor(baseName, language)
+                    if (existing.name == expectedName) existing else existing.copy(name = expectedName)
+                } else {
+                    Source(
+                        ssrc = mintSsrc(ssrcInUse, next),
+                        mediaType = MediaType.AUDIO,
+                        name = nameFor(baseName, language),
+                        synthetic = true
+                    )
+                }
+            }
+            next[sender] = nextForSender
+        }
+
+        allocated.clear()
+        allocated.putAll(next)
+
+        val sourcesBySender = next.mapValues { (_, byLang) -> byLang.values.toSet() }
+        val requestNames = next.keys.mapNotNull { baseNameResolver(it) }.toSet()
+        val exportNames = next.values.flatMap { it.values }.map { it.name!! }.toSet()
+
+        return TranslationSources(sourcesBySender, requestNames, exportNames)
+    }
+
+    /** All synthetic SSRCs currently allocated. */
+    @Synchronized
+    fun allocatedSsrcs(): Set<Long> = allocated.values.flatMap { it.values }.map { it.ssrc }.toSet()
+
+    private fun mintSsrc(ssrcInUse: (Long) -> Boolean, next: Map<String, Map<String, Source>>): Long {
+        val usedByNext = next.values.flatMap { it.values }.map { it.ssrc }.toSet()
+        val usedByAllocated = allocated.values.flatMap { it.values }.map { it.ssrc }.toSet()
+        repeat(MAX_MINT_ATTEMPTS) {
+            val candidate = ssrcGenerator() and 0xFFFFFFFFL
+            if (candidate != 0L && !ssrcInUse(candidate) && candidate !in usedByNext && candidate !in usedByAllocated) {
+                return candidate
+            }
+        }
+        throw IllegalStateException("Failed to mint a non-conflicting SSRC after $MAX_MINT_ATTEMPTS attempts")
+    }
+
+    companion object {
+        private const val MAX_SSRC = 0x1_0000_0000L
+        private const val MAX_MINT_ATTEMPTS = 1000
+
+        /** The synthetic source name for a base source name and a language: "<baseName>.<language>". */
+        fun nameFor(baseName: String, language: String) = "$baseName.$language"
+    }
+}

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManager.kt
@@ -23,10 +23,10 @@ import java.util.concurrent.ThreadLocalRandom
  * The result of recomputing the set of synthetic translation sources.
  *
  * @param sourcesBySender for each sender endpoint id, the set of synthetic audio sources (one per requested language).
- * @param requestNames the names of the (real) source the translator should receive, i.e. the senders' base audio
- * sources to be translated.
- * @param exportNames the names of the synthetic sources the translator produces (each encodes the language as a
- * "<baseName>.<lang>" suffix).
+ * @param requestNames the names of the synthetic sources the bridge requests from the translator (each encodes the
+ * language as a "<baseName>.<lang>" suffix).
+ * @param exportNames the names of the (real) sources the bridge exports to the translator, i.e. the senders' base
+ * audio sources to be translated.
  */
 data class TranslationSources(
     val sourcesBySender: Map<String, Set<Source>>,
@@ -100,8 +100,8 @@ class TranslationSourceManager(
         allocated.putAll(next)
 
         val sourcesBySender = next.mapValues { (_, byLang) -> byLang.values.toSet() }
-        val requestNames = next.keys.mapNotNull { baseNameResolver(it) }.toSet()
-        val exportNames = next.values.flatMap { it.values }.map { it.name!! }.toSet()
+        val requestNames = next.values.flatMap { it.values }.map { it.name!! }.toSet()
+        val exportNames = next.keys.mapNotNull { baseNameResolver(it) }.toSet()
 
         return TranslationSources(sourcesBySender, requestNames, exportNames)
     }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2024 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.bridge.colibri
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import org.jitsi.jicofo.TaskPools
+import org.jitsi.jicofo.bridge.Bridge
+import org.jitsi.jicofo.bridge.BridgeSelector
+import org.jitsi.jicofo.conference.inPlaceExecutor
+import org.jitsi.jicofo.conference.inPlaceScheduledExecutor
+import org.jitsi.jicofo.conference.source.EndpointSourceSet
+import org.jitsi.jicofo.mock.MockXmppConnection
+import org.jitsi.jicofo.mock.TestColibri2Server
+import org.jitsi.utils.TemplatedUrl
+import org.jitsi.utils.logging2.createLogger
+import org.jitsi.xmpp.extensions.colibri2.ConferenceModifyIQ
+import org.jitsi.xmpp.extensions.colibri2.Connect
+import org.jivesoftware.smack.packet.IQ
+import org.jxmpp.jid.impl.JidCreate
+
+/**
+ * Tests the colibri2 signaling for live translation in the default per-source mode: each sender's connect is placed on
+ * its (single, here) bridge, signaled as create/update/expire deltas, keyed by a per-source connect id.
+ */
+class ColibriTranslationTest : ShouldSpec() {
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    private val colibriRequests = mutableListOf<ConferenceModifyIQ>()
+    private val colibri2Server = TestColibri2Server()
+    private val xmppConnection = object : MockXmppConnection() {
+        override fun handleIq(iq: IQ): IQ? {
+            if (iq is ConferenceModifyIQ) {
+                colibriRequests.add(iq)
+                return colibri2Server.handleConferenceModifyIq(iq)
+            }
+            return null
+        }
+    }
+
+    private val bridge: Bridge = mockk(relaxed = true) {
+        every { jid } returns JidCreate.from("jvb@example.com/jvb1")
+        every { relayId } returns null
+        every { isOperational } returns true
+        every { debugState } returns JsonNodeFactory.instance.objectNode()
+        every { region } returns "us-east"
+    }
+
+    private val bridgeSelector: BridgeSelector = mockk {
+        every { selectBridge(any(), any(), any()) } returns bridge
+    }
+
+    private fun createSessionManager() = ColibriV2SessionManager(
+        xmppConnection.xmppConnection,
+        bridgeSelector,
+        "test-conference",
+        "test-meeting-id",
+        false,
+        null,
+        createLogger()
+    )
+
+    private fun allocateParticipant(manager: ColibriV2SessionManager, id: String) = manager.allocate(
+        ParticipantAllocationParameters(
+            id = id,
+            statsId = null,
+            region = null,
+            sources = EndpointSourceSet.EMPTY,
+            useSsrcRewriting = false,
+            forceMuteAudio = false,
+            forceMuteVideo = false,
+            useSctp = false,
+            visitor = false,
+            supportsPrivateAddresses = false,
+            medias = emptySet()
+        )
+    )
+
+    override suspend fun beforeAny(testCase: TestCase) = super.beforeAny(testCase).also {
+        TaskPools.ioPool = inPlaceExecutor
+        TaskPools.scheduledPool = inPlaceScheduledExecutor
+    }
+
+    override suspend fun afterAny(testCase: TestCase, result: TestResult) = super.afterAny(testCase, result).also {
+        TaskPools.resetIoPool()
+        TaskPools.resetScheduledPool()
+    }
+
+    init {
+        val translatorUrl = TemplatedUrl(
+            "wss://{{REGION}}.translate.example.com/t",
+            requiredKeys = setOf("REGION")
+        )
+        val expectedUrl = "wss://us-east.translate.example.com/t"
+
+        fun lastConnect() = colibriRequests.lastOrNull { it.connects != null }?.connects?.getConnects()?.firstOrNull()
+
+        context("Enabling per-source translation for a sender") {
+            val manager = createSessionManager()
+            allocateParticipant(manager, "p1")
+            colibriRequests.clear()
+            manager.setTranslator(
+                translatorUrl,
+                listOf(TranslationRequest("p1", "p1-a0", listOf("p1-a0.en", "p1-a0.es")))
+            )
+            val connect = lastConnect()
+
+            should("send a per-source translator connect with create") {
+                connect shouldNotBe null
+                connect!!.id shouldBe "translator-p1-0"
+                connect.type shouldBe Connect.Types.TRANSLATOR
+                connect.create shouldBe true
+                connect.expire shouldBe false
+            }
+            should("export the sender's source and request its synthetic outputs") {
+                connect!!.getExports() shouldBe listOf("p1-a0")
+                connect.getRequests() shouldBe listOf("p1-a0.en", "p1-a0.es")
+            }
+            should("resolve the url for the bridge region") {
+                connect!!.url.toString() shouldBe expectedUrl
+            }
+        }
+
+        context("Updating the requested languages") {
+            val manager = createSessionManager()
+            allocateParticipant(manager, "p1")
+            manager.setTranslator(translatorUrl, listOf(TranslationRequest("p1", "p1-a0", listOf("p1-a0.en"))))
+            colibriRequests.clear()
+            manager.setTranslator(
+                translatorUrl,
+                listOf(TranslationRequest("p1", "p1-a0", listOf("p1-a0.en", "p1-a0.es")))
+            )
+            val connect = lastConnect()
+
+            should("re-signal the same connect as an update (not create)") {
+                connect shouldNotBe null
+                connect!!.id shouldBe "translator-p1-0"
+                connect.create shouldBe false
+                connect.expire shouldBe false
+                connect.getRequests() shouldBe listOf("p1-a0.en", "p1-a0.es")
+            }
+        }
+
+        context("Disabling translation") {
+            val manager = createSessionManager()
+            allocateParticipant(manager, "p1")
+            manager.setTranslator(translatorUrl, listOf(TranslationRequest("p1", "p1-a0", listOf("p1-a0.en"))))
+            colibriRequests.clear()
+            manager.setTranslator(null, emptyList())
+            val connect = lastConnect()
+
+            should("expire the connect") {
+                connect shouldNotBe null
+                connect!!.id shouldBe "translator-p1-0"
+                connect.expire shouldBe true
+            }
+        }
+    }
+}

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
@@ -129,7 +129,7 @@ class ColibriTranslationTest : ShouldSpec() {
 
             should("send a per-source translator connect with create") {
                 connect shouldNotBe null
-                connect!!.id shouldBe "translator-p1-0"
+                connect!!.id shouldBe "translator-p1-a0-0"
                 connect.type shouldBe Connect.Types.TRANSLATOR
                 connect.create shouldBe true
                 connect.expire shouldBe false
@@ -156,7 +156,7 @@ class ColibriTranslationTest : ShouldSpec() {
 
             should("re-signal the same connect as an update (not create)") {
                 connect shouldNotBe null
-                connect!!.id shouldBe "translator-p1-0"
+                connect!!.id shouldBe "translator-p1-a0-0"
                 connect.create shouldBe false
                 connect.expire shouldBe false
                 connect.getRequests() shouldBe listOf("p1-a0.en", "p1-a0.es")
@@ -173,7 +173,7 @@ class ColibriTranslationTest : ShouldSpec() {
 
             should("expire the connect") {
                 connect shouldNotBe null
-                connect!!.id shouldBe "translator-p1-0"
+                connect!!.id shouldBe "translator-p1-a0-0"
                 connect.expire shouldBe true
             }
         }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
@@ -177,5 +177,39 @@ class ColibriTranslationTest : ShouldSpec() {
                 connect.expire shouldBe true
             }
         }
+
+        context("With per-room translator headers") {
+            val manager = createSessionManager()
+            allocateParticipant(manager, "p1")
+            colibriRequests.clear()
+            manager.setTranslator(
+                translatorUrl,
+                listOf(TranslationRequest("p1", "p1-a0", listOf("p1-a0.en"))),
+                customHeaders = mapOf("Authorization" to "Bearer per-room", "X-Custom" to "v1")
+            )
+            val connect = lastConnect()
+
+            should("put the per-room headers on the connect") {
+                connect shouldNotBe null
+                connect!!.getHttpHeaders().associate { it.name to it.value } shouldBe mapOf(
+                    "Authorization" to "Bearer per-room",
+                    "X-Custom" to "v1"
+                )
+            }
+        }
+
+        context("Without per-room translator headers") {
+            val manager = createSessionManager()
+            allocateParticipant(manager, "p1")
+            colibriRequests.clear()
+            // No customHeaders: fall back to the (empty, in this test) static config headers.
+            manager.setTranslator(translatorUrl, listOf(TranslationRequest("p1", "p1-a0", listOf("p1-a0.en"))))
+            val connect = lastConnect()
+
+            should("fall back to the config headers (none configured here)") {
+                connect shouldNotBe null
+                connect!!.getHttpHeaders().associate { it.name to it.value } shouldBe emptyMap()
+            }
+        }
     }
 }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManagerTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManagerTest.kt
@@ -48,9 +48,9 @@ class TranslationSourceManagerTest : ShouldSpec() {
                 source.synthetic shouldBe true
                 source.ssrc shouldBe 100L
             }
-            should("report the input and export names for the connect") {
-                result.requestNames shouldContainExactly setOf("aaaaaaaa-a0")
-                result.exportNames shouldContainExactly setOf("aaaaaaaa-a0.en")
+            should("report the request and export names for the connect") {
+                result.requestNames shouldContainExactly setOf("aaaaaaaa-a0.en")
+                result.exportNames shouldContainExactly setOf("aaaaaaaa-a0")
             }
         }
 
@@ -62,8 +62,8 @@ class TranslationSourceManagerTest : ShouldSpec() {
                 sources.map { it.name } shouldContainExactlyInAnyOrder listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.es")
                 sources.map { it.ssrc }.toSet().size shouldBe 2
             }
-            should("export both synthetic names") {
-                result.exportNames shouldContainExactlyInAnyOrder listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.es")
+            should("request both synthetic names") {
+                result.requestNames shouldContainExactlyInAnyOrder listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.es")
             }
         }
 
@@ -106,7 +106,7 @@ class TranslationSourceManagerTest : ShouldSpec() {
             )
             should("skip the unresolved sender and keep the resolved one") {
                 result.sourcesBySender.keys shouldContainExactly setOf("aaaaaaaa")
-                result.exportNames shouldContainExactly setOf("aaaaaaaa-a0.en")
+                result.requestNames shouldContainExactly setOf("aaaaaaaa-a0.en")
             }
         }
 

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManagerTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManagerTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright @ 2024 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.conference.translation
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.jitsi.utils.MediaType
+
+class TranslationSourceManagerTest : ShouldSpec() {
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    /** A deterministic SSRC generator returning 100, 101, 102, ... */
+    private var nextSsrc = 100L
+    private val sequentialGenerator: () -> Long = { nextSsrc++ }
+
+    /** Every sender resolves to "<id>-a0" unless overridden. */
+    private val baseName: (String) -> String? = { "$it-a0" }
+    private val noneInUse: (Long) -> Boolean = { false }
+
+    init {
+        val manager = TranslationSourceManager(sequentialGenerator)
+
+        context("A single sender and language") {
+            val result = manager.update(mapOf("aaaaaaaa" to listOf("en")), baseName, noneInUse)
+            val sources = result.sourcesBySender["aaaaaaaa"]!!
+
+            should("produce one synthetic audio source named <base>.<lang>") {
+                sources.size shouldBe 1
+                val source = sources.first()
+                source.name shouldBe "aaaaaaaa-a0.en"
+                source.mediaType shouldBe MediaType.AUDIO
+                source.synthetic shouldBe true
+                source.ssrc shouldBe 100L
+            }
+            should("report the input and export names for the connect") {
+                result.requestNames shouldContainExactly setOf("aaaaaaaa-a0")
+                result.exportNames shouldContainExactly setOf("aaaaaaaa-a0.en")
+            }
+        }
+
+        context("Multiple languages for one sender") {
+            val result = manager.update(mapOf("aaaaaaaa" to listOf("en", "es")), baseName, noneInUse)
+            val sources = result.sourcesBySender["aaaaaaaa"]!!
+
+            should("produce one source per language with distinct ssrcs") {
+                sources.map { it.name } shouldContainExactlyInAnyOrder listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.es")
+                sources.map { it.ssrc }.toSet().size shouldBe 2
+            }
+            should("export both synthetic names") {
+                result.exportNames shouldContainExactlyInAnyOrder listOf("aaaaaaaa-a0.en", "aaaaaaaa-a0.es")
+            }
+        }
+
+        context("Stability across updates") {
+            val first = manager.update(mapOf("aaaaaaaa" to listOf("en")), baseName, noneInUse)
+            val ssrc = first.sourcesBySender["aaaaaaaa"]!!.first().ssrc
+
+            should("keep the same ssrc when re-applying the same request") {
+                val second = manager.update(mapOf("aaaaaaaa" to listOf("en")), baseName, noneInUse)
+                second.sourcesBySender["aaaaaaaa"]!!.first().ssrc shouldBe ssrc
+            }
+            should("keep existing ssrc and mint a fresh one when adding a language") {
+                val second = manager.update(mapOf("aaaaaaaa" to listOf("en", "es")), baseName, noneInUse)
+                val byName = second.sourcesBySender["aaaaaaaa"]!!.associateBy { it.name }
+                byName["aaaaaaaa-a0.en"]!!.ssrc shouldBe ssrc
+                byName["aaaaaaaa-a0.es"]!!.ssrc shouldBe 101L
+            }
+            should("drop a language that is no longer requested, keeping the other") {
+                manager.update(mapOf("aaaaaaaa" to listOf("en", "es")), baseName, noneInUse)
+                val third = manager.update(mapOf("aaaaaaaa" to listOf("es")), baseName, noneInUse)
+                val sources = third.sourcesBySender["aaaaaaaa"]!!
+                sources.size shouldBe 1
+                sources.first().name shouldBe "aaaaaaaa-a0.es"
+            }
+        }
+
+        context("SSRC collision avoidance") {
+            // 100 is already used by the conference; the manager must skip it and pick 101.
+            val result = manager.update(mapOf("aaaaaaaa" to listOf("en")), baseName, ssrcInUse = { it == 100L })
+            should("mint an ssrc that does not collide with the conference") {
+                result.sourcesBySender["aaaaaaaa"]!!.first().ssrc shouldBe 101L
+            }
+        }
+
+        context("Sender not present or without an audio source") {
+            val result = manager.update(
+                mapOf("aaaaaaaa" to listOf("en"), "bbbbbbbb" to listOf("fr")),
+                baseNameResolver = { if (it == "aaaaaaaa") "aaaaaaaa-a0" else null },
+                noneInUse
+            )
+            should("skip the unresolved sender and keep the resolved one") {
+                result.sourcesBySender.keys shouldContainExactly setOf("aaaaaaaa")
+                result.exportNames shouldContainExactly setOf("aaaaaaaa-a0.en")
+            }
+        }
+
+        context("Empty requests") {
+            manager.update(mapOf("aaaaaaaa" to listOf("en")), baseName, noneInUse)
+            val result = manager.update(emptyMap(), baseName, noneInUse)
+            should("clear all synthetic sources") {
+                result.isEmpty shouldBe true
+                manager.allocatedSsrcs().isEmpty() shouldBe true
+            }
+        }
+    }
+}

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManagerTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/translation/TranslationSourceManagerTest.kt
@@ -110,6 +110,24 @@ class TranslationSourceManagerTest : ShouldSpec() {
             }
         }
 
+        context("Sender's audio source appears on a later update") {
+            var hasAudio = false
+            val lateResolver: (String) -> String? = { if (it == "aaaaaaaa" && hasAudio) "aaaaaaaa-a0" else null }
+
+            // Request arrives before the sender has an audio source: skipped, no synthetic source.
+            val first = manager.update(mapOf("aaaaaaaa" to listOf("es")), lateResolver, noneInUse)
+
+            should("skip the sender while it has no audio source") {
+                first.isEmpty shouldBe true
+            }
+            should("create the synthetic source once the audio source appears and the same request is re-applied") {
+                hasAudio = true
+                val second = manager.update(mapOf("aaaaaaaa" to listOf("es")), lateResolver, noneInUse)
+
+                second.sourcesBySender["aaaaaaaa"]!!.map { it.name } shouldContainExactly listOf("aaaaaaaa-a0.es")
+            }
+        }
+
         context("Empty requests") {
             manager.update(mapOf("aaaaaaaa" to listOf("en")), baseName, noneInUse)
             val result = manager.update(emptyMap(), baseName, noneInUse)

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-113-g4281255</version>
+        <version>1.0-114-g087129a</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-112-gfe4b514</version>
+        <version>1.0-113-g4281255</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Adds the jicofo side of live audio translation.

- Maintains synthetic audio sources (one per requested target language, named `<base>.<lang>`) in the conference source map, driven by the aggregated request map from RoomMetadata.
- Drives the translator `<connect>` to the bridge(s), signaled as **id-keyed create/expire deltas** (matching jitsi/jitsi-xmpp-extensions#143).
- Two placement modes via `jicofo.translation.mode`:
  - **per-source** (default) — each sender's audio is translated by connect(s) on its own local bridge, split into multiple connects when it has more than `max-languages-per-connect` target languages;
  - **single-bridge** — all translation aggregated onto one selected bridge (previous behaviour). `max-languages-per-connect` applies only to per-source.
- Configurable translator URL template and HTTP headers.

**Depends on jitsi/jitsi-xmpp-extensions#143** for the connect id/create/expire attributes. Will not compile against a released xmpp-ext until #143 merges and is released, after which the pom dependency gets bumped.