### PR TITLE
Add basic distributed tracing

### DIFF
--- a/jicofo-common/pom.xml
+++ b/jicofo-common/pom.xml
@@ -126,11 +126,6 @@
       <artifactId>mockk-jvm</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-api</artifactId>
-      <version>${opentelemetry.version}</version>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/jicofo-common/pom.xml
+++ b/jicofo-common/pom.xml
@@ -37,6 +37,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>jicoco-tracing</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-metaconfig</artifactId>
     </dependency>
     <dependency>

--- a/jicofo-common/pom.xml
+++ b/jicofo-common/pom.xml
@@ -122,6 +122,11 @@
       <artifactId>mockk-jvm</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>${opentelemetry.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/util/TracingUtil.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/util/TracingUtil.kt
@@ -1,0 +1,29 @@
+package org.jitsi.jicofo.util
+
+import io.opentelemetry.api.common.Attributes
+import org.jitsi.jicofo.xmpp.muc.ChatRoom
+import org.jitsi.jicofo.xmpp.muc.ChatRoomMember
+import java.util.Objects
+
+class TracingUtil {
+    companion object {
+        @JvmStatic
+        fun memberAttributes(member: ChatRoomMember): Attributes {
+            return Attributes.builder()
+                .put("member.name", member.name)
+                .put("member.id", Objects.toString(member.jid))
+                .put("member.role", member.role.toString())
+                .put("member.region", Objects.toString(member.region))
+                .build()
+        }
+
+        @JvmStatic
+        fun roomAttributes(room: ChatRoom): Attributes {
+            return Attributes.builder()
+                .put("room.id", Objects.toString(room.roomJid))
+                .put("room.members", room.memberCount.toString())
+                .put("room.visitors", room.visitorCount.toString())
+                .build()
+        }
+    }
+}

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -20,6 +20,7 @@ package org.jitsi.jicofo.xmpp.jingle
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import org.jitsi.jicofo.TaskPools
@@ -91,6 +92,9 @@ class JingleSession(
                 span.makeCurrent().use {
                     doProcessIq(iq)
                 }
+            } catch (e: Throwable) {
+                span.setStatus(StatusCode.ERROR, e.message ?: "")
+                throw e
             } finally {
                 span.end()
             }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -19,16 +19,22 @@ package org.jitsi.jicofo.xmpp.jingle
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
+import org.jitsi.jicofo.util.TracingUtil
 import org.jitsi.jicofo.xmpp.IqProcessingResult
 import org.jitsi.jicofo.xmpp.createSessionInitiate
 import org.jitsi.jicofo.xmpp.createTransportReplace
 import org.jitsi.jicofo.xmpp.sendIqAndGetResponse
 import org.jitsi.jicofo.xmpp.tryToSendStanza
+import org.jitsi.tracing.TracingGlobal
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.utils.queue.PacketQueue
+import org.jitsi.xmpp.extensions.TraceParent
 import org.jitsi.xmpp.extensions.jingle.ContentPacketExtension
 import org.jitsi.xmpp.extensions.jingle.GroupPacketExtension
 import org.jitsi.xmpp.extensions.jingle.JingleAction
@@ -43,6 +49,7 @@ import org.jivesoftware.smack.packet.ExtensionElement
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.packet.StanzaError
 import org.jxmpp.jid.Jid
+import java.util.Objects
 
 /**
  * Class describes Jingle session.
@@ -67,13 +74,26 @@ class JingleSession(
         addContext("remoteJid", remoteJid.toString())
         addContext("sid", sid)
     }
+    val tracer: Tracer = TracingGlobal.sdk.getTracer("org.jitsi.jicofo.jingle")
 
     private val incomingIqQueue = PacketQueue<JingleIQ>(
         Integer.MAX_VALUE,
         true,
         "jingle-iq-queue",
-        {
-            doProcessIq(it)
+        { iq ->
+            val span = tracer.spanBuilder("jingle.${iq.action}")
+                .setParent(org.jitsi.tracing.TracingUtil.remoteContextFromIq(iq))
+                .setAttribute("initiator.id", Objects.toString(iq.initiator))
+                .setAttribute("responder.id", Objects.toString(iq.responder))
+                .setAttribute("session.id", Objects.toString(iq.sid))
+                .startSpan()
+            try {
+                span.makeCurrent().use {
+                    doProcessIq(iq)
+                }
+            } finally {
+                span.end()
+            }
             return@PacketQueue true
         },
         TaskPools.ioPool
@@ -257,6 +277,15 @@ class JingleSession(
             additionalExtensions.forEach { addExtension(it) }
             if (encodeSourcesAsJson) {
                 addExtension(sources.toJsonMessageExtension())
+            }
+            Span.fromContextOrNull(Context.current())?.let {
+                addExtension(
+                    TraceParent(
+                        it.spanContext.traceId,
+                        it.spanContext.spanId,
+                        it.spanContext.traceFlags.asHex()
+                    )
+                )
             }
         }
 

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -20,7 +20,10 @@ package org.jitsi.jicofo.xmpp.jingle
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import org.jitsi.jicofo.TaskPools
@@ -53,6 +56,34 @@ import org.jxmpp.jid.Jid
 import java.util.Objects
 
 /**
+ * Extracts a remote [Span] from the `traceparent` extension of an IQ, if present.
+ *
+ * Inlined from jicoco-tracing's TracingUtil, which was removed because it pulled in a Smack
+ * dependency that isn't available on Maven Central: https://github.com/jitsi/jicoco/pull/241
+ */
+private fun remoteSpanFromIq(iq: IQ): Span? {
+    val extension = iq.getExtension(TraceParent::class.java) ?: return null
+    return Span.wrap(
+        SpanContext.createFromRemoteParent(
+            extension.traceId,
+            extension.parentId,
+            TraceFlags.fromHex(extension.traceFlags, 0),
+            TraceState.getDefault()
+        )
+    )
+}
+
+/**
+ * Extracts a remote [Context] from the `traceparent` extension of an IQ, if present, or the root
+ * context otherwise.
+ */
+private fun remoteContextFromIq(iq: IQ): Context {
+    val root = Context.root()
+    val span = remoteSpanFromIq(iq) ?: return root
+    return root.with(span)
+}
+
+/**
  * Class describes Jingle session.
  *
  * @author Pawel Domas
@@ -83,7 +114,7 @@ class JingleSession(
         "jingle-iq-queue",
         { iq ->
             val span = tracer.spanBuilder("jingle.${iq.action}")
-                .setParent(org.jitsi.tracing.TracingUtil.remoteContextFromIq(iq))
+                .setParent(remoteContextFromIq(iq))
                 .setAttribute("initiator.id", Objects.toString(iq.initiator))
                 .setAttribute("responder.id", Objects.toString(iq.responder))
                 .setAttribute("session.id", Objects.toString(iq.sid))

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -28,7 +28,6 @@ import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
-import org.jitsi.jicofo.util.TracingUtil
 import org.jitsi.jicofo.xmpp.IqProcessingResult
 import org.jitsi.jicofo.xmpp.createSessionInitiate
 import org.jitsi.jicofo.xmpp.createTransportReplace

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -19,6 +19,8 @@ package org.jitsi.jicofo.bridge.colibri
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.context.Context
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.bridge.Bridge
 import org.jitsi.jicofo.bridge.CascadeLink
@@ -30,6 +32,7 @@ import org.jitsi.jicofo.conference.source.EndpointSourceSet
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import org.jitsi.xmpp.extensions.TraceParent
 import org.jitsi.xmpp.extensions.colibri.WebSocketPacketExtension
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Endpoint
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Error
@@ -197,6 +200,17 @@ class Colibri2Session(
     private fun createRequest(create: Boolean = false) = ConferenceModifyIQ.builder(xmppConnection).apply {
         to(bridge.jid)
         setMeetingId(colibriSessionManager.meetingId)
+
+        Span.fromContextOrNull(Context.current())?.let {
+            addExtension(
+                TraceParent(
+                    it.spanContext.traceId,
+                    it.spanContext.spanId,
+                    it.spanContext.traceFlags.asHex()
+                )
+            )
+        }
+
         if (create) {
             setCreate(true)
             setConferenceName(colibriSessionManager.conferenceName)

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode
 import org.jitsi.jicofo.MediaType
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.TaskPools
@@ -506,6 +507,9 @@ class ColibriV2SessionManager(
             span.makeCurrent().use { s ->
                 return doAllocate(participant)
             }
+        } catch (e: Throwable) {
+            span.setStatus(StatusCode.ERROR, e.message ?: "")
+            throw e
         } finally {
             span.end()
         }
@@ -799,6 +803,9 @@ class ColibriV2SessionManager(
             span.makeCurrent().use { s ->
                 return doUpdateParticipant(participantId, transport, sources, initialLastN, suppressLocalBridgeUpdate)
             }
+        } catch (e: Throwable) {
+            span.setStatus(StatusCode.ERROR, e.message ?: "")
+            throw e
         } finally {
             span.end()
         }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -21,6 +21,7 @@ package org.jitsi.jicofo.bridge.colibri
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.opentelemetry.api.trace.Span
 import org.jitsi.jicofo.MediaType
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.TaskPools
@@ -38,6 +39,7 @@ import org.jitsi.jicofo.bridge.getNodesBehind
 import org.jitsi.jicofo.bridge.getPathsFrom
 import org.jitsi.jicofo.bridge.removeNode
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
+import org.jitsi.tracing.TracingGlobal
 import org.jitsi.utils.TemplatedUrl
 import org.jitsi.utils.event.AsyncEventEmitter
 import org.jitsi.utils.logging2.Logger
@@ -111,6 +113,7 @@ class ColibriV2SessionManager(
     parentLogger: Logger
 ) : ColibriSessionManager, Cascade<Colibri2Session, Colibri2Session.Relay> {
     private val logger = createChildLogger(parentLogger)
+    private val tracer = TracingGlobal.sdk.getTracer("org.jitsi.jicofo.colibri")
 
     private val eventEmitter = AsyncEventEmitter<ColibriSessionManager.Listener>(TaskPools.ioPool)
     override fun addListener(listener: ColibriSessionManager.Listener) = eventEmitter.addHandler(listener)
@@ -497,6 +500,19 @@ class ColibriV2SessionManager(
 
     @Throws(ColibriAllocationFailedException::class, BridgeSelectionFailedException::class)
     override fun allocate(participant: ParticipantAllocationParameters): ColibriAllocation {
+        val span: Span = tracer.spanBuilder("colibri.allocate")
+            .startSpan()
+        try {
+            span.makeCurrent().use { s ->
+                return doAllocate(participant)
+            }
+        } finally {
+            span.end()
+        }
+    }
+
+    @Throws(ColibriAllocationFailedException::class, BridgeSelectionFailedException::class)
+    fun doAllocate(participant: ParticipantAllocationParameters): ColibriAllocation {
         logger.info("Allocating for ${participant.id}")
         val stanzaCollector: StanzaCollector
         val session: Colibri2Session

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -792,6 +792,24 @@ class ColibriV2SessionManager(
         sources: EndpointSourceSet?,
         initialLastN: InitialLastN?,
         suppressLocalBridgeUpdate: Boolean
+    ) {
+        val span: Span = tracer.spanBuilder("colibri.update-participant")
+            .startSpan()
+        try {
+            span.makeCurrent().use { s ->
+                return doUpdateParticipant(participantId, transport, sources, initialLastN, suppressLocalBridgeUpdate)
+            }
+        } finally {
+            span.end()
+        }
+    }
+
+    fun doUpdateParticipant(
+        participantId: String,
+        transport: IceUdpTransportPacketExtension?,
+        sources: EndpointSourceSet?,
+        initialLastN: InitialLastN?,
+        suppressLocalBridgeUpdate: Boolean
     ) = synchronized(syncRoot) {
         logger.debug("Updating $participantId with transport=$transport, sources=$sources")
 

--- a/jicofo/pom.xml
+++ b/jicofo/pom.xml
@@ -92,6 +92,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>jicoco-tracing</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
     </dependency>
     <dependency>

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jicofo.conference;
 
+import io.opentelemetry.api.trace.*;
+import io.opentelemetry.context.*;
 import kotlin.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.jicofo.*;
@@ -27,6 +29,7 @@ import org.jitsi.jicofo.bridge.colibri.*;
 import org.jitsi.jicofo.conference.source.*;
 import org.jitsi.jicofo.conference.translation.*;
 import org.jitsi.jicofo.util.*;
+import org.jitsi.jicofo.util.TracingUtil;
 import org.jitsi.jicofo.version.*;
 import org.jitsi.jicofo.visitors.*;
 import org.jitsi.jicofo.xmpp.*;
@@ -34,6 +37,7 @@ import org.jitsi.jicofo.xmpp.UtilKt;
 import org.jitsi.jicofo.xmpp.muc.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.node.*;
+import org.jitsi.tracing.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.logging2.Logger;
@@ -103,6 +107,7 @@ public class JitsiMeetConferenceImpl
 
     @NotNull
     private final Logger logger;
+    private final Tracer tracer = TracingGlobal.Companion.getSdk().getTracer("org.jitsi.jicofo.conference");
 
     /**
      * The instance of conference configuration.
@@ -2726,7 +2731,21 @@ public class JitsiMeetConferenceImpl
         {
             // Run in the IO pool because feature discovery may send disco#info and block for a response, and shouldn't
             // run in Smack's thread.
-            TaskPools.getIoPool().submit(() -> onMemberJoined(member));
+            TaskPools.getIoPool().submit(() -> {
+                Span span = tracer.spanBuilder("conference.memberJoined")
+                        .setAllAttributes(TracingUtil.memberAttributes(member))
+                        .setAllAttributes(TracingUtil.roomAttributes(chatRoom))
+                        .setAttribute("conference.id", Objects.toString(meetingId))
+                        .startSpan();
+                try (Scope s = span.makeCurrent())
+                {
+                    onMemberJoined(member);
+                }
+                finally
+                {
+                    span.end();
+                }
+            });
         }
 
         @Override

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -976,7 +976,7 @@ public class JitsiMeetConferenceImpl
         );
 
         participant.setInviteRunnable(channelAllocator);
-        TaskPools.getIoPool().execute(channelAllocator);
+        TaskPools.getIoPool().execute(Context.current().wrap(channelAllocator));
     }
 
     @NotNull EndpointSourceSet getSourcesForParticipant(@NotNull Participant participant)

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -2732,7 +2732,7 @@ public class JitsiMeetConferenceImpl
             // Run in the IO pool because feature discovery may send disco#info and block for a response, and shouldn't
             // run in Smack's thread.
             TaskPools.getIoPool().submit(() -> {
-                Span span = tracer.spanBuilder("conference.memberJoined")
+                Span span = tracer.spanBuilder("conference.member-joined")
                         .setAllAttributes(TracingUtil.memberAttributes(member))
                         .setAllAttributes(TracingUtil.roomAttributes(chatRoom))
                         .setAttribute("conference.id", Objects.toString(meetingId))

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -2725,6 +2725,11 @@ public class JitsiMeetConferenceImpl
             {
                 stop();
             }
+            catch (Throwable e)
+            {
+                span.setStatus(StatusCode.ERROR, Objects.toString(e.getMessage(), ""));
+                throw e;
+            }
             finally
             {
                 span.end();
@@ -2753,6 +2758,11 @@ public class JitsiMeetConferenceImpl
                 {
                     onMemberJoined(member);
                 }
+                catch (Throwable e)
+                {
+                    span.setStatus(StatusCode.ERROR, Objects.toString(e.getMessage(), ""));
+                    throw e;
+                }
                 finally
                 {
                     span.end();
@@ -2777,6 +2787,11 @@ public class JitsiMeetConferenceImpl
             try (Scope s = span.makeCurrent())
             {
                 onMemberLeft(member);
+            }
+            catch (Throwable e)
+            {
+                span.setStatus(StatusCode.ERROR, Objects.toString(e.getMessage(), ""));
+                throw e;
             }
             finally
             {

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -2716,7 +2716,19 @@ public class JitsiMeetConferenceImpl
         public void roomDestroyed(String reason)
         {
             logger.info("Room destroyed with reason=" + reason);
-            stop();
+            Span span = tracer.spanBuilder("conference.room-destroyed")
+                    .setAllAttributes(TracingUtil.roomAttributes(chatRoom))
+                    .setAttribute("conference.id", Objects.toString(meetingId))
+                    .setAttribute("reason", Objects.toString(reason))
+                    .startSpan();
+            try (Scope s = span.makeCurrent())
+            {
+                stop();
+            }
+            finally
+            {
+                span.end();
+            }
         }
 
         @Override
@@ -2757,7 +2769,19 @@ public class JitsiMeetConferenceImpl
         @Override
         public void memberLeft(@NotNull ChatRoomMember member)
         {
-            onMemberLeft(member);
+            Span span = tracer.spanBuilder("conference.member-left")
+                    .setAllAttributes(TracingUtil.memberAttributes(member))
+                    .setAllAttributes(TracingUtil.roomAttributes(chatRoom))
+                    .setAttribute("conference.id", Objects.toString(meetingId))
+                    .startSpan();
+            try (Scope s = span.makeCurrent())
+            {
+                onMemberLeft(member);
+            }
+            finally
+            {
+                span.end();
+            }
         }
 
         @Override

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
@@ -159,6 +159,7 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
         catch (Throwable e)
         {
             logger.error("Channel allocator failed: ", e);
+            span.setStatus(StatusCode.ERROR, Objects.toString(e.getMessage(), ""));
             cancel();
         }
         finally

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/ParticipantInviteRunnable.java
@@ -17,6 +17,8 @@
  */
 package org.jitsi.jicofo.conference;
 
+import io.opentelemetry.api.trace.*;
+import io.opentelemetry.context.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.jicofo.*;
 import org.jitsi.jicofo.bridge.colibri.*;
@@ -27,6 +29,7 @@ import org.jitsi.jicofo.jigasi.*;
 import org.jitsi.jicofo.util.*;
 import org.jitsi.jicofo.xmpp.jingle.*;
 import org.jitsi.jicofo.xmpp.muc.*;
+import org.jitsi.tracing.*;
 import org.jitsi.xmpp.extensions.colibri2.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 import org.jitsi.xmpp.extensions.jingle.JingleUtils;
@@ -47,6 +50,7 @@ import java.util.*;
 public class ParticipantInviteRunnable implements Runnable, Cancelable
 {
     private final Logger logger;
+    private final Tracer tracer = TracingGlobal.Companion.getSdk().getTracer("org.jitsi.jicofo.conference");
 
     /**
      * The {@link JitsiMeetConferenceImpl} into which a participant will be
@@ -146,7 +150,9 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
     @Override
     public void run()
     {
-        try
+        Span span = tracer.spanBuilder("conference.participant-invite")
+                .startSpan();
+        try (Scope s = span.makeCurrent())
         {
             doRun();
         }
@@ -158,6 +164,7 @@ public class ParticipantInviteRunnable implements Runnable, Cancelable
         finally
         {
             participant.inviteRunnableCompleted(this);
+            span.end();
         }
     }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -19,12 +19,14 @@ package org.jitsi.jicofo.xmpp
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
+import io.opentelemetry.api.trace.Tracer
 import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.auth.AuthenticationAuthority
 import org.jitsi.jicofo.auth.ErrorFactory
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
 import org.jitsi.jwt.JitsiToken
+import org.jitsi.tracing.TracingGlobal.Companion.sdk
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.jitsimeet.ConferenceIq
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler
@@ -35,6 +37,7 @@ import org.jxmpp.jid.DomainBareJid
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
 import java.lang.Boolean.parseBoolean
+import java.util.Objects
 import org.jitsi.jicofo.visitors.VisitorsConfig.Companion.config as visitorsConfig
 
 /**
@@ -56,6 +59,7 @@ class ConferenceIqHandler(
     private val connection = xmppProvider.xmppConnection
     private var breakoutAddress: DomainBareJid? = null
     private val logger = createLogger()
+    private val tracer: Tracer = sdk.getTracer("org.jitsi.jicofo.xmpp")
 
     init {
         xmppProvider.addListener(this)
@@ -73,6 +77,20 @@ class ConferenceIqHandler(
 
     /** Handle a [ConferenceIq] synchronously and return a response. */
     fun handleConferenceIq(query: ConferenceIq): IQ {
+        val span = tracer.spanBuilder("xmpp.conference")
+            .setAttribute("client.id", Objects.toString(query.from))
+            .setAttribute("room.id", Objects.toString(query.room))
+            .startSpan()
+        try {
+            span.makeCurrent().use {
+                return doHandleConferenceIq(query)
+            }
+        } finally {
+            span.end()
+        }
+    }
+
+    private fun doHandleConferenceIq(query: ConferenceIq): IQ {
         val room = query.room ?: return IQ.createErrorResponse(
             query,
             StanzaError.from(StanzaError.Condition.bad_request, "No 'room' specified.").build()

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -19,6 +19,7 @@ package org.jitsi.jicofo.xmpp
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import org.jitsi.jicofo.FocusManager
 import org.jitsi.jicofo.TaskPools
@@ -37,7 +38,7 @@ import org.jxmpp.jid.DomainBareJid
 import org.jxmpp.jid.EntityBareJid
 import org.jxmpp.jid.impl.JidCreate
 import java.lang.Boolean.parseBoolean
-import java.util.Objects
+import java.util.*
 import org.jitsi.jicofo.visitors.VisitorsConfig.Companion.config as visitorsConfig
 
 /**
@@ -85,6 +86,9 @@ class ConferenceIqHandler(
             span.makeCurrent().use {
                 return doHandleConferenceIq(query)
             }
+        } catch (e: Throwable) {
+            span.setStatus(StatusCode.ERROR, e.message ?: "")
+            throw e
         } finally {
             span.end()
         }

--- a/jicofo/src/main/resources/reference.conf
+++ b/jicofo/src/main/resources/reference.conf
@@ -213,3 +213,8 @@ jicofo {
     enable-live-room = false
   }
 }
+
+tracing {
+  enabled = false
+  service-name = "jicofo"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-116-gc47d314</version>
+        <version>1.0-117-g60c0446</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>jicoco-tracing</artifactId>
+        <version>${jicoco.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-metaconfig</artifactId>
         <version>1.0-9-g5e1b624</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
     <junit.version>5.10.0</junit.version>
     <mockk.version>1.13.8</mockk.version>
-    <opentelemetry.version>1.48.0</opentelemetry.version>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
     <junit.version>5.10.0</junit.version>
     <mockk.version>1.13.8</mockk.version>
+    <opentelemetry.version>1.48.0</opentelemetry.version>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <slf4j.version>1.7.32</slf4j.version>
     <jackson.version>2.19.0</jackson.version>
     <jitsi.utils.version>1.0-150-g4ab9a3b</jitsi.utils.version>
-    <jicoco.version>1.1-171-gb3b9e1f</jicoco.version>
+    <jicoco.version>1.1-178-ga09ed33</jicoco.version>
     <ktlint-maven-plugin.version>3.0.0</ktlint-maven-plugin.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-117-g60c0446</version>
+        <version>1.0-118-g64ecd07</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION

This PR adds tracing for the initialization of conferences.

1. Client sends conference request.
1. Client joins MUC.
1. Jicofo invites participant.
1. Jicofo allocates bridge.
1. Client accepts jingle session.
1. Jicofo updates participant information.
1. JVB receives colibri requests.

To propagate context through xmpp messages, I've added a new extension called `TraceParent`. Incomming xmpp messages should include the extension as well.

This PR depends on some changes in:
- jitsi-xmpp-extensions - https://github.com/jitsi/jitsi-xmpp-extensions/pull/146
- jitsi-meet-lib - https://github.com/jitsi/lib-jitsi-meet/pull/3067
- jicoco - https://github.com/jitsi/jicoco/pull/240

Although not required for this to work, I've added some tracing to jitsi-videobridge - https://github.com/jitsi/jitsi-videobridge/pull/2433 and prosody - https://github.com/jitsi/jitsi-meet/pull/17621.

## Setup

To test this, the following configuration is required
```conf
tracing {
    enabled = true
    otlp-protocol = "grpc"
    otlp-endpoint = "http://localhost:4317"
}
```

As well as an OpenTelemetry exporter listening on the configured port.

