### PR TITLE
feat: ensure to leave chatRoom on failure

### DIFF
--- a/jicofo-common/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
+++ b/jicofo-common/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
@@ -206,6 +206,8 @@ public abstract class BaseBrewery<T extends ExtensionElement>
             if (chatRoom != null)
             {
                 chatRoom.removeListener(chatRoomListener);
+                chatRoom.leave();
+
                 chatRoom = null;
             }
         }


### PR DESCRIPTION
When Jicofo starts before Prosody is ready, might try to join a chat room and faill. I know it shouln't happen, but due to some bug in our charts probably, it's sometimes not.

1. `BaseBrewery.start()` calls `xmppProvider.createRoom(jvbbrewery)`.
2. `createRoom()` puts the `ChatRoomImpl` into the local map before `join()`.
3. `join()` fails with some error.
4. `BaseBrewery` only removed the listener and set `chatRoom = null`, but did not remove the room from `XmppProvider.Muc.rooms`.
5. The next attempt to start the brewery fails with `RoomExistsException`, and Jicofo remains Ready, but without Joined the room / bridges.

