### PR TITLE
Signal rtp-mid-demux capability for supporting participants

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/Features.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/Features.kt
@@ -36,6 +36,9 @@ enum class Features(val value: String) {
     /** Source name signalling. */
     SOURCE_NAMES("http://jitsi.org/source-name"),
     SSRC_REWRITING_V1("http://jitsi.org/ssrc-rewriting-1"),
+
+    /** The endpoint can demux forwarded media by the RTP sdes:mid header extension (requires SSRC rewriting). */
+    RTP_MID_DEMUX("http://jitsi.org/rtp-mid-demux"),
     RECEIVE_MULTIPLE_STREAMS("http://jitsi.org/receive-multiple-video-streams"),
 
     /** Jingle sources encoded as JSON. */

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -103,6 +103,7 @@ data class ParticipantAllocationParameters(
     val region: String?,
     val sources: EndpointSourceSet,
     val useSsrcRewriting: Boolean,
+    val useRtpMidDemux: Boolean,
     val forceMuteAudio: Boolean,
     val forceMuteVideo: Boolean,
     val useSctp: Boolean,

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
@@ -115,9 +115,7 @@ internal fun ParticipantInfo.toEndpoint(
             addCapability(Capability.CAP_SSRC_REWRITING_SUPPORT)
         }
         if (useRtpMidDemux) {
-            // TODO: replace the literal with Capability.CAP_RTP_MID_DEMUX_SUPPORT once a jitsi-xmpp-extensions release
-            // containing it is depended on here.
-            addCapability("rtp-mid-demux")
+            addCapability(Capability.CAP_RTP_MID_DEMUX_SUPPORT)
         }
     }
     // TODO: find a way to signal sources only when they change? Or is this already the case implicitly?

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
@@ -111,6 +111,11 @@ internal fun ParticipantInfo.toEndpoint(
         if (useSsrcRewriting) {
             addCapability(Capability.CAP_SSRC_REWRITING_SUPPORT)
         }
+        if (useRtpMidDemux) {
+            // TODO: replace the literal with Capability.CAP_RTP_MID_DEMUX_SUPPORT once a jitsi-xmpp-extensions release
+            // containing it is depended on here.
+            addCapability("rtp-mid-demux")
+        }
     }
     // TODO: find a way to signal sources only when they change? Or is this already the case implicitly?
     if (!expire) {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
@@ -33,6 +33,7 @@ class ParticipantInfo(
     val medias = parameters.medias
     val supportsPrivateAddresses = parameters.supportsPrivateAddresses
     val useSsrcRewriting = parameters.useSsrcRewriting
+    val useRtpMidDemux = parameters.useRtpMidDemux
     val visitor = parameters.visitor
 
     var audioMuted = parameters.forceMuteAudio
@@ -48,6 +49,7 @@ class ParticipantInfo(
         put("video_muted", videoMuted)
         put("private_addresses", supportsPrivateAddresses)
         put("ssrc_rewriting", useSsrcRewriting)
+        put("rtp_mid_demux", useRtpMidDemux)
         put("visitor", visitor)
     }
 }

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -245,6 +245,10 @@ jicofo {
     // Whether to use SSRC rewriting for participants that support it.
     use-ssrc-rewriting = true
 
+    // Whether to have the bridge stamp the sdes:mid header extension on rewritten media (and signal per-slot mids),
+    // for participants that support mid-based demuxing. Only takes effect together with use-ssrc-rewriting.
+    use-rtp-mid-demux = true
+
     // Whether to use a JSON encoding of sources instead of the standard Jingle encoding (only used for participants
     // that signal support for JSON encoded sources).
     use-json-encoded-sources = true

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
@@ -201,6 +201,7 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
                     participant.getChatMember().getRegion(),
                     participant.getSources(),
                     participant.useSsrcRewriting(),
+                    participant.useRtpMidDemux(),
                     forceMuteAudio,
                     forceMuteVideo,
                     offer.getContents().stream().anyMatch(c -> c.getName() == "data"),

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/ConferenceConfig.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/ConferenceConfig.kt
@@ -72,6 +72,10 @@ class ConferenceConfig private constructor() {
         "jicofo.conference.use-ssrc-rewriting".from(newConfig)
     }
 
+    val useRtpMidDemux: Boolean by config {
+        "jicofo.conference.use-rtp-mid-demux".from(newConfig)
+    }
+
     val useJsonEncodedSources: Boolean by config {
         "jicofo.conference.use-json-encoded-sources".from(newConfig)
     }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -171,6 +171,12 @@ open class Participant @JvmOverloads constructor(
     /** Return `true` if SSRC rewriting should be used for this participant. */
     fun useSsrcRewriting() = ConferenceConfig.config.useSsrcRewriting && hasSsrcRewritingSupport()
 
+    /** Return `true` if this participant supports demuxing forwarded media by the RTP sdes:mid header extension. */
+    fun hasRtpMidDemuxSupport() = supportedFeatures.contains(Features.RTP_MID_DEMUX)
+
+    /** Return `true` if the bridge should stamp mids on media forwarded to this participant. Requires SSRC rewriting. */
+    fun useRtpMidDemux() = useSsrcRewriting() && ConferenceConfig.config.useRtpMidDemux && hasRtpMidDemuxSupport()
+
     /** Return `true` if this participant supports receiving Jingle sources encoded in JSON. */
     fun supportsJsonEncodedSources() = supportedFeatures.contains(Features.JSON_SOURCES)
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.jicofo.ConferenceConfig
 import org.jitsi.jicofo.TaskPools.Companion.scheduledPool
+import org.jitsi.jicofo.codec.Config
 import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.InvalidBridgeSessionIdException
 import org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.SenderCountExceededException
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
@@ -174,8 +175,14 @@ open class Participant @JvmOverloads constructor(
     /** Return `true` if this participant supports demuxing forwarded media by the RTP sdes:mid header extension. */
     fun hasRtpMidDemuxSupport() = supportedFeatures.contains(Features.RTP_MID_DEMUX)
 
-    /** Return `true` if the bridge should stamp mids on media forwarded to this participant. Requires SSRC rewriting. */
-    fun useRtpMidDemux() = useSsrcRewriting() && ConferenceConfig.config.useRtpMidDemux && hasRtpMidDemuxSupport()
+    /**
+     * Return `true` if the bridge should stamp mids on media forwarded to this participant. Requires SSRC rewriting and
+     * that the sdes:mid header extension is being offered.
+     */
+    fun useRtpMidDemux() = useSsrcRewriting() &&
+        ConferenceConfig.config.useRtpMidDemux &&
+        hasRtpMidDemuxSupport() &&
+        Config.config.mid.enabled()
 
     /** Return `true` if this participant supports receiving Jingle sources encoded in JSON. */
     fun supportsJsonEncodedSources() = supportedFeatures.contains(Features.JSON_SOURCES)

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranscriptionTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranscriptionTest.kt
@@ -90,6 +90,7 @@ class ColibriTranscriptionTest : ShouldSpec() {
             region = null,
             sources = EndpointSourceSet.EMPTY,
             useSsrcRewriting = false,
+            useRtpMidDemux = false,
             forceMuteAudio = false,
             forceMuteVideo = false,
             useSctp = false,

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-114-g087129a</version>
+        <version>1.0-115-gd0c3cd0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Summary

When a participant advertises mid-demux support (and SSRC rewriting is in use), tell the bridge via the new `rtp-mid-demux` Colibri2 endpoint capability so it stamps the `sdes:mid` header extension on rewritten media. The mid extension itself is already offered to clients, so no change to the offer is needed; this only controls the bridge-side stamping.

Part of the cross-repo **bridge-stamped mid** change (durable fix for the Chrome/WebRTC silent audio-demux wedge under SSRC rewriting). Companion `mid-demux-stamping` branches in **jitsi-xmpp-extensions**, **jitsi-videobridge**, and **lib-jitsi-meet**; tested together.

## Details

- `Features.RTP_MID_DEMUX` disco feature (`http://jitsi.org/rtp-mid-demux`).
- `Participant.useRtpMidDemux()`: requires SSRC rewriting, the new `use-rtp-mid-demux` config (default on), and client support.
- Plumbed through `ParticipantAllocationParameters` → `ParticipantInfo` and emitted in `Extensions.toEndpoint`.

The capability is added by literal string to keep building against the currently-depended jitsi-xmpp-extensions release; switch to `Capability.CAP_RTP_MID_DEMUX_SUPPORT` once a release containing it is used.

## Tests

`mvn test-compile`, ktlint, and `ColibriTranscriptionTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
