### PR TITLE
feat: Make the H.264 profile-level-id configurable.

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecConfig.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecConfig.kt
@@ -74,6 +74,39 @@ private class RtxCodecConfigWithLegacy(
     }
 }
 
+open class H264CodecConfig(base: String, name: String) : RtxCodecConfig(base, name) {
+    private val profileLevelId: String by config {
+        "$base.profile-level-id".from(JitsiConfig.newConfig)
+    }
+
+    fun profileLevelId(): String = profileLevelId
+}
+
+private class H264CodecConfigWithLegacy(
+    legacyBase: String,
+    newBase: String,
+    name: String
+) : H264CodecConfig(newBase, name) {
+    override val enabled: Boolean by config {
+        "$legacyBase.ENABLE_$name".from(JitsiConfig.legacyConfig)
+        "$newBase.enabled".from(JitsiConfig.newConfig)
+    }
+
+    override val pt: Int by config {
+        "$legacyBase.${name}_PT".from(JitsiConfig.legacyConfig)
+        "$newBase.pt".from(JitsiConfig.newConfig)
+    }
+
+    override val rtxPt: Int by config {
+        "$legacyBase.${name}_RTX_PT".from(JitsiConfig.legacyConfig)
+        "$newBase.rtx-pt".from(JitsiConfig.newConfig)
+    }
+
+    override val enableRemb: Boolean by config {
+        "$newBase.enable-remb".from(JitsiConfig.newConfig)
+    }
+}
+
 class OpusConfig : CodecConfig("jicofo.codec.audio.opus", "opus") {
     private val minptime: Int by config {
         "$base.minptime".from(JitsiConfig.newConfig)
@@ -124,7 +157,7 @@ class Config {
     val vp9: RtxCodecConfig = RtxCodecConfigWithLegacy(LEGACY_BASE, "jicofo.codec.video.vp9", "VP9")
 
     @JvmField
-    val h264: RtxCodecConfig = RtxCodecConfigWithLegacy(LEGACY_BASE, "jicofo.codec.video.h264", "H264")
+    val h264: H264CodecConfig = H264CodecConfigWithLegacy(LEGACY_BASE, "jicofo.codec.video.h264", "H264")
 
     @JvmField
     val opus = OpusConfig()

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/codec/CodecUtil.kt
@@ -50,7 +50,10 @@ class CodecUtil {
                 // fail to enable h264, if the encoding name is in lower case.
                 val h264 = createPayloadTypeExtension(config.h264.pt(), "H264", 90000)
                 h264.addVideoExtensions(options, config.h264)
-                h264.addParameterExtension("profile-level-id", "42e01f;level-asymmetry-allowed=1;packetization-mode=1;")
+                h264.addParameterExtension(
+                    "profile-level-id",
+                    "${config.h264.profileLevelId()};level-asymmetry-allowed=1;packetization-mode=1;"
+                )
 
                 add(h264)
             }

--- a/jicofo-common/src/main/resources/reference.conf
+++ b/jicofo-common/src/main/resources/reference.conf
@@ -31,6 +31,11 @@ jicofo {
         // Payload type for the associated RTX stream. Set to -1 to disable RTX.
         rtx-pt = 99
         enable-remb = true
+        // The H.264 profile-level-id advertised in offers. The default (Constrained Baseline, level 3.1) is kept
+        // for compatibility, but note that some platform encoders do not advertise CBP and browsers match profiles
+        // exactly, resulting in a software-encode fallback (e.g. macOS VideoToolbox, which only advertises
+        // Baseline/Main/High -- offering "42001f" instead enables hardware encode there).
+        profile-level-id = "42e01f"
       }
     }
 

--- a/jicofo-common/src/test/kotlin/org/jitsi/jicofo/codec/CodecUtilTest.kt
+++ b/jicofo-common/src/test/kotlin/org/jitsi/jicofo/codec/CodecUtilTest.kt
@@ -115,6 +115,20 @@ class CodecUtilTest : ShouldSpec() {
                     val h264 = CodecUtil.createVideoPayloadTypeExtensions().find { it.name == "H264" }
                     h264!!.id shouldBe 123
                 }
+                context("Default profile-level-id") {
+                    val h264 = CodecUtil.createVideoPayloadTypeExtensions().find { it.name == "H264" }
+                    h264!!.parameters.any {
+                        it.name == "profile-level-id" &&
+                            it.value == "42e01f;level-asymmetry-allowed=1;packetization-mode=1;"
+                    } shouldBe true
+                }
+                withNewConfig("jicofo.codec.video.h264.profile-level-id=\"42001f\"") {
+                    val h264 = CodecUtil.createVideoPayloadTypeExtensions().find { it.name == "H264" }
+                    h264!!.parameters.any {
+                        it.name == "profile-level-id" &&
+                            it.value == "42001f;level-asymmetry-allowed=1;packetization-mode=1;"
+                    } shouldBe true
+                }
             }
         }
         context("Audio") {


### PR DESCRIPTION
As discussed in [H.264 fmtp in jicofo offers (42e01f) — deliberate interop floor or 2017 legacy?](https://community.jitsi.org/t/h-264-fmtp-in-jicofo-offers-42e01f-blocks-videotoolbox-mediafoundation-hardware-encode-deliberate-interop-floor-or-2017-legacy/142402) with @jallamsetty1: jicofo hardcodes `42e01f` (Constrained Baseline) in every H.264 offer, a value dating to the 2017 Firefox workaround (#308). Some platform encoder factories don't advertise CBP while libwebrtc matches profiles exactly, so senders on those platforms silently fall back to software encoding — macOS VideoToolbox advertises only Baseline/Main/High (offering `42001f` on the same machine flips it to hardware encode, `powerEfficient: true`), and MediaFoundation on Windows reportedly behaves the same.

This makes the value configurable:

- New config: `jicofo.codec.video.h264.profile-level-id`, default `"42e01f"` — the offer output is byte-identical to current behavior at default config (the existing param cramming is deliberately untouched to keep the change minimal).
- `H264CodecConfig` follows the existing `RtxCodecConfigWithLegacy` pattern, preserving the legacy `ENABLE_H264`/`H264_PT` properties.
- Tests: default asserts the exact current fmtp string; `withNewConfig` covers an overridden value.

A companion lib-jitsi-meet PR making the client-side H.264 profile filtering in `TPCUtils.ts` configurable will follow, per the same thread.
