### PR TITLE
feat(jibri): wait and retry selection when all Jibris are busy

### DIFF
--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -303,6 +303,19 @@ jicofo {
     // How many times to retry a given Jibri request before giving up. Set to -1 to allow infinite retries.
     num-retries = 5
 
+    // When a start request can not be served because all connected Jibri instances are busy, retry the selection
+    // this many additional times (waiting `busy-retry-delay` between attempts) before failing with a
+    // "resource_constraint" error. This bridges brief capacity shortfalls, e.g. a demand spike at the top of the
+    // hour while the autoscaler spins up more instances, or two requests racing for the last free instance. Unlike
+    // `num-retries` (which moves on to a *different* instance after one fails), this waits for the pool itself to
+    // free up. Set to 0 (the default) to fail immediately, preserving the previous behavior. Note that this delays
+    // the response to the client and briefly blocks the conference's request queue, so keep the total wait
+    // (`busy-retries` * `busy-retry-delay`) modest.
+    busy-retries = 0
+
+    // How long to wait between busy retries (see `busy-retries`). Only used when `busy-retries` > 0.
+    busy-retry-delay = 5 seconds
+
     // How long to wait for Jibri to start recording from the time it accepts a START request.
     pending-timeout = 90 seconds
 

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -304,13 +304,14 @@ jicofo {
     num-retries = 5
 
     // When a start request can not be served because all connected Jibri instances are busy, retry the selection
-    // this many additional times (waiting `busy-retry-delay` between attempts) before failing with a
-    // "resource_constraint" error. This bridges brief capacity shortfalls, e.g. a demand spike at the top of the
-    // hour while the autoscaler spins up more instances, or two requests racing for the last free instance. Unlike
-    // `num-retries` (which moves on to a *different* instance after one fails), this waits for the pool itself to
-    // free up. Set to 0 (the default) to fail immediately, preserving the previous behavior. Note that this delays
-    // the response to the client and briefly blocks the conference's request queue, so keep the total wait
-    // (`busy-retries` * `busy-retry-delay`) modest.
+    // this many additional times (waiting `busy-retry-delay` between attempts) before giving up. This bridges
+    // brief capacity shortfalls, e.g. a demand spike at the top of the hour while the autoscaler spins up more
+    // instances, or two requests racing for the last free instance. Unlike `num-retries` (which moves on to a
+    // *different* instance after one fails), this waits for the pool itself to free up. The retries are performed
+    // asynchronously: the client receives an immediate "result" and is told the eventual outcome via presence (the
+    // recording turns ON if an instance frees up, or is reported failed once the retries are exhausted), so this
+    // does not block jicofo. Set to 0 (the default) to fail immediately with a "resource_constraint" error,
+    // preserving the previous behavior.
     busy-retries = 0
 
     // How long to wait between busy retries (see `busy-retries`). Only used when `busy-retries` > 0.

--- a/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
@@ -171,6 +171,24 @@ public class JibriSession
     private final long busyRetryDelayMs;
 
     /**
+     * How many busy-retries have been scheduled so far for this session. Bounded by {@link #maxBusyRetries} across
+     * the whole session (it is not reset per attempt).
+     */
+    private int busyRetries = 0;
+
+    /**
+     * Reference to a scheduled busy-retry task, so it can be cancelled (e.g. on {@link #stop(Jid)}).
+     */
+    @NotNull
+    private final AtomicReference<ScheduledFuture<?>> busyRetryTask = new AtomicReference<>();
+
+    /**
+     * Set once the session is stopped, so that a busy-retry task which is already firing becomes a no-op instead of
+     * (re)starting a session that the caller has already torn down.
+     */
+    private boolean cancelled = false;
+
+    /**
      * The full JID of the entity that has initiated the recording flow.
      */
     private final Jid initiator;
@@ -322,7 +340,31 @@ public class JibriSession
     private void startInternal()
         throws StartException
     {
-        final Jid jibriJid = selectJibriWithBusyRetries();
+        final Jid jibriJid = jibriDetector.selectJibri();
+
+        if (jibriJid == null)
+        {
+            if (!jibriDetector.isAnyInstanceConnected())
+            {
+                logger.error("Unable to find an available Jibri, can't start (no instances connected)");
+                throw new StartException.NotAvailable();
+            }
+
+            // All connected instances are busy. Rather than blocking the calling thread, schedule an asynchronous
+            // retry (up to maxBusyRetries times) in case one frees up, and return without failing. The caller
+            // treats the recording as in-progress; the client is notified of the eventual outcome via presence
+            // (ON on success, OFF/ERROR if the retries are exhausted). This bridges brief capacity shortfalls,
+            // e.g. a demand spike while the autoscaler spins up more instances, or two requests racing for the
+            // last free instance.
+            if (busyRetryDelayMs > 0 && busyRetries < maxBusyRetries)
+            {
+                scheduleBusyRetry();
+                return;
+            }
+
+            logger.error("Unable to find an available Jibri, can't start (all instances busy)");
+            throw new StartException.AllBusy();
+        }
 
         try
         {
@@ -346,58 +388,36 @@ public class JibriSession
     }
 
     /**
-     * Selects a Jibri to use, retrying when all connected instances are busy.
-     *
-     * When {@link JibriDetector#selectJibri()} returns no instance because they are all busy, this waits up to
-     * {@link #maxBusyRetries} times (sleeping {@link #busyRetryDelayMs} between attempts) for one to free up before
-     * giving up with {@link StartException.AllBusy}. This bridges brief capacity shortfalls (e.g. a demand spike
-     * while the autoscaler spins up more instances, or two requests racing for the last free instance).
-     *
-     * The "no instances connected at all" case ({@link StartException.NotAvailable}) fails immediately, since
-     * waiting can not help when no Jibri infrastructure is present.
-     *
-     * @return the selected Jibri's JID (never null).
-     * @throws StartException.AllBusy if all connected instances remained busy after exhausting the retries.
-     * @throws StartException.NotAvailable if no Jibri instance is connected.
+     * Schedules an asynchronous retry of {@link #startInternal()} after {@link #busyRetryDelayMs}, used when all
+     * connected Jibris are busy. Unlike a blocking wait, this does not tie up the calling thread or hold this
+     * session's monitor while waiting: the delay runs on the (small) scheduled pool and the retry itself (which
+     * exchanges the bounded start IQ with a Jibri) runs on the IO pool.
      */
-    private Jid selectJibriWithBusyRetries()
-        throws StartException
+    private void scheduleBusyRetry()
     {
-        int busyRetries = 0;
-        while (true)
+        busyRetries++;
+        logger.info("All Jibris are busy, scheduling busy-retry " + busyRetries + "/" + maxBusyRetries
+            + " in " + busyRetryDelayMs + "ms");
+        ScheduledFuture<?> newTask = TaskPools.getScheduledPool().schedule(
+            () -> TaskPools.getIoPool().execute(new BusyRetryTask()),
+            busyRetryDelayMs,
+            TimeUnit.MILLISECONDS);
+        ScheduledFuture<?> oldTask = busyRetryTask.getAndSet(newTask);
+        if (oldTask != null)
         {
-            final Jid jibriJid = jibriDetector.selectJibri();
-            if (jibriJid != null)
-            {
-                return jibriJid;
-            }
+            oldTask.cancel(false);
+        }
+    }
 
-            if (!jibriDetector.isAnyInstanceConnected())
-            {
-                logger.error("Unable to find an available Jibri, can't start (no instances connected)");
-                throw new StartException.NotAvailable();
-            }
-
-            // All connected instances are busy. Optionally wait and retry, in case one frees up.
-            if (busyRetryDelayMs <= 0 || busyRetries >= maxBusyRetries)
-            {
-                logger.error("Unable to find an available Jibri, can't start (all instances busy)");
-                throw new StartException.AllBusy();
-            }
-
-            busyRetries++;
-            logger.info("All Jibris are busy, waiting " + busyRetryDelayMs + "ms before busy-retry "
-                + busyRetries + "/" + maxBusyRetries);
-            try
-            {
-                Thread.sleep(busyRetryDelayMs);
-            }
-            catch (InterruptedException e)
-            {
-                Thread.currentThread().interrupt();
-                logger.warn("Interrupted while waiting to retry Jibri selection.");
-                throw new StartException.AllBusy();
-            }
+    /**
+     * Cancels any scheduled busy-retry task.
+     */
+    private void clearBusyRetry()
+    {
+        ScheduledFuture<?> oldTask = busyRetryTask.getAndSet(null);
+        if (oldTask != null)
+        {
+            oldTask.cancel(false);
         }
     }
 
@@ -410,11 +430,25 @@ public class JibriSession
      */
     synchronized public void stop(Jid initiator)
     {
+        this.terminator = initiator;
+
+        // Cancel any scheduled busy-retry, and make sure a retry that is already firing becomes a no-op.
+        boolean hadPendingBusyRetry = busyRetryTask.get() != null;
+        cancelled = true;
+        clearBusyRetry();
+
         if (currentJibriJid == null)
         {
+            // No Jibri has been engaged yet. If we were still waiting for capacity (a busy-retry was pending),
+            // let the owner know the session is over so its presence is cleared; otherwise there is nothing to do.
+            if (hadPendingBusyRetry)
+            {
+                logger.info("Stopping session while still waiting for an available Jibri: " + roomName);
+                jibriDetector.removeHandler(jibriEventHandler);
+                dispatchSessionStateChanged(Status.OFF, null);
+            }
             return;
         }
-        this.terminator = initiator;
 
         logger.info("Stopping session for room: " + roomName);
 
@@ -457,6 +491,7 @@ public class JibriSession
         logger.info("Cleaning up current JibriSession");
         currentJibriJid = null;
         numRetries = 0;
+        clearBusyRetry();
         jibriDetector.removeHandler(jibriEventHandler);
     }
 
@@ -819,6 +854,43 @@ public class JibriSession
     public String getSessionId()
     {
         return this.sessionId;
+    }
+
+    /**
+     * Task that retries {@link #startInternal()} after a busy-retry delay, scheduled when all Jibris were busy at
+     * the time of the previous attempt. Runs on the IO pool (so the bounded start-IQ exchange does not occupy the
+     * small scheduled pool). If the session has already been stopped, it does nothing. If the retry budget is
+     * exhausted, it notifies the owner of failure via presence, mirroring the terminal failure path.
+     */
+    private class BusyRetryTask implements Runnable
+    {
+        public void run()
+        {
+            synchronized (JibriSession.this)
+            {
+                // This task has now fired; clear our reference to it.
+                busyRetryTask.set(null);
+
+                if (cancelled)
+                {
+                    logger.info("Busy-retry fired but the session was stopped; ignoring.");
+                    return;
+                }
+
+                try
+                {
+                    startInternal();
+                }
+                catch (StartException e)
+                {
+                    // No Jibri became available within the retry budget (or another terminal error). Notify the
+                    // owner (which publishes presence) that the recording failed, then clean up.
+                    logger.warn("Giving up starting Jibri session after busy-retries: " + e);
+                    dispatchSessionStateChanged(Status.OFF, FailureReason.ERROR);
+                    cleanupSession();
+                }
+            }
+        }
     }
 
     /**

--- a/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
@@ -160,6 +160,17 @@ public class JibriSession
     private int numRetries = 0;
 
     /**
+     * The maximum number of times to re-select a Jibri when all connected instances are busy, waiting
+     * {@link #busyRetryDelayMs} between attempts. Zero disables busy-retries (the request fails immediately).
+     */
+    private final int maxBusyRetries;
+
+    /**
+     * How long (in milliseconds) to wait between busy-retries. See {@link #maxBusyRetries}.
+     */
+    private final long busyRetryDelayMs;
+
+    /**
      * The full JID of the entity that has initiated the recording flow.
      */
     private final Jid initiator;
@@ -186,6 +197,9 @@ public class JibriSession
      * @param youTubeBroadcastId the YouTube broadcast id (optional)
      * @param applicationData a JSON-encoded string containing application-specific
      * data for Jibri
+     * @param maxBusyRetries the maximum number of times to re-select a Jibri when all connected instances are busy
+     * (waiting {@code busyRetryDelayMs} between attempts). Zero disables busy-retries.
+     * @param busyRetryDelayMs how long (in milliseconds) to wait between busy-retries.
      * @param parentLogger the parent logger whose context will be inherited by {@link #logger}.
      */
     JibriSession(
@@ -203,6 +217,8 @@ public class JibriSession
             String sessionId,
             String applicationData,
             boolean rtcStatsEnabled,
+            int maxBusyRetries,
+            long busyRetryDelayMs,
             Logger parentLogger)
     {
         this.stateListener = stateListener;
@@ -210,6 +226,8 @@ public class JibriSession
         this.initiator = initiator;
         this.pendingTimeout = pendingTimeout;
         this.maxNumRetries = maxNumRetries;
+        this.maxBusyRetries = maxBusyRetries;
+        this.busyRetryDelayMs = busyRetryDelayMs;
         this.isSIP = isSIP;
         this.jibriDetector = jibriDetector;
         this.sipAddress = sipAddress;
@@ -304,19 +322,7 @@ public class JibriSession
     private void startInternal()
         throws StartException
     {
-        final Jid jibriJid = jibriDetector.selectJibri();
-
-        if (jibriJid == null)
-        {
-            logger.error("Unable to find an available Jibri, can't start");
-
-            if (jibriDetector.isAnyInstanceConnected())
-            {
-                throw new StartException.AllBusy();
-            }
-
-            throw new StartException.NotAvailable();
-        }
+        final Jid jibriJid = selectJibriWithBusyRetries();
 
         try
         {
@@ -335,6 +341,62 @@ public class JibriSession
             else
             {
                 throw new StartException.InternalServerError();
+            }
+        }
+    }
+
+    /**
+     * Selects a Jibri to use, retrying when all connected instances are busy.
+     *
+     * When {@link JibriDetector#selectJibri()} returns no instance because they are all busy, this waits up to
+     * {@link #maxBusyRetries} times (sleeping {@link #busyRetryDelayMs} between attempts) for one to free up before
+     * giving up with {@link StartException.AllBusy}. This bridges brief capacity shortfalls (e.g. a demand spike
+     * while the autoscaler spins up more instances, or two requests racing for the last free instance).
+     *
+     * The "no instances connected at all" case ({@link StartException.NotAvailable}) fails immediately, since
+     * waiting can not help when no Jibri infrastructure is present.
+     *
+     * @return the selected Jibri's JID (never null).
+     * @throws StartException.AllBusy if all connected instances remained busy after exhausting the retries.
+     * @throws StartException.NotAvailable if no Jibri instance is connected.
+     */
+    private Jid selectJibriWithBusyRetries()
+        throws StartException
+    {
+        int busyRetries = 0;
+        while (true)
+        {
+            final Jid jibriJid = jibriDetector.selectJibri();
+            if (jibriJid != null)
+            {
+                return jibriJid;
+            }
+
+            if (!jibriDetector.isAnyInstanceConnected())
+            {
+                logger.error("Unable to find an available Jibri, can't start (no instances connected)");
+                throw new StartException.NotAvailable();
+            }
+
+            // All connected instances are busy. Optionally wait and retry, in case one frees up.
+            if (busyRetryDelayMs <= 0 || busyRetries >= maxBusyRetries)
+            {
+                logger.error("Unable to find an available Jibri, can't start (all instances busy)");
+                throw new StartException.AllBusy();
+            }
+
+            busyRetries++;
+            logger.info("All Jibris are busy, waiting " + busyRetryDelayMs + "ms before busy-retry "
+                + busyRetries + "/" + maxBusyRetries);
+            try
+            {
+                Thread.sleep(busyRetryDelayMs);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while waiting to retry Jibri selection.");
+                throw new StartException.AllBusy();
             }
         }
     }

--- a/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
@@ -355,8 +355,9 @@ public class JibriSession
             // treats the recording as in-progress; the client is notified of the eventual outcome via presence
             // (ON on success, OFF/ERROR if the retries are exhausted). This bridges brief capacity shortfalls,
             // e.g. a demand spike while the autoscaler spins up more instances, or two requests racing for the
-            // last free instance.
-            if (busyRetryDelayMs > 0 && busyRetries < maxBusyRetries)
+            // last free instance. A busy-retry-delay of 0 is honored as "retry immediately" (the retry is
+            // asynchronous, so this does not spin a thread); the feature is disabled only via busy-retries = 0.
+            if (busyRetries < maxBusyRetries)
             {
                 scheduleBusyRetry();
                 return;
@@ -400,7 +401,7 @@ public class JibriSession
             + " in " + busyRetryDelayMs + "ms");
         ScheduledFuture<?> newTask = TaskPools.getScheduledPool().schedule(
             () -> TaskPools.getIoPool().execute(new BusyRetryTask()),
-            busyRetryDelayMs,
+            Math.max(0L, busyRetryDelayMs),
             TimeUnit.MILLISECONDS);
         ScheduledFuture<?> oldTask = busyRetryTask.getAndSet(newTask);
         if (oldTask != null)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriConfig.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriConfig.kt
@@ -55,6 +55,14 @@ class JibriConfig private constructor() {
         "jicofo.jibri.num-retries".from(newConfig)
     }
 
+    val busyRetries: Int by config {
+        "jicofo.jibri.busy-retries".from(newConfig)
+    }
+
+    val busyRetryDelay: Duration by config {
+        "jicofo.jibri.busy-retry-delay".from(newConfig)
+    }
+
     val xmppConnectionName: XmppConnectionEnum by config {
         "jicofo.jibri.xmpp-connection-name".from(newConfig)
     }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriRecorder.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriRecorder.kt
@@ -109,6 +109,7 @@ class JibriRecorder(
                     jibriDetector,
                     false, null, iq.displayName, iq.streamId, iq.youtubeBroadcastId, sessionId, iq.appData,
                     conference.isRtcStatsEnabled,
+                    config.busyRetries, config.busyRetryDelay.toMillis(),
                     logger
                 )
                 this.jibriSession = jibriSession

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriSipGateway.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriSipGateway.kt
@@ -84,6 +84,7 @@ class JibriSipGateway(
             iq.sipAddress,
             iq.displayName, null, null, sessionId, null,
             conference.isRtcStatsEnabled,
+            config.busyRetries, config.busyRetryDelay.toMillis(),
             logger
         )
         sipSessions[iq.sipAddress] = jibriSession

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriSessionTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriSessionTest.kt
@@ -79,6 +79,10 @@ class JibriSessionTest : ShouldSpec({
         "sessionId",
         "applicationData",
         true,
+        // maxBusyRetries
+        0,
+        // busyRetryDelayMs
+        0L,
         logger
     )
 
@@ -142,6 +146,53 @@ class JibriSessionTest : ShouldSpec({
         jibriSession.start()
         should("retry with another jibri") {
             verify(exactly = 2) { mockXmppConnection.sendIqAndGetResponse(any()) }
+        }
+    }
+    context("When all Jibris are busy and busy-retries are enabled") {
+        // selectJibri() returns no instance (all busy) twice, then one frees up.
+        every { detector.selectJibri() } returnsMany listOf(null, null, JidCreate.bareFrom("jibri1@bar.com"))
+        val iq = slot<IQ>()
+        every { mockXmppConnection.sendIqAndGetResponse(capture(iq)) } answers {
+            JibriIq().apply {
+                type = IQ.Type.result
+                from = iq.captured.to
+                status = JibriIq.Status.PENDING
+            }
+        }
+        val busyRetrySession = JibriSession(
+            stateListener, roomName, initiator, pendingTimeout, maxNumRetries, detector,
+            false, null, "displayName", "streamID", "youTubeBroadcastId", "sessionId", "applicationData", true,
+            // maxBusyRetries
+            5,
+            // busyRetryDelayMs (kept tiny to keep the test fast)
+            1L,
+            logger
+        )
+        should("wait and retry selection until an instance frees up") {
+            busyRetrySession.start()
+            verify(exactly = 3) { detector.selectJibri() }
+            verify(exactly = 1) { mockXmppConnection.sendIqAndGetResponse(any()) }
+        }
+    }
+    context("When all Jibris are busy and busy-retries are exhausted") {
+        // No instance ever frees up.
+        every { detector.selectJibri() } returns null
+        every { detector.isAnyInstanceConnected } returns true
+        val busyRetrySession = JibriSession(
+            stateListener, roomName, initiator, pendingTimeout, maxNumRetries, detector,
+            false, null, "displayName", "streamID", "youTubeBroadcastId", "sessionId", "applicationData", true,
+            // maxBusyRetries
+            2,
+            // busyRetryDelayMs
+            1L,
+            logger
+        )
+        should("give up with AllBusy after exhausting busy-retries") {
+            shouldThrow<JibriSession.StartException.AllBusy> {
+                busyRetrySession.start()
+            }
+            // initial attempt + 2 retries
+            verify(exactly = 3) { detector.selectJibri() }
         }
     }
 })

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriSessionTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriSessionTest.kt
@@ -165,13 +165,15 @@ class JibriSessionTest : ShouldSpec({
             // maxBusyRetries
             5,
             // busyRetryDelayMs (kept tiny to keep the test fast)
-            1L,
+            10L,
             logger
         )
-        should("wait and retry selection until an instance frees up") {
+        should("asynchronously retry selection until an instance frees up and start the session") {
+            // start() returns immediately after scheduling the async retry: it neither blocks nor throws.
             busyRetrySession.start()
-            verify(exactly = 3) { detector.selectJibri() }
-            verify(exactly = 1) { mockXmppConnection.sendIqAndGetResponse(any()) }
+            // The retries run on the scheduled/IO pools; wait for them to converge.
+            verify(timeout = 5000, exactly = 3) { detector.selectJibri() }
+            verify(timeout = 5000, exactly = 1) { mockXmppConnection.sendIqAndGetResponse(any()) }
         }
     }
     context("When all Jibris are busy and busy-retries are exhausted") {
@@ -184,15 +186,17 @@ class JibriSessionTest : ShouldSpec({
             // maxBusyRetries
             2,
             // busyRetryDelayMs
-            1L,
+            10L,
             logger
         )
-        should("give up with AllBusy after exhausting busy-retries") {
-            shouldThrow<JibriSession.StartException.AllBusy> {
-                busyRetrySession.start()
+        should("give up after exhausting busy-retries and report failure via presence") {
+            // start() does not throw: it schedules async retries and returns.
+            busyRetrySession.start()
+            // initial attempt + 2 retries, then the owner is notified of the failure.
+            verify(timeout = 5000, exactly = 3) { detector.selectJibri() }
+            verify(timeout = 5000) {
+                stateListener.onSessionStateChanged(any(), JibriIq.Status.OFF, JibriIq.FailureReason.ERROR)
             }
-            // initial attempt + 2 retries
-            verify(exactly = 3) { detector.selectJibri() }
         }
     }
 })

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriSessionTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriSessionTest.kt
@@ -199,4 +199,30 @@ class JibriSessionTest : ShouldSpec({
             }
         }
     }
+    context("When busy-retries are enabled with a zero delay") {
+        // selectJibri() returns no instance (all busy) once, then one frees up.
+        every { detector.selectJibri() } returnsMany listOf(null, JidCreate.bareFrom("jibri1@bar.com"))
+        val iq = slot<IQ>()
+        every { mockXmppConnection.sendIqAndGetResponse(capture(iq)) } answers {
+            JibriIq().apply {
+                type = IQ.Type.result
+                from = iq.captured.to
+                status = JibriIq.Status.PENDING
+            }
+        }
+        val busyRetrySession = JibriSession(
+            stateListener, roomName, initiator, pendingTimeout, maxNumRetries, detector,
+            false, null, "displayName", "streamID", "youTubeBroadcastId", "sessionId", "applicationData", true,
+            // maxBusyRetries
+            3,
+            // busyRetryDelayMs: 0 means retry immediately, NOT disabled
+            0L,
+            logger
+        )
+        should("still retry (a zero delay does not disable the feature)") {
+            busyRetrySession.start()
+            verify(timeout = 5000, exactly = 2) { detector.selectJibri() }
+            verify(timeout = 5000, exactly = 1) { mockXmppConnection.sendIqAndGetResponse(any()) }
+        }
+    }
 })


### PR DESCRIPTION
## Problem

When a recording/streaming start request arrives and **all connected Jibri instances are busy**, jicofo fails immediately with a `resource_constraint` error and the recording never starts.

The existing `jicofo.jibri.num-retries` does **not** help this case: it only moves on to a *different* instance after one fails. The moment `JibriDetector.selectJibri()` returns no available instance, `startInternal()` throws `AllBusy` and gives up — there is no way to make jicofo **wait** for the pool to free up.

In production we see this as a hard recording failure during brief capacity shortfalls:
- a demand spike at the top of the hour while the autoscaler is still spinning up instances, or
- two start requests racing for the last free instance (the second arrives a few hundred ms too late).

## Change

Add an optional **asynchronous** busy-retry on the "all busy" path, controlled by two new config properties:

| Property | Default | Meaning |
|---|---|---|
| `jicofo.jibri.busy-retries` | `0` (disabled) | How many extra times to re-select when all instances are busy |
| `jicofo.jibri.busy-retry-delay` | `5 seconds` | How long to wait between busy-retries |

When all connected instances are busy, jicofo schedules a retry (up to `busy-retries` times) and **returns immediately**. The client gets a `result` and learns the eventual outcome via presence: the recording turns **ON** if an instance frees up, or is reported **failed** (`OFF`/`ERROR`) once the retries are exhausted. The default of `0` preserves current behavior exactly (immediate `resource_constraint` error).

The "no instances connected at all" case (`NotAvailable`) still fails fast.

## Design notes (async, non-blocking)

The retry is **not** a blocking wait. An earlier revision of this PR used `Thread.sleep` on the synchronized start path, but that runs on the per-room XMPP task-queue thread (`TaskPools.ioPool`) and would (a) block that room's request queue for the whole wait, (b) hold the `JibriSession` monitor (delaying a concurrent `stop()`), and (c) multiply the total wait by `num-retries` since the num-retries path re-enters the wait. The current implementation instead:

- schedules the delay on the **scheduled pool** (3 threads, timing only) and runs the actual start-IQ exchange on the **IO pool** — neither the calling thread nor the session monitor is held during the wait;
- tracks `busyRetries` as an instance field, so the total is bounded by `busy-retries` across the whole session regardless of `num-retries`;
- cancels a pending retry on `stop()` (with a guard for the already-firing race) and clears presence if the session was still waiting for capacity.

## Tests

`JibriSessionTest` adds two async cases (verified with `verify(timeout=…)`):
- busy-retries enabled: selection returns nothing twice then frees up → the session starts after retrying;
- busy-retries exhausted: pool never frees up → the owner is notified of failure via presence.

All existing tests pass; build and checkstyle are clean (Java 17/21 CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)