### PR TITLE
fix: retry brewery MUC join after a transient failure on reconnect

### DIFF
--- a/jicofo-common/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
+++ b/jicofo-common/src/main/java/org/jitsi/jicofo/xmpp/BaseBrewery.java
@@ -210,6 +210,14 @@ public abstract class BaseBrewery<T extends ExtensionElement>
 
                 chatRoom = null;
             }
+
+            // The XMPP connection is already authenticated at this point, so registrationChanged() won't
+            // fire again. Schedule an explicit retry so a transient failure (e.g. the server not responding
+            // to a stale MUC leave during reconnect) doesn't permanently break the brewery.
+            TaskPools.getScheduledPool().schedule(
+                this::maybeStart,
+                XmppConfig.service.getReplyTimeout().toMillis(),
+                TimeUnit.MILLISECONDS);
         }
     }
 


### PR DESCRIPTION
## Problem

When the XMPP client connection drops uncleanly (e.g. an XML parse error after a very long-running stream), Smack reconnects with `resumed=false`. `BaseBrewery.registrationChanged(true)` then calls `stop()` followed by `maybeStart()` → `start()` to re-enter the brewery room.

Inside `start()`, `ChatRoomImpl.joinAs()` checks `muc.isJoined` — which is still `true` from the crashed connection — and calls `muc.leave()` before rejoining. If the XMPP server doesn't respond to that stale leave stanza within the reply timeout, a `NoResponseException` is thrown.

The exception is caught and `chatRoom` is set to `null`, but **no retry is scheduled**. Because the connection is already in the authenticated state at that point, `registrationChanged()` will not fire again. The brewery is permanently stuck outside the MUC room, and no amount of JVB restarts helps — jicofo must be a room member to receive JVB presence events.

Observed on alpha: after a ~17-day uptime the XML stream hit an overflow condition, the XMPP reconnect triggered this path, and jicofo stopped seeing bridges entirely.

## Fix

Schedule a `maybeStart()` retry (using the same reply-timeout delay used elsewhere) at the end of the catch block in `start()`. If the server is responsive by the time the timer fires, the join succeeds and the brewery recovers. If it fails again, the retry loop continues until it succeeds.

## Testing

- Reproduce: kill the XMPP connection in a way that prevents stream resumption while Prosody is slow to respond to MUC leave stanzas; confirm jicofo recovers automatically without a restart.
- Existing tests pass (`mvn test -pl jicofo-common`).