### PR TITLE
feat: signal per-endpoint diarize to the bridge via Colibri2

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMember.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMember.kt
@@ -59,6 +59,9 @@ interface ChatRoomMember {
     val isAudioMuted: Boolean
     val isVideoMuted: Boolean
 
+    /** Whether this member requested per-endpoint diarization (signaled via the "diarize" participant property). */
+    val diarize: Boolean
+
     /** Gets the region (e.g. "us-east") of this [ChatRoomMember]. */
     val region: String?
 

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberImpl.kt
@@ -70,6 +70,8 @@ class ChatRoomMemberImpl(
         private set
     override var statsId: String? = null
         private set
+    override var diarize: Boolean = false
+        private set
     override var videoCodecs: List<String>? = null
         private set
     override var isAudioMuted = true
@@ -209,6 +211,9 @@ class ChatRoomMemberImpl(
             statsId = it.statsId
         }
 
+        val diarizeElement = presence.getExtensionElement("jitsi_participant_diarize", "jabber:client")
+        diarize = (diarizeElement as? StandardExtensionElement)?.text?.toBoolean() ?: false
+
         val newVideoCodecs =
             presence.getExtension(JitsiParticipantCodecList::class.java)?.let {
                 if (!it.codecs.contains("vp8")) {
@@ -270,6 +275,7 @@ class ChatRoomMemberImpl(
             put("stats_id", statsId.toString())
             put("is_audio_muted", isAudioMuted)
             put("is_video_muted", isVideoMuted)
+            put("diarize", diarize)
             set<ObjectNode>("features", jsonMapper.valueToTree(features.map { it.name }))
             put("capsNodeVer", capsNodeVer.toString())
         }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -122,6 +122,7 @@ data class ParticipantAllocationParameters(
     val useSctp: Boolean,
     val visitor: Boolean,
     val supportsPrivateAddresses: Boolean,
+    val diarize: Boolean,
     val medias: Set<Media>
 )
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
@@ -117,6 +117,11 @@ internal fun ParticipantInfo.toEndpoint(
         if (useRtpMidDemux) {
             addCapability(Capability.CAP_RTP_MID_DEMUX_SUPPORT)
         }
+        if (diarize) {
+            // Call setDiarize on the Colibri2Endpoint.Builder directly: the fluent builder chain returns a parent
+            // Builder type after setId(...) which does not expose setDiarize.
+            setDiarize(true)
+        }
     }
     // TODO: find a way to signal sources only when they change? Or is this already the case implicitly?
     if (!expire) {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
@@ -35,6 +35,7 @@ class ParticipantInfo(
     val useSsrcRewriting = parameters.useSsrcRewriting
     val useRtpMidDemux = parameters.useRtpMidDemux
     val visitor = parameters.visitor
+    val diarize = parameters.diarize
 
     var audioMuted = parameters.forceMuteAudio
     var videoMuted = parameters.forceMuteVideo
@@ -51,5 +52,6 @@ class ParticipantInfo(
         put("ssrc_rewriting", useSsrcRewriting)
         put("rtp_mid_demux", useRtpMidDemux)
         put("visitor", visitor)
+        put("diarize", diarize)
     }
 }

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
@@ -207,6 +207,7 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
                     offer.getContents().stream().anyMatch(c -> c.getName() == "data"),
                     (participant.getChatMember().getRole() == MemberRole.VISITOR),
                     privateAddresses,
+                    participant.getChatMember().getDiarize(),
                     medias);
             colibriAllocation = colibriSessionManager.allocate(participantOptions);
         }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranscriptionTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranscriptionTest.kt
@@ -83,22 +83,24 @@ class ColibriTranscriptionTest : ShouldSpec() {
         createLogger()
     )
 
-    private fun allocateParticipant(manager: ColibriV2SessionManager, id: String = "p1") = manager.allocate(
-        ParticipantAllocationParameters(
-            id = id,
-            statsId = null,
-            region = null,
-            sources = EndpointSourceSet.EMPTY,
-            useSsrcRewriting = false,
-            useRtpMidDemux = false,
-            forceMuteAudio = false,
-            forceMuteVideo = false,
-            useSctp = false,
-            visitor = false,
-            supportsPrivateAddresses = false,
-            medias = emptySet()
+    private fun allocateParticipant(manager: ColibriV2SessionManager, id: String = "p1", diarize: Boolean = false) =
+        manager.allocate(
+            ParticipantAllocationParameters(
+                id = id,
+                statsId = null,
+                region = null,
+                sources = EndpointSourceSet.EMPTY,
+                useSsrcRewriting = false,
+                useRtpMidDemux = false,
+                forceMuteAudio = false,
+                forceMuteVideo = false,
+                useSctp = false,
+                visitor = false,
+                supportsPrivateAddresses = false,
+                diarize = diarize,
+                medias = emptySet()
+            )
         )
-    )
 
     override suspend fun beforeAny(testCase: TestCase) = super.beforeAny(testCase).also {
         TaskPools.ioPool = inPlaceExecutor
@@ -173,6 +175,32 @@ class ColibriTranscriptionTest : ShouldSpec() {
                 urlStr shouldContain "$expectedBaseUrl?"
                 urlStr shouldContain "key1=value1"
                 urlStr shouldContain "key2=hello+world"
+            }
+        }
+
+        context("Diarize flag") {
+            context("Participant with diarize=true") {
+                val manager = createSessionManager()
+                allocateParticipant(manager, diarize = true)
+
+                val createRequest = colibriRequests.find { it.create }!!
+                val endpoint = createRequest.endpoints.first()
+
+                should("set the diarize attribute on the endpoint") {
+                    endpoint.diarize shouldBe true
+                }
+            }
+            context("Participant with diarize=false") {
+                val manager = createSessionManager()
+                allocateParticipant(manager, diarize = false)
+
+                val createRequest = colibriRequests.find { it.create }!!
+                val endpoint = createRequest.endpoints.first()
+
+                should("not set the diarize attribute on the endpoint") {
+                    // The attribute is omitted, so getDiarize() returns null.
+                    endpoint.diarize shouldBe null
+                }
             }
         }
 

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriTranslationTest.kt
@@ -95,6 +95,7 @@ class ColibriTranslationTest : ShouldSpec() {
             useSctp = false,
             visitor = false,
             supportsPrivateAddresses = false,
+            diarize = false,
             medias = emptySet()
         )
     )

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/ParticipantInviteRunnableTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/ParticipantInviteRunnableTest.kt
@@ -114,6 +114,7 @@ class ParticipantInviteRunnableTest : ShouldSpec({
                     every { isJibri } returns false
                     every { isJigasi } returns false
                     every { isTranscriber } returns false
+                    every { diarize } returns false
                 },
                 conference,
                 mockk(),

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/jibri/JibriDetectorTest.kt
@@ -141,6 +141,7 @@ class JibriChatRoomMember(
     override val isJibri: Boolean get() = TODO("Not yet implemented")
     override val isAudioMuted: Boolean get() = TODO("Not yet implemented")
     override val isVideoMuted: Boolean get() = TODO("Not yet implemented")
+    override val diarize: Boolean get() = TODO("Not yet implemented")
     override val region: String? get() = TODO("Not yet implemented")
     override val statsId: String? get() = TODO("Not yet implemented")
     override val videoCodecs: List<String>? get() = TODO("Not yet implemented")

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberDiarizeTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/xmpp/muc/ChatRoomMemberDiarizeTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2026 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.xmpp.muc
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.jivesoftware.smack.packet.StandardExtensionElement
+import org.jivesoftware.smack.packet.StanzaBuilder
+import org.jxmpp.jid.EntityFullJid
+import org.jxmpp.jid.impl.JidCreate
+import java.util.logging.Level
+
+/**
+ * Tests that the "diarize" participant property is parsed from presence into [ChatRoomMember.diarize].
+ */
+class ChatRoomMemberDiarizeTest : ShouldSpec() {
+    private val occupantJid: EntityFullJid = JidCreate.entityFullFrom("conference@example.com/member")
+    private val conferenceJid = JidCreate.entityBareFrom("conference@example.com")
+    private val chatRoom = ChatRoomImpl(mockk(relaxed = true), conferenceJid, Level.INFO) { }
+
+    private fun member() = ChatRoomMemberImpl(occupantJid, chatRoom, mockk(relaxed = true))
+
+    private fun presenceWithDiarize(value: String?) = StanzaBuilder.buildPresence().from(occupantJid).apply {
+        value?.let {
+            addExtension(
+                StandardExtensionElement.builder("jitsi_participant_diarize", "jabber:client").setText(it).build()
+            )
+        }
+    }.build()
+
+    init {
+        context("Parsing the diarize participant property") {
+            should("default to false when the element is absent") {
+                member().apply { processPresence(presenceWithDiarize(null)) }.diarize shouldBe false
+            }
+            should("parse 'true' as true") {
+                member().apply { processPresence(presenceWithDiarize("true")) }.diarize shouldBe true
+            }
+            should("parse 'false' as false") {
+                member().apply { processPresence(presenceWithDiarize("false")) }.diarize shouldBe false
+            }
+            should("parse a non-boolean value as false") {
+                member().apply { processPresence(presenceWithDiarize("garbage")) }.diarize shouldBe false
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-115-gd0c3cd0</version>
+        <version>1.0-116-gc47d314</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Propagates a per-participant `diarize` flag from MUC presence to the videobridge via COLIBRI v2, so diarization can be enabled per endpoint (for multi-speaker endpoints such as room systems and dial-in) instead of only globally.

The client advertises the flag as a `<jitsi_participant_diarize>` presence element (lib-jitsi-meet participant property). jicofo reads it in `ChatRoomMemberImpl.processPresence`, threads it through `ParticipantAllocationParameters` → `ParticipantInfo`, and emits it as the `diarize` attribute on the COLIBRI v2 endpoint (create path only; the flag is static per session). Mirrors the existing `useSsrcRewriting` / `supportsPrivateAddresses` end-to-end pattern.

Part of a multi-repo change. The four Maven repos share the branch `diarization-endpoint-control` so CI builds them together; no dependency version bumps are included (they follow after jitsi-xmpp-extensions is released).

---

**Related PRs** (per-endpoint speaker diarization, multi-repo):
- jitsi-meet: jitsi/jitsi-meet#17614
- jitsi-xmpp-extensions: jitsi/jitsi-xmpp-extensions#145
- jicoco: jitsi/jicoco#238
- jicofo: jitsi/jicofo#1291
- jitsi-videobridge: jitsi/jitsi-videobridge#2431
- opus-transcriber-proxy: jitsi/opus-transcriber-proxy#106
