### PR TITLE
feat: thread per-room translator connect headers from room metadata

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
@@ -106,7 +106,6 @@ data class RoomMetadata(val metadata: Metadata?) : JsonMessage(TYPE) {
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         data class Translation(
-            val urlParams: Map<String, String>? = null,
             val httpHeaders: Map<String, String>? = null
         )
     }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
@@ -81,6 +81,11 @@ data class RoomMetadata(val metadata: Metadata?) : JsonMessage(TYPE) {
         val visitorsEnabled: Boolean? = null,
         val lobbyEnabled: Boolean? = null,
         val transcription: Transcription? = null,
+        /**
+         * Per-room live-translation connect config (e.g. a per-customer usage token as an HTTP header,
+         * delivered to jicofo on the admin-only metadata path). Mirrors [transcription].
+         */
+        val translation: Translation? = null,
         /** Aggregated live-translation requests: sender endpoint id -> set of requested language codes. */
         val audioTranslationRequests: Map<String, List<String>>? = null
     ) {
@@ -95,6 +100,12 @@ data class RoomMetadata(val metadata: Metadata?) : JsonMessage(TYPE) {
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         data class Transcription(
+            val urlParams: Map<String, String>? = null,
+            val httpHeaders: Map<String, String>? = null
+        )
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        data class Translation(
             val urlParams: Map<String, String>? = null,
             val httpHeaders: Map<String, String>? = null
         )

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoom.kt
@@ -69,6 +69,9 @@ interface ChatRoom {
     /** Transcription configuration from room metadata. */
     val transcription: RoomMetadata.Metadata.Transcription?
 
+    /** Translation configuration from room metadata (e.g. per-customer connect headers). */
+    val translation: RoomMetadata.Metadata.Translation?
+
     val debugState: ObjectNode
 
     /** Returns the number of members that currently have their audio sources unmuted. */

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomImpl.kt
@@ -202,6 +202,10 @@ class ChatRoomImpl(
     override var transcription: RoomMetadata.Metadata.Transcription? = null
         private set
 
+    /** Translation configuration from room metadata. */
+    override var translation: RoomMetadata.Metadata.Translation? = null
+        private set
+
     /**
      * List of user IDs which the room is configured to allow to be moderators.
      */
@@ -399,6 +403,7 @@ class ChatRoomImpl(
             eventEmitter.fireEvent { startMutedChanged(it.audio == true, it.video == true) }
         }
         transcription = roomMetadata.metadata?.transcription
+        translation = roomMetadata.metadata?.translation
         eventEmitter.fireEvent {
             transcribingEnabledChanged(
                 roomMetadata.metadata?.recording?.isTranscribingEnabled == true &&

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/TranslationConfig.kt
@@ -104,5 +104,24 @@ class TranslationConfig private constructor() {
 
         const val MEETING_ID_TEMPLATE = "MEETING_ID"
         const val REGION_TEMPLATE = "REGION"
+
+        /**
+         * Merge per-room translation headers (from room metadata) over the static config headers, with the
+         * per-room values taking precedence. Mirrors [TranscriptionConfig.processTranscriptionMetadata].
+         *
+         * Returns null when there are no per-room headers, so callers fall back to the static config headers
+         * (i.e. `merged ?: TranslationConfig.config.httpHeaders`).
+         *
+         * @param translation the translation metadata from room metadata (e.g. a per-customer usage token)
+         * @param baseHeaders the static headers from configuration
+         */
+        @JvmStatic
+        fun processTranslationMetadata(
+            translation: org.jitsi.jicofo.xmpp.RoomMetadata.Metadata.Translation?,
+            baseHeaders: Map<String, String>
+        ): Map<String, String>? {
+            val customHeaders = translation?.httpHeaders ?: return null
+            return baseHeaders.toMutableMap().apply { putAll(customHeaders) }
+        }
     }
 }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -73,7 +73,11 @@ interface ColibriSessionManager {
      * @param requests the per-sender translation requests. How these are placed on bridges depends on the configured
      * [org.jitsi.jicofo.TranslationConfig.mode].
      */
-    fun setTranslator(url: TemplatedUrl?, requests: List<TranslationRequest> = emptyList())
+    fun setTranslator(
+        url: TemplatedUrl?,
+        requests: List<TranslationRequest> = emptyList(),
+        customHeaders: Map<String, String>? = null
+    )
 
     /**
      * Stop using [bridge], expiring all endpoints on it (e.g. because it was detected to have failed).

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -138,6 +138,9 @@ class ColibriV2SessionManager(
     /** The current per-sender translation requests. */
     private var translatorRequests: List<TranslationRequest> = emptyList()
 
+    /** Per-room translator connect headers (merged config + room metadata), or null to use config headers. */
+    private var translatorCustomHeaders: Map<String, String>? = null
+
     /**
      * The colibri2 sessions that are currently active, mapped by the relayId of the [Bridge] that they use.
      */
@@ -391,7 +394,7 @@ class ColibriV2SessionManager(
         type = Connect.Types.TRANSLATOR,
         exports = translatorRequests.map { it.sourceName },
         requests = translatorRequests.flatMap { it.syntheticSourceNames },
-        httpHeaders = TranslationConfig.config.httpHeaders,
+        httpHeaders = translatorCustomHeaders ?: TranslationConfig.config.httpHeaders,
         ping = translatorPing()
     )
 
@@ -408,7 +411,7 @@ class ColibriV2SessionManager(
                     request,
                     url,
                     TranslationConfig.config.maxLanguagesPerConnect,
-                    TranslationConfig.config.httpHeaders,
+                    translatorCustomHeaders ?: TranslationConfig.config.httpHeaders,
                     translatorPing()
                 ).also { specs ->
                     // Detect the at-risk condition for the positional-chunking glitch noted on perSourceTranslatorSpecs:
@@ -450,9 +453,14 @@ class ColibriV2SessionManager(
         )
     }
 
-    override fun setTranslator(url: TemplatedUrl?, requests: List<TranslationRequest>) = synchronized(syncRoot) {
+    override fun setTranslator(
+        url: TemplatedUrl?,
+        requests: List<TranslationRequest>,
+        customHeaders: Map<String, String>?
+    ) = synchronized(syncRoot) {
         translatorUrl = url
         translatorRequests = requests
+        translatorCustomHeaders = customHeaders
         updateConnects()
     }
 

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/TranslationConfigTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/TranslationConfigTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2024 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.config.withNewConfig
+import org.jitsi.jicofo.xmpp.RoomMetadata
+
+class TranslationConfigTest : ShouldSpec() {
+    init {
+        context("http-headers") {
+            context("With no headers configured") {
+                withNewConfig("") {
+                    TranslationConfig.config.httpHeaders shouldBe emptyMap()
+                }
+            }
+
+            context("With headers configured") {
+                withNewConfig(
+                    """
+                    jicofo.translation.http-headers {
+                        "Authorization" = "Bearer token123"
+                        "X-API-Key" = "secret-key"
+                    }
+                    """.trimIndent()
+                ) {
+                    TranslationConfig.config.httpHeaders shouldBe mapOf(
+                        "Authorization" to "Bearer token123",
+                        "X-API-Key" to "secret-key"
+                    )
+                }
+            }
+        }
+
+        context("processTranslationMetadata") {
+            val baseHeaders = mapOf("Base-Header" to "base-value", "Shared-Header" to "base-shared")
+
+            context("With null translation") {
+                should("return null so callers fall back to config headers") {
+                    TranslationConfig.processTranslationMetadata(null, baseHeaders) shouldBe null
+                }
+            }
+
+            context("With translation having no headers") {
+                should("return null so callers fall back to config headers") {
+                    TranslationConfig.processTranslationMetadata(
+                        RoomMetadata.Metadata.Translation(),
+                        baseHeaders
+                    ) shouldBe null
+                }
+            }
+
+            context("With custom headers") {
+                val customHeaders = mapOf("X-Custom" to "custom-value", "Shared-Header" to "custom-shared")
+                should("return base headers merged with custom, custom taking precedence") {
+                    TranslationConfig.processTranslationMetadata(
+                        RoomMetadata.Metadata.Translation(httpHeaders = customHeaders),
+                        baseHeaders
+                    ) shouldBe mapOf(
+                        "Base-Header" to "base-value",
+                        "Shared-Header" to "custom-shared",
+                        "X-Custom" to "custom-value"
+                    )
+                }
+            }
+
+            context("With empty custom headers") {
+                should("return the base headers unchanged") {
+                    TranslationConfig.processTranslationMetadata(
+                        RoomMetadata.Metadata.Translation(httpHeaders = emptyMap()),
+                        baseHeaders
+                    ) shouldBe baseHeaders
+                }
+            }
+        }
+    }
+}

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -2768,9 +2768,15 @@ public class JitsiMeetConferenceImpl
         @Override
         public void audioTranslationRequestsChanged(@NotNull Map<String, ? extends List<String>> requests)
         {
+            // Merge any per-room translator headers (e.g. a per-customer usage token delivered on the
+            // admin-only metadata path) over the static config headers; null falls back to config headers.
+            Map<String, String> translationHeaders = TranslationConfig.processTranslationMetadata(
+                    chatRoom != null ? chatRoom.getTranslation() : null,
+                    TranslationConfig.config.getHttpHeaders());
             //noinspection unchecked
             translationManager.setRequests(
                     (Map<String, List<String>>) (Map<String, ?>) requests,
+                    translationHeaders,
                     colibriSessionManager,
                     meetingId);
         }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/translation/ConferenceTranslationManager.kt
@@ -44,14 +44,22 @@ class ConferenceTranslationManager(
     private val sourceManager = TranslationSourceManager()
     private var requests: Map<String, List<String>> = emptyMap()
 
-    /** Update the aggregated request map and re-apply. */
+    /**
+     * Per-room translator connect headers (config headers merged with room metadata, e.g. a per-customer usage
+     * token), or null to use the static config headers. Stored so [reapply] reuses the last value.
+     */
+    private var customHeaders: Map<String, String>? = null
+
+    /** Update the aggregated request map (and per-room connect headers) and re-apply. */
     @Synchronized
     fun setRequests(
         requests: Map<String, List<String>>,
+        customHeaders: Map<String, String>?,
         colibriSessionManager: ColibriSessionManager?,
         meetingId: String?
     ) {
         this.requests = requests
+        this.customHeaders = customHeaders
         apply(colibriSessionManager, meetingId)
     }
 
@@ -102,7 +110,7 @@ class ConferenceTranslationManager(
             val baseName = baseName(sender) ?: return@mapNotNull null
             TranslationRequest(sender, baseName, sources.map { it.name!! }.sorted())
         }
-        colibriSessionManager.setTranslator(url, translationRequests)
+        colibriSessionManager.setTranslator(url, translationRequests, customHeaders)
 
         logger.info(
             "Applied audio translation: requests=$requests, translationRequests=$translationRequests, " +

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
@@ -177,5 +177,39 @@ class ColibriTranslationTest : ShouldSpec() {
                 connect.expire shouldBe true
             }
         }
+
+        context("With per-room translator headers") {
+            val manager = createSessionManager()
+            allocateParticipant(manager, "p1")
+            colibriRequests.clear()
+            manager.setTranslator(
+                translatorUrl,
+                listOf(TranslationRequest("p1", "p1-a0", listOf("p1-a0.en"))),
+                customHeaders = mapOf("Authorization" to "Bearer per-room", "X-Custom" to "v1")
+            )
+            val connect = lastConnect()
+
+            should("put the per-room headers on the connect") {
+                connect shouldNotBe null
+                connect!!.getHttpHeaders().associate { it.name to it.value } shouldBe mapOf(
+                    "Authorization" to "Bearer per-room",
+                    "X-Custom" to "v1"
+                )
+            }
+        }
+
+        context("Without per-room translator headers") {
+            val manager = createSessionManager()
+            allocateParticipant(manager, "p1")
+            colibriRequests.clear()
+            // No customHeaders: fall back to the (empty, in this test) static config headers.
+            manager.setTranslator(translatorUrl, listOf(TranslationRequest("p1", "p1-a0", listOf("p1-a0.en"))))
+            val connect = lastConnect()
+
+            should("fall back to the config headers (none configured here)") {
+                connect shouldNotBe null
+                connect!!.getHttpHeaders().associate { it.name to it.value } shouldBe emptyMap()
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

Threads a per-room set of translator **connect HTTP headers** from room metadata into the translator `<connect>`, so they reach the bridge (and the transcriber/translator endpoint it connects to). This mirrors the existing per-room transcriber custom-header path.

- `RoomMetadata.Metadata`: add `translation { urlParams, httpHeaders }` and a `ChatRoom` getter, populated from metadata.
- `TranslationConfig.processTranslationMetadata`: merge per-room headers over the static config headers (per-room wins), mirroring `processTranscriptionMetadata`.
- `ColibriV2SessionManager`: store `translatorCustomHeaders` and use `customHeaders ?: config.httpHeaders` in both translator spec builders; `setTranslator` gains an optional `customHeaders` param.
- `ConferenceTranslationManager` / `JitsiMeetConferenceImpl`: plumb the merged headers through.

## Why

Lets a deployment attach per-room headers (e.g. a routing/attribution credential) to the translator connect, decided outside jicofo from room metadata — the same mechanism transcription already supports.

## Notes
- Stacked on the live-translation branch (`translation`).
- `mvn compile` and `test-compile` pass.
- No behavior change when the metadata field is absent (falls back to configured headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
