### PR TITLE
feat: add audio-translation feature

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/Features.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/Features.kt
@@ -45,6 +45,7 @@ enum class Features(val value: String) {
     JSON_SOURCES("http://jitsi.org/json-encoded-sources"),
     OPUS_RED("http://jitsi.org/opus-red"),
     AUDIO_MUTE("http://jitsi.org/protocol/audio-mute"),
+    AUDIO_TRANSLATION("http://jitsi.org/protocol/audio-translation"),
 
     // The ones below are not used in jicofo, but are defined here to improve the xmpp-caps statistics and avoid logs
     // about unknown features.


### PR DESCRIPTION
Add a new `http://jitsi.org/protocol/audio-translation` feature to `Features.kt`. No-op; defined to improve xmpp-caps statistics and avoid logs about unknown features.