### PR TITLE
feat: Limit the rate at which a conference adds endpoints to a bridge

### DIFF
--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
@@ -37,6 +37,19 @@ class BridgeConfig private constructor() {
         "$BASE.max-bridge-participants".from(JitsiConfig.newConfig)
     }
 
+    /**
+     * The maximum number of participants that a single conference may add to a single bridge within
+     * [maxBridgeParticipantsInterval]. Use -1 to disable.
+     */
+    val maxBridgeParticipantsPerInterval: Int by config {
+        "$BASE.max-bridge-participants-per-interval".from(JitsiConfig.newConfig)
+    }
+
+    /** The interval over which [maxBridgeParticipantsPerInterval] is enforced. */
+    val maxBridgeParticipantsInterval: Duration by config {
+        "$BASE.max-bridge-participants-interval".from(JitsiConfig.newConfig)
+    }
+
     val averageParticipantStress: Double by config {
         "$BASE.average-participant-stress".from(JitsiConfig.newConfig)
     }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeMetrics.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeMetrics.kt
@@ -24,5 +24,10 @@ class BridgeMetrics {
             "Total number of endpoints moved away from a bridge for automatic load redistribution.",
             labelNames = listOf("jvb")
         )
+        val rateLimited = metricsContainer.registerCounter(
+            "bridge_selection_rate_limited",
+            "Total number of times a bridge was considered overloaded for a conference because the conference had " +
+                "reached max-bridge-participants-per-interval on it."
+        )
     }
 }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategy.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategy.kt
@@ -42,6 +42,7 @@ abstract class BridgeSelectionStrategy {
         participantProperties: ParticipantProperties,
         allowMultiBridge: Boolean
     ): Bridge? {
+        logRateLimitedBridges(conferenceBridges)
         return if (conferenceBridges.isEmpty()) {
             val bridge = doSelect(bridges, conferenceBridges, participantProperties)
             if (bridge != null) {
@@ -319,7 +320,9 @@ abstract class BridgeSelectionStrategy {
      * @return `true` if the bridge should be considered overloaded.
      */
     private fun Bridge.isOverloaded(conferenceBridges: Map<Bridge, ConferenceBridgeProperties>): Boolean {
-        return isOverloaded || hasMaxParticipantsInConference(conferenceBridges)
+        return isOverloaded ||
+            hasMaxParticipantsInConference(conferenceBridges) ||
+            hasMaxRecentParticipantsInConference(conferenceBridges)
     }
 
     private fun Bridge.hasMaxParticipantsInConference(
@@ -328,5 +331,39 @@ abstract class BridgeSelectionStrategy {
         return config.maxBridgeParticipants > 0 &&
             conferenceBridges.containsKey(this) &&
             conferenceBridges[this]!!.participantCount >= config.maxBridgeParticipants
+    }
+
+    /**
+     * Whether the conference has recently added too many endpoints to this bridge, i.e. it is growing on this bridge
+     * faster than the bridge's stress reports can keep up with. Note that this is specific to the conference, and does
+     * not affect the way the bridge is treated for other conferences.
+     */
+    private fun Bridge.hasMaxRecentParticipantsInConference(
+        conferenceBridges: Map<Bridge, ConferenceBridgeProperties>
+    ): Boolean {
+        return config.maxBridgeParticipantsPerInterval > 0 &&
+            (conferenceBridges[this]?.recentlyAddedParticipantCount ?: 0) >=
+            config.maxBridgeParticipantsPerInterval
+    }
+
+    /**
+     * Log (and count) the bridges on which the conference has hit the [config.maxBridgeParticipantsPerInterval] limit.
+     * This is only for visibility, the limit itself is enforced in [hasMaxRecentParticipantsInConference].
+     */
+    private fun logRateLimitedBridges(conferenceBridges: Map<Bridge, ConferenceBridgeProperties>) {
+        if (config.maxBridgeParticipantsPerInterval <= 0) return
+        val rateLimited = conferenceBridges.filterValues {
+            it.recentlyAddedParticipantCount >= config.maxBridgeParticipantsPerInterval
+        }
+        if (rateLimited.isNotEmpty()) {
+            BridgeMetrics.rateLimited.inc()
+            logger.info(
+                "The conference has recently added too many endpoints to these bridges, they will not be used for " +
+                    "this participant: " +
+                    rateLimited.entries.joinToString {
+                        "${it.key}=${it.value.recentlyAddedParticipantCount}"
+                    }
+            )
+        }
     }
 }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelector.kt
@@ -288,7 +288,12 @@ class BridgeSelector @JvmOverloads constructor(
 
 data class ConferenceBridgeProperties(
     val participantCount: Int,
-    val visitor: Boolean = false
+    val visitor: Boolean = false,
+    /**
+     * The number of endpoints that this conference has added to this bridge within
+     * [BridgeConfig.maxBridgeParticipantsInterval].
+     */
+    val recentlyAddedParticipantCount: Long = 0
 )
 
 data class ParticipantProperties(

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -23,6 +23,7 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
 import org.jitsi.jicofo.OctoConfig
 import org.jitsi.jicofo.bridge.Bridge
+import org.jitsi.jicofo.bridge.BridgeConfig
 import org.jitsi.jicofo.bridge.CascadeLink
 import org.jitsi.jicofo.bridge.CascadeNode
 import org.jitsi.jicofo.codec.CodecUtil
@@ -32,6 +33,7 @@ import org.jitsi.jicofo.conference.source.EndpointSourceSet
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import org.jitsi.utils.stats.RateTracker
 import org.jitsi.xmpp.extensions.TraceParent
 import org.jitsi.xmpp.extensions.colibri.WebSocketPacketExtension
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Endpoint
@@ -50,8 +52,13 @@ import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 import org.jivesoftware.smack.StanzaCollector
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smackx.muc.MUCRole
+import java.time.Duration
 import java.util.Collections.singletonList
 import java.util.UUID
+import kotlin.math.ceil
+
+/** The size of the buckets used to track the rate at which endpoints are added to a session. */
+private const val BUCKET_SIZE_MS = 100L
 
 /** Represents a colibri2 session with one specific bridge. */
 class Colibri2Session(
@@ -66,6 +73,34 @@ class Colibri2Session(
     }
     private val xmppConnection = colibriSessionManager.xmppConnection
     val id = UUID.randomUUID().toString()
+
+    /**
+     * Keep track of the endpoints that this conference recently added to this bridge. Note that this is
+     * per-(conference, bridge), as opposed to [Bridge]'s own tracker which is per-bridge (across all conferences).
+     *
+     * We use the number-of-buckets constructor (as opposed to the window-size one) so that an interval which is not a
+     * multiple of the bucket size is rounded up instead of failing at runtime.
+     */
+    private val newEndpointsRate = RateTracker(
+        numBuckets = ceil(
+            BridgeConfig.config.maxBridgeParticipantsInterval.toMillis().toDouble() / BUCKET_SIZE_MS
+        ).toInt().coerceAtLeast(1),
+        bucketSize = Duration.ofMillis(BUCKET_SIZE_MS),
+        clock = colibriSessionManager.clock
+    )
+
+    /** The number of endpoints that this conference recently added to this bridge. */
+    internal val recentlyAddedEndpointCount: Long
+        get() = newEndpointsRate.getAccumulatedCount()
+
+    /**
+     * Notifies this session that it was used for a new endpoint. Note that endpoints leaving are intentionally not
+     * subtracted (this models the rate at which endpoints were *added*, matching [Bridge.endpointAdded]).
+     */
+    internal fun endpointAdded() {
+        newEndpointsRate.update(1)
+        bridge.endpointAdded()
+    }
 
     /**
      * The colibri2 `<connect>`s currently active on this session, by id (the last set signaled to the bridge).
@@ -410,6 +445,7 @@ class Colibri2Session(
         put("id", id)
         set<ObjectNode>("feedback_sources", feedbackSources.toJson())
         put("created", created)
+        put("recently_added_endpoints", recentlyAddedEndpointCount)
         set<ObjectNode>(
             "relays",
             JsonNodeFactory.instance.objectNode().apply {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -59,6 +59,7 @@ import org.jivesoftware.smack.packet.StanzaError.Condition.item_not_found
 import org.jivesoftware.smack.packet.StanzaError.Condition.service_unavailable
 import java.net.URI
 import java.net.URLEncoder
+import java.time.Clock
 import java.util.Collections.singletonList
 
 /** The fixed connect id used for the (single) transcriber connect. */
@@ -100,7 +101,7 @@ internal fun perSourceTranslatorSpecs(
  * Implements [ColibriSessionManager] using colibri2.
  */
 @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
-class ColibriV2SessionManager(
+class ColibriV2SessionManager @JvmOverloads constructor(
     internal val xmppConnection: AbstractXMPPConnection,
     private val bridgeSelector: BridgeSelector,
     internal val conferenceName: String,
@@ -111,7 +112,8 @@ class ColibriV2SessionManager(
     internal val meetingId: String,
     internal val rtcStatsEnabled: Boolean,
     private val bridgeVersion: String?,
-    parentLogger: Logger
+    parentLogger: Logger,
+    internal val clock: Clock = Clock.systemUTC()
 ) : ColibriSessionManager, Cascade<Colibri2Session, Colibri2Session.Relay> {
     private val logger = createChildLogger(parentLogger)
     private val tracer = TracingGlobal.sdk.getTracer("org.jitsi.jicofo.colibri")
@@ -477,7 +479,8 @@ class ColibriV2SessionManager(
                     it.key.bridge,
                     ConferenceBridgeProperties(
                         it.value.size,
-                        it.value.firstOrNull()?.visitor == true
+                        it.value.firstOrNull()?.visitor == true,
+                        it.key.recentlyAddedEndpointCount
                     )
                 )
             }
@@ -574,7 +577,7 @@ class ColibriV2SessionManager(
                 )
             }
             participantInfo = ParticipantInfo(participant, session)
-            session.bridge.endpointAdded()
+            session.endpointAdded()
             stanzaCollector = session.sendAllocationRequest(participantInfo)
             add(participantInfo)
             if (created) {

--- a/jicofo-selector/src/main/resources/reference.conf
+++ b/jicofo-selector/src/main/resources/reference.conf
@@ -5,6 +5,23 @@ jicofo {
   bridge {
     // The maximum number of participants in a single conference to put on one bridge (use -1 for no maximum).
     max-bridge-participants = 80
+    // The maximum number of participants that a single conference may add to a single bridge within
+    // [max-bridge-participants-interval]. A bridge which has reached this limit is considered overloaded *for that
+    // conference only* when selecting a bridge for a new participant; other conferences, and all other bridge-level
+    // logic (stress, sorting, load redistribution) are unaffected.
+    //
+    // This limits the overshoot that happens when a conference bursts: a bridge reports its stress level only every
+    // 5-10 seconds, so during a burst of joins the reported stress is stale by construction and jicofo can keep
+    // selecting the same bridge long after it is full. Note this is a limit on the *rate* at which a conference grows
+    // on a bridge, so it does not affect a conference which grows slowly (where the stress feedback has caught up),
+    // and it does not affect many small conferences sharing a bridge (each has a low rate of its own).
+    //
+    // Use -1 to disable. A suggested value for a production deployment is 30 (with the default 1 minute interval).
+    // Note that [max-bridge-participants] remains in effect as a hard limit.
+    max-bridge-participants-per-interval = -1
+    // The interval over which [max-bridge-participants-per-interval] is enforced. It should comfortably cover the
+    // interval at which bridges report their stress level (5-10 seconds).
+    max-bridge-participants-interval = 1 minute
     // The default assumed average stress per participant. This value is only used when a bridge does not report its
     // own value.
     average-participant-stress = 0.01

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeConfigTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/BridgeConfigTest.kt
@@ -24,6 +24,7 @@ import org.jitsi.config.withNewConfig
 import org.jitsi.jicofo.bridge.BridgeConfig.Companion.config
 import org.jitsi.metaconfig.MetaconfigSettings
 import org.jitsi.utils.mins
+import org.jitsi.utils.secs
 
 class BridgeConfigTest : ShouldSpec() {
     override fun isolationMode() = IsolationMode.InstancePerLeaf
@@ -32,6 +33,20 @@ class BridgeConfigTest : ShouldSpec() {
         MetaconfigSettings.cacheEnabled = false
         context("with no config the defaults from reference.conf should be used") {
             config.maxBridgeParticipants shouldBe 80
+            // The rate limit is disabled by default.
+            config.maxBridgeParticipantsPerInterval shouldBe -1
+            config.maxBridgeParticipantsInterval shouldBe 1.mins
+        }
+        context("max-bridge-participants-per-interval") {
+            withNewConfig(
+                """
+                jicofo.bridge.max-bridge-participants-per-interval=30
+                jicofo.bridge.max-bridge-participants-interval=30 seconds
+                """.trimIndent()
+            ) {
+                config.maxBridgeParticipantsPerInterval shouldBe 30
+                config.maxBridgeParticipantsInterval shouldBe 30.secs
+            }
         }
         context("with legacy config") {
             withLegacyConfig(legacyConfig) {

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/MaxParticipantsPerIntervalTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/MaxParticipantsPerIntervalTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.bridge
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.config.withNewConfig
+import org.jxmpp.jid.impl.JidCreate
+
+/**
+ * Tests the `max-bridge-participants-per-interval` limit, i.e. a bridge being considered overloaded for a specific
+ * conference because that conference recently added too many endpoints to it.
+ */
+class MaxParticipantsPerIntervalTest : ShouldSpec() {
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    private fun createBridge(name: String, stress: Double) = Bridge(JidCreate.from(name)).apply {
+        setStats(stress = stress, region = REGION)
+    }
+    private val bridge1 = createBridge("bridge1", 0.0)
+    private val bridge2 = createBridge("bridge2", 0.1)
+    private val bridges = listOf(bridge1, bridge2)
+    private val participant = ParticipantProperties(REGION)
+
+    /** The conference has [recentlyAdded] endpoints on [bridge1] and none on [bridge2] (which it doesn't use). */
+    private fun onlyBridge1(recentlyAdded: Long) = mapOf(bridge1 to conferenceBridge(recentlyAdded))
+
+    private fun conferenceBridge(recentlyAdded: Long, participantCount: Int = 1) =
+        ConferenceBridgeProperties(participantCount, false, recentlyAdded)
+
+    init {
+        context("With the limit disabled (the default)") {
+            BridgeConfig.config.maxBridgeParticipantsPerInterval shouldBe -1
+
+            with(RegionBasedBridgeSelectionStrategy()) {
+                should("not affect selection regardless of the number of recently added endpoints") {
+                    select(bridges, onlyBridge1(1000), participant, true) shouldBe bridge1
+                }
+            }
+        }
+        context("With the limit enabled") {
+            withNewConfig("$MAX_PER_INTERVAL_CONFIG=$MAX_PER_INTERVAL") {
+                with(RegionBasedBridgeSelectionStrategy()) {
+                    should("keep using the bridge below the limit") {
+                        select(bridges, onlyBridge1(MAX_PER_INTERVAL - 1L), participant, true) shouldBe bridge1
+                    }
+                    should("select another bridge once the limit is reached") {
+                        select(bridges, onlyBridge1(MAX_PER_INTERVAL.toLong()), participant, true) shouldBe bridge2
+                        select(bridges, onlyBridge1(MAX_PER_INTERVAL + 100L), participant, true) shouldBe bridge2
+                    }
+                    should("prefer another bridge that the conference already uses") {
+                        val bridge3 = createBridge("bridge3", 0.2)
+                        select(
+                            bridges + bridge3,
+                            mapOf(
+                                bridge1 to conferenceBridge(MAX_PER_INTERVAL.toLong()),
+                                bridge3 to conferenceBridge(0)
+                            ),
+                            participant,
+                            true
+                        ) shouldBe bridge3
+                    }
+                    should("fall through to the least loaded bridge when all bridges are over the limit") {
+                        select(
+                            bridges,
+                            mapOf(
+                                bridge1 to conferenceBridge(MAX_PER_INTERVAL.toLong()),
+                                bridge2 to conferenceBridge(MAX_PER_INTERVAL.toLong())
+                            ),
+                            participant,
+                            true
+                        ) shouldBe bridge1
+                    }
+                    should("not affect the initial selection for a conference with no bridges") {
+                        select(bridges, emptyMap(), participant, true) shouldBe bridge1
+                    }
+                }
+                context("With IntraRegionBridgeSelectionStrategy") {
+                    with(IntraRegionBridgeSelectionStrategy()) {
+                        should("keep using the bridge below the limit") {
+                            select(bridges, onlyBridge1(MAX_PER_INTERVAL - 1L), participant, true) shouldBe bridge1
+                        }
+                        should("select another bridge once the limit is reached") {
+                            select(bridges, onlyBridge1(MAX_PER_INTERVAL.toLong()), participant, true) shouldBe bridge2
+                        }
+                    }
+                }
+                context("With all bridges overloaded") {
+                    // The last-resort tier (leastLoadedNotMaxedAlreadyInConference) intentionally does not honor the
+                    // rate limit: it exists to return *some* bridge rather than fail the allocation.
+                    val overloaded1 = createBridge("overloaded1", 0.9)
+                    val overloaded2 = createBridge("overloaded2", 0.95)
+                    overloaded1.isOverloaded shouldBe true
+
+                    with(RegionBasedBridgeSelectionStrategy()) {
+                        should("still select a bridge that the conference already uses") {
+                            select(
+                                listOf(overloaded1, overloaded2),
+                                mapOf(
+                                    overloaded1 to conferenceBridge(MAX_PER_INTERVAL.toLong()),
+                                    overloaded2 to conferenceBridge(MAX_PER_INTERVAL.toLong())
+                                ),
+                                participant,
+                                true
+                            ) shouldBe overloaded1
+                        }
+                    }
+                }
+                context("The bridge-level state") {
+                    should("not be affected") {
+                        // The limit is specific to a conference. Nothing about the bridge itself changes, so other
+                        // conferences (and load redistribution, sorting, etc) are unaffected.
+                        val conferenceBridges = onlyBridge1(MAX_PER_INTERVAL + 100L)
+                        with(RegionBasedBridgeSelectionStrategy()) {
+                            select(bridges, conferenceBridges, participant, true) shouldBe bridge2
+                        }
+
+                        bridge1.isOverloaded shouldBe false
+                        bridge1.correctedStress shouldBe 0.0
+
+                        // A different conference, which has not added anything to bridge1, still gets bridge1.
+                        with(RegionBasedBridgeSelectionStrategy()) {
+                            select(bridges, mapOf(bridge1 to conferenceBridge(0)), participant, true) shouldBe bridge1
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private const val REGION = "region"
+private const val MAX_PER_INTERVAL = 10
+private const val MAX_PER_INTERVAL_CONFIG = "jicofo.bridge.max-bridge-participants-per-interval"

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManagerTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManagerTest.kt
@@ -31,6 +31,7 @@ import io.mockk.mockk
 import org.jitsi.config.withNewConfig
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.bridge.Bridge
+import org.jitsi.jicofo.bridge.BridgeConfig
 import org.jitsi.jicofo.bridge.BridgeSelector
 import org.jitsi.jicofo.bridge.ParticipantProperties
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
@@ -39,6 +40,8 @@ import org.jitsi.jicofo.mock.PendingExecutor
 import org.jitsi.jicofo.mock.TestColibri2Server
 import org.jitsi.jicofo.mock.inPlaceScheduledExecutor
 import org.jitsi.utils.logging2.createLogger
+import org.jitsi.utils.ms
+import org.jitsi.utils.time.FakeClock
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifyIQ
 import org.jitsi.xmpp.extensions.jingle.DtlsFingerprintPacketExtension
 import org.jivesoftware.smack.packet.IQ
@@ -105,6 +108,8 @@ class ColibriV2SessionManagerTest : ShouldSpec() {
      */
     private val ioExecutor = PendingExecutor()
 
+    private val clock = FakeClock()
+
     // Initialized lazily so that construction happens after [beforeAny] has replaced the TaskPools executors.
     private val sessionManager by lazy {
         ColibriV2SessionManager(
@@ -114,7 +119,8 @@ class ColibriV2SessionManagerTest : ShouldSpec() {
             "test-meeting-id",
             false,
             null,
-            createLogger()
+            createLogger(),
+            clock
         ).apply { addListener(listener) }
     }
 
@@ -248,6 +254,38 @@ class ColibriV2SessionManagerTest : ShouldSpec() {
                 should("keep the remaining bridge in the conference") {
                     sessionManager.getBridges().keys shouldBe setOf(bridge1)
                     sessionManager.getParticipants(bridge1) shouldBe listOf("p1")
+                }
+            }
+        }
+
+        context("Tracking recently added endpoints") {
+            withNewConfig("jicofo.octo.enabled=true") {
+                allocate("p1", region = "region-jvb1")
+                allocate("p2", region = "region-jvb1")
+                allocate("p3", region = "region-jvb2")
+
+                should("count the endpoints that this conference added to each bridge") {
+                    sessionManager.getBridges()[bridge1]!!.recentlyAddedParticipantCount shouldBe 2
+                    sessionManager.getBridges()[bridge2]!!.recentlyAddedParticipantCount shouldBe 1
+                }
+                should("not decrease the count when a participant is removed") {
+                    sessionManager.removeParticipant("p2").also { drain() }
+                    with(sessionManager.getBridges()[bridge1]!!) {
+                        participantCount shouldBe 1
+                        recentlyAddedParticipantCount shouldBe 2
+                    }
+                }
+                should("decay the count after the configured interval") {
+                    clock.elapse(BridgeConfig.config.maxBridgeParticipantsInterval + 100.ms)
+                    sessionManager.getBridges()[bridge1]!!.recentlyAddedParticipantCount shouldBe 0
+                }
+                should("reset the count when the session is removed and re-created") {
+                    sessionManager.removeParticipant("p1").also { drain() }
+                    sessionManager.removeParticipant("p2").also { drain() }
+                    sessionManager.getBridges().keys shouldBe setOf(bridge2)
+
+                    allocate("p4", region = "region-jvb1")
+                    sessionManager.getBridges()[bridge1]!!.recentlyAddedParticipantCount shouldBe 1
                 }
             }
         }

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/mock/TestColibri2Server.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/mock/TestColibri2Server.kt
@@ -79,6 +79,11 @@ class TestColibri2Server {
             val responseBuilder =
                 ConferenceModifiedIQ.builder(ConferenceModifiedIQ.Builder.createResponse(request))
 
+            if (request.expire) {
+                expireConference(meetingId)
+                return responseBuilder.build()
+            }
+
             if (request.create) {
                 responseBuilder.setSources(buildFeedbackSources(Random.nextLong(), Random.nextLong()))
             }


### PR DESCRIPTION
Adds an optional per-(bridge, conference) limit on the **rate** at which a conference adds endpoints to a bridge: `jicofo.bridge.max-bridge-participants-per-interval` (default `-1`, i.e. disabled) over `jicofo.bridge.max-bridge-participants-interval` (default 1 minute). A suggested production value is 30.

### Why

A bridge reports its stress level via presence only every 5-10 seconds. During a burst of joins the reported stress, and therefore `correctedStress`, is stale by construction, and selection keeps assigning to the same bridge long after it is full. Observed in production: a conference added 92 endpoints in 31 seconds, 58 of them landing on a single bridge which reached a real stress of 1.1, while 9-11 operational bridges in the same pool stayed below 0.05 stress. The logged stress for the overloaded bridge stayed frozen at 0.008 across ~15 consecutive selection decisions.

Rate is a better discriminator than a count:

- A conference which grows to 30 endpoints on a bridge slowly is fine, the stress feedback has caught up and the existing logic works.
- Many small conferences sharing a bridge each have a low rate of their own, so the limit never fires for them.

### How

- The rate is tracked with a `RateTracker` on `Colibri2Session`, which is exactly one object per (conference, bridge), so its lifecycle needs no extra bookkeeping: it is created with the session and dies with it (conference expiry, last endpoint leaving the bridge, bridge removal).
- It reaches selection as a new field on `ConferenceBridgeProperties`, and is checked in the private merged `Bridge.isOverloaded(conferenceBridges)` next to `hasMaxParticipantsInConference`, so every selection strategy inherits it.
- The check reads only `conferenceBridges` and config, never `Bridge`, so `correctedStress`, the bare `Bridge.isOverloaded`, bridge sorting, `hasNonOverloadedBridge()` and load redistribution are unchanged. Behavior for other conferences is unaffected.
- The last-resort tier (`leastLoadedNotMaxedAlreadyInConference`) intentionally does not honor the limit. It exists to return some bridge rather than fail an allocation, and the limit is a spreading heuristic, not a capacity limit.
- `max-bridge-participants` stays in effect as the hard cap.
- A bridge hitting the limit is logged and counted (`bridge_selection_rate_limited`), and the per-session count is exposed in the debug state.

Also fixes a fidelity gap in `TestColibri2Server`, which ignored the conference-level `expire` flag and so never let a bridge be re-used after its session was torn down.
