### PR TITLE
feat: Support in-place ICE restart

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/metrics/IceRestartMetrics.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/metrics/IceRestartMetrics.kt
@@ -1,0 +1,56 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2026 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.metrics
+
+import org.jitsi.jicofo.metrics.JicofoMetricsContainer.Companion.instance as metricsContainer
+
+/**
+ * Metrics for the in-place ICE restart flow. They live here rather than next to either end of the flow because it
+ * spans modules: the request comes in in the `jicofo` module (Participant/JitsiMeetConferenceImpl) while the colibri2
+ * exchange with the bridge happens in `jicofo-selector`.
+ *
+ * The naming matches jitsi-videobridge's `ice_restarts_*` metrics, which cover the other half of the same flow.
+ */
+class IceRestartMetrics {
+    companion object {
+        /** A participant asked for an in-place ICE restart via session-info. */
+        @JvmField
+        val requested = metricsContainer.registerCounter(
+            "ice_restarts_requested",
+            "Number of in-place ICE restarts requested by a participant."
+        )
+
+        /** The bridge's rotated transport was signaled back to the participant in a Jingle transport-info. */
+        @JvmField
+        val relayed = metricsContainer.registerCounter(
+            "ice_restarts_relayed",
+            "Number of in-place ICE restarts for which the bridge's rotated transport was signaled to the participant."
+        )
+
+        /**
+         * An ICE restart did not complete: the request was rejected (disabled, rate-limited, stale bridge-session ID)
+         * or the bridge's response could not be relayed (no transport in the response, stale generation, participant
+         * or Jingle session gone).
+         */
+        @JvmField
+        val failed = metricsContainer.registerCounter(
+            "ice_restarts_failed",
+            "Number of in-place ICE restarts that were rejected or could not be completed."
+        )
+    }
+}

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -40,6 +40,7 @@ import org.jitsi.utils.queue.PacketQueue
 import org.jitsi.xmpp.extensions.TraceParent
 import org.jitsi.xmpp.extensions.jingle.ContentPacketExtension
 import org.jitsi.xmpp.extensions.jingle.GroupPacketExtension
+import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 import org.jitsi.xmpp.extensions.jingle.JingleAction
 import org.jitsi.xmpp.extensions.jingle.JingleIQ
 import org.jitsi.xmpp.extensions.jingle.JinglePacketFactory
@@ -286,6 +287,37 @@ class JingleSession(
         if (state != State.ACTIVE) logger.error("Sending source-remove for session in state $state")
         connection.tryToSendStanza(removeSourceIq)
         JingleStats.stanzaSent(JingleAction.SOURCEREMOVE)
+    }
+
+    /**
+     * Send a transport-info IQ carrying the bridge's transport. Used after the bridge performed an ICE restart
+     * and rotated its ICE credentials: the client's connectivity checks are addressed to those credentials, so
+     * it has to be told the new ones. Returns immediately without waiting for a response.
+     *
+     * The transport is sent on a single content; the client applies the credentials to its whole (bundled)
+     * transport, so which content carries them does not matter.
+     */
+    fun sendTransportInfo(transport: IceUdpTransportPacketExtension) {
+        val transportInfoIq = JingleIQ(JingleAction.TRANSPORT_INFO, sid).apply {
+            from = localJid
+            type = IQ.Type.set
+            to = remoteJid
+            addContent(
+                ContentPacketExtension().apply {
+                    creator = ContentPacketExtension.CreatorEnum.initiator
+                    name = "audio"
+                    addChildExtension(IceUdpTransportPacketExtension.cloneTransportAndCandidates(transport, true))
+                }
+            )
+        }
+
+        logger.info(
+            "ICE restart: sending transport-info with the bridge's transport, generation=${transport.iceGeneration}, " +
+                "ufrag=${transport.ufrag}"
+        )
+        if (state != State.ACTIVE) logger.error("Sending transport-info for session in state $state")
+        connection.tryToSendStanza(transportInfoIq)
+        JingleStats.stanzaSent(JingleAction.TRANSPORT_INFO)
     }
 
     /**

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -30,6 +30,7 @@ import org.jitsi.jicofo.codec.CodecUtil
 import org.jitsi.jicofo.codec.Config
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
+import org.jitsi.jicofo.metrics.IceRestartMetrics
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
@@ -193,6 +194,35 @@ class Colibri2Session(
 
         request.addEndpoint(endpoint.build())
         sendRequest(request.build(), "updateParticipant")
+    }
+
+    /**
+     * Ask the bridge to perform an in-place ICE restart for an endpoint: it creates a new ICE agent with fresh
+     * credentials while the existing one keeps carrying media, and answers with the new transport.
+     *
+     * The bridge's new credentials are relayed on to the endpoint (via
+     * [ColibriV2SessionManager.endpointIceRestarted]), which addresses its connectivity checks to them.
+     */
+    internal fun restartIce(participant: ParticipantInfo) {
+        val request = createRequest()
+        request.addEndpoint(
+            Colibri2Endpoint.getBuilder().apply {
+                setId(participant.id)
+                setStatsId(participant.statsId)
+                setTransport(Transport.getBuilder().setIceRestart(true).build())
+            }.build()
+        )
+
+        logger.info("Requesting an ICE restart for ${participant.id}")
+        sendRequest(request.build(), "restartIce") { response ->
+            val bridgeTransport = response.endpoints.find { it.id == participant.id }?.transport?.iceUdpTransport
+            if (bridgeTransport == null) {
+                logger.error("No transport in the response to an ICE restart request for ${participant.id}")
+                IceRestartMetrics.failed.inc()
+            } else {
+                colibriSessionManager.endpointIceRestarted(participant.id, bridgeTransport)
+            }
+        }
     }
 
     internal fun updateForceMute(participants: Set<ParticipantInfo>) {
@@ -394,8 +424,12 @@ class Colibri2Session(
     /**
      * Send an IQ async, and handle timeouts and errors: timeouts are just logged, while errors trigger a session
      * failure.
+     *
+     * @param onSuccess invoked with the response when the bridge answered successfully. Note that this runs on
+     * [org.jitsi.jicofo.util.TaskPools.ioPool], so responses to two requests sent in order may be handled out of
+     * order — anything order-sensitive needs its own guard.
      */
-    private fun sendRequest(iq: IQ, name: String) {
+    private fun sendRequest(iq: IQ, name: String, onSuccess: ((ConferenceModifiedIQ) -> Unit)? = null) {
         logger.debug { "Sending $name request: ${iq.toXML()}" }
         xmppConnection.sendIqAndHandleResponseAsync(iq) { response ->
             if (response == null) {
@@ -434,6 +468,7 @@ class Colibri2Session(
                 colibriSessionManager.sessionFailed(this@Colibri2Session)
             } else {
                 logger.debug { "Received $name response: ${response.toXML()}" }
+                onSuccess?.invoke(response)
             }
         }
     }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -30,7 +30,6 @@ import org.jitsi.jicofo.codec.CodecUtil
 import org.jitsi.jicofo.codec.Config
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
-import org.jitsi.jicofo.metrics.IceRestartMetrics
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
@@ -217,8 +216,10 @@ class Colibri2Session(
         sendRequest(request.build(), "restartIce") { response ->
             val bridgeTransport = response.endpoints.find { it.id == participant.id }?.transport?.iceUdpTransport
             if (bridgeTransport == null) {
-                logger.error("No transport in the response to an ICE restart request for ${participant.id}")
-                IceRestartMetrics.failed.inc()
+                // The bridge declined the restart (disabled in its configuration, transport not established yet,
+                // or shutting down). It says so by omitting the transport rather than by returning an error.
+                logger.warn("No transport in the response to an ICE restart request for ${participant.id}")
+                colibriSessionManager.endpointIceRestartFailed(participant.id)
             } else {
                 colibriSessionManager.endpointIceRestarted(participant.id, bridgeTransport)
             }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -120,6 +120,14 @@ interface ColibriSessionManager {
          * transport has to be signalled to the endpoint, whose connectivity checks are addressed to it.
          */
         fun endpointIceRestarted(endpointId: String, transport: IceUdpTransportPacketExtension) {}
+
+        /**
+         * The bridge did not perform the ICE restart that was requested for an endpoint. The bridge signals this
+         * by answering with no transport rather than with an error (so that one endpoint can not fail a
+         * conference-modify carrying updates for others), which leaves the endpoint waiting for a restart that
+         * will never arrive. Recover it the way it would have been recovered without an in-place restart.
+         */
+        fun endpointIceRestartFailed(endpointId: String) {}
     }
 }
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriSessionManager.kt
@@ -58,6 +58,13 @@ interface ColibriSessionManager {
         suppressLocalBridgeUpdate: Boolean = false
     )
 
+    /**
+     * Ask the bridge to perform an in-place ICE restart for a participant. The bridge creates a new ICE agent with
+     * fresh credentials (while the existing one keeps carrying media) and answers with its new transport, which is
+     * relayed back to the participant via [Listener.endpointIceRestarted].
+     */
+    fun restartIce(participantId: String)
+
     fun getBridgeSessionId(participantId: String): Pair<Bridge?, String?>
 
     fun setTranscriberUrl(
@@ -107,6 +114,12 @@ interface ColibriSessionManager {
 
         /** Endpoint removed due to a failure e.g. unknown endpoint */
         fun endpointRemoved(endpointId: String)
+
+        /**
+         * The bridge performed an ICE restart for an endpoint and rotated its own ICE credentials. The new
+         * transport has to be signalled to the endpoint, whose connectivity checks are addressed to it.
+         */
+        fun endpointIceRestarted(endpointId: String, transport: IceUdpTransportPacketExtension) {}
     }
 }
 

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -40,6 +40,7 @@ import org.jitsi.jicofo.bridge.getNodesBehind
 import org.jitsi.jicofo.bridge.getPathsFrom
 import org.jitsi.jicofo.bridge.removeNode
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
+import org.jitsi.jicofo.metrics.IceRestartMetrics
 import org.jitsi.tracing.TracingGlobal
 import org.jitsi.utils.TemplatedUrl
 import org.jitsi.utils.event.AsyncEventEmitter
@@ -781,6 +782,53 @@ class ColibriV2SessionManager @JvmOverloads constructor(
             val removedParticipants = removeSession(session)
             eventEmitter.fireEvent { bridgeRemoved(session.bridge, removedParticipants.map { it.id }.toList()) }
         }
+    }
+
+    /**
+     * The bridge performed an ICE restart for [endpointId] and rotated its own ICE credentials. Relay its new
+     * transport on to the participant, which needs it to address its connectivity checks to the bridge's new
+     * Agent.
+     *
+     * Stale responses are dropped here rather than downstream: colibri2 responses are handled on an IO pool, so
+     * if the participant restarts twice in quick succession the two responses can arrive in either order. The
+     * `ice-generation` the bridge echoes tells us which round each belongs to, and anything older than what we
+     * have already relayed is discarded.
+     */
+    internal fun endpointIceRestarted(endpointId: String, transport: IceUdpTransportPacketExtension) {
+        val generation = transport.iceGeneration
+        synchronized(syncRoot) {
+            val participantInfo = participants[endpointId] ?: run {
+                logger.info("ICE restart: got a transport for an unknown endpoint $endpointId, ignoring.")
+                IceRestartMetrics.failed.inc()
+                return
+            }
+            if (generation != IceUdpTransportPacketExtension.GENERATION_UNSPECIFIED &&
+                participantInfo.lastRelayedIceGeneration != IceUdpTransportPacketExtension.GENERATION_UNSPECIFIED &&
+                generation <= participantInfo.lastRelayedIceGeneration
+            ) {
+                logger.info(
+                    "ICE restart: ignoring a stale transport for $endpointId, generation=$generation " +
+                        "(already relayed ${participantInfo.lastRelayedIceGeneration})"
+                )
+                IceRestartMetrics.failed.inc()
+                return
+            }
+            participantInfo.lastRelayedIceGeneration = generation
+        }
+        logger.info(
+            "ICE restart: received the bridge's transport for $endpointId, generation=$generation, " +
+                "ufrag=${transport.ufrag}"
+        )
+        eventEmitter.fireEvent { endpointIceRestarted(endpointId, transport) }
+    }
+
+    override fun restartIce(participantId: String) = synchronized(syncRoot) {
+        val participantInfo = participants[participantId] ?: run {
+            logger.error("ICE restart: no ParticipantInfo for $participantId, can not request an ICE restart.")
+            IceRestartMetrics.failed.inc()
+            return
+        }
+        participantInfo.session.restartIce(participantInfo)
     }
 
     internal fun endpointFailed(endpointId: String) {

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -822,6 +822,17 @@ class ColibriV2SessionManager @JvmOverloads constructor(
         eventEmitter.fireEvent { endpointIceRestarted(endpointId, transport) }
     }
 
+    /**
+     * The bridge declined an ICE restart we requested for [endpointId] (it answered with no transport). The
+     * endpoint is waiting for a restart that will never arrive, so escalate to the recovery it would have got
+     * if it had never asked for an in-place restart.
+     */
+    internal fun endpointIceRestartFailed(endpointId: String) {
+        logger.warn("ICE restart: the bridge did not restart ICE for $endpointId, falling back to a re-invite.")
+        IceRestartMetrics.failed.inc()
+        eventEmitter.fireEvent { endpointIceRestartFailed(endpointId) }
+    }
+
     override fun restartIce(participantId: String) = synchronized(syncRoot) {
         val participantInfo = participants[participantId] ?: run {
             logger.error("ICE restart: no ParticipantInfo for $participantId, can not request an ICE restart.")

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ParticipantInfo.kt
@@ -19,6 +19,7 @@ package org.jitsi.jicofo.bridge.colibri
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
+import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 
 /**
  * Represents the information for a specific participant/endpoint needed for colibri2.
@@ -40,6 +41,13 @@ class ParticipantInfo(
     var audioMuted = parameters.forceMuteAudio
     var videoMuted = parameters.forceMuteVideo
     var sources = parameters.sources
+
+    /**
+     * The `ice-generation` of the most recent ICE restart for which we relayed the bridge's rotated transport
+     * back to this participant, used to discard responses that arrive out of order. See
+     * [ColibriV2SessionManager.endpointIceRestarted]. Guarded by the session manager's lock.
+     */
+    var lastRelayedIceGeneration = IceUdpTransportPacketExtension.GENERATION_UNSPECIFIED
 
     fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("id", id)

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManagerTest.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManagerTest.kt
@@ -44,9 +44,17 @@ import org.jitsi.utils.ms
 import org.jitsi.utils.time.FakeClock
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifyIQ
 import org.jitsi.xmpp.extensions.jingle.DtlsFingerprintPacketExtension
+import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
+import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension.GENERATION_UNSPECIFIED
 import org.jivesoftware.smack.packet.IQ
 import org.jxmpp.jid.Jid
 import org.jxmpp.jid.impl.JidCreate
+
+private fun transportWithGeneration(generation: Int?) = IceUdpTransportPacketExtension().apply {
+    ufrag = "ufrag-$generation"
+    password = "password-$generation"
+    generation?.let { setIceGeneration(it) }
+}
 
 /**
  * Tests [ColibriV2SessionManager] against [TestColibri2Server]s, including multi-bridge (Octo) conferences with
@@ -92,6 +100,9 @@ class ColibriV2SessionManagerTest : ShouldSpec() {
 
     private val failedSessions = mutableListOf<Bridge>()
     private val removedEndpoints = mutableListOf<String>()
+
+    /** The transports relayed to participants after an ICE restart, in the order they were fired. */
+    private val iceRestartedTransports = mutableListOf<Pair<String, IceUdpTransportPacketExtension>>()
     private val listener = object : ColibriSessionManager.Listener {
         override fun bridgeCountChanged(bridgeCount: Int) {}
         override fun bridgeRemoved(bridge: Bridge, participantIds: List<String>) {
@@ -99,6 +110,9 @@ class ColibriV2SessionManagerTest : ShouldSpec() {
         }
         override fun endpointRemoved(endpointId: String) {
             removedEndpoints.add(endpointId)
+        }
+        override fun endpointIceRestarted(endpointId: String, transport: IceUdpTransportPacketExtension) {
+            iceRestartedTransports.add(endpointId to transport)
         }
     }
 
@@ -286,6 +300,74 @@ class ColibriV2SessionManagerTest : ShouldSpec() {
 
                     allocate("p4", region = "region-jvb1")
                     sessionManager.getBridges()[bridge1]!!.recentlyAddedParticipantCount shouldBe 1
+                }
+            }
+        }
+
+        context("ICE restart") {
+            allocate("p1", region = "region-jvb1")
+
+            context("For an existing participant") {
+                sessionManager.restartIce("p1").also { drain() }
+
+                should("request an ICE restart for the endpoint from its bridge") {
+                    val iceRestarts = requestsTo(bridge1).flatMap { it.endpoints }
+                        .filter { it.transport?.iceRestart == true }
+                    iceRestarts.map { it.id } shouldBe listOf("p1")
+                }
+                should("relay the bridge's rotated transport back to the participant") {
+                    iceRestartedTransports.size shouldBe 1
+                    val (endpointId, transport) = iceRestartedTransports.first()
+                    endpointId shouldBe "p1"
+                    // The bridge rotated its credentials and tagged them with the first generation.
+                    transport.iceGeneration shouldBe 1
+                    transport.ufrag shouldBe "ufrag-test-meeting-id-p1-1"
+                }
+                should("not fail the session") {
+                    failedSessions.shouldBeEmpty()
+                }
+
+                context("And restarting again") {
+                    sessionManager.restartIce("p1").also { drain() }
+
+                    should("relay the next generation") {
+                        iceRestartedTransports.map { it.second.iceGeneration } shouldBe listOf(1, 2)
+                    }
+                }
+            }
+
+            context("For an unknown participant") {
+                sessionManager.restartIce("nonexistent").also { drain() }
+
+                should("not send anything to the bridge") {
+                    requestsTo(bridge1).flatMap { it.endpoints }.none { it.transport?.iceRestart == true } shouldBe true
+                }
+                should("not relay anything") {
+                    iceRestartedTransports.shouldBeEmpty()
+                }
+            }
+
+            context("With responses arriving out of order") {
+                // Colibri2 responses are handled on an IO pool, so two restarts in quick succession can be handled in
+                // either order. Only the latest generation may be relayed on to the participant.
+                sessionManager.endpointIceRestarted("p1", transportWithGeneration(2)).also { drain() }
+                sessionManager.endpointIceRestarted("p1", transportWithGeneration(1)).also { drain() }
+                sessionManager.endpointIceRestarted("p1", transportWithGeneration(3)).also { drain() }
+
+                should("drop the stale generation and relay the rest") {
+                    iceRestartedTransports.map { it.second.iceGeneration } shouldBe listOf(2, 3)
+                }
+            }
+
+            context("With a bridge that does not tag generations") {
+                sessionManager.endpointIceRestarted("p1", transportWithGeneration(null)).also { drain() }
+                sessionManager.endpointIceRestarted("p1", transportWithGeneration(null)).also { drain() }
+
+                should("relay everything (the guard can not order untagged transports)") {
+                    iceRestartedTransports.size shouldBe 2
+                    iceRestartedTransports.map {
+                        it.second.iceGeneration
+                    } shouldBe listOf(GENERATION_UNSPECIFIED, GENERATION_UNSPECIFIED)
                 }
             }
         }

--- a/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/mock/TestColibri2Server.kt
+++ b/jicofo-selector/src/test/kotlin/org/jitsi/jicofo/mock/TestColibri2Server.kt
@@ -153,6 +153,13 @@ class TestColibri2Server {
                     )
                 }
                 respBuilder.setTransport(transBuilder.build())
+            } else if (c2endpoint.transport?.iceRestart == true) {
+                // Model the bridge's in-place ICE restart: it creates a new agent with fresh credentials, tags them
+                // with the next generation, and returns them in the response.
+                endpoint.iceGeneration++
+                respBuilder.setTransport(
+                    Transport.getBuilder().setIceUdpExtension(endpoint.describeTransport()).build()
+                )
             }
 
             c2endpoint.forceMute?.let {
@@ -237,17 +244,28 @@ class TestColibri2Server {
             var forceMuteAudio = false
             var forceMuteVideo = false
 
-            fun describeTransport() = IceUdpTransportPacketExtension().apply {
-                password = "password-$meetingId-$id"
-                ufrag = "ufrag-$meetingId-$id"
-                // TODO add some candidates?
-                addChildExtension(
-                    DtlsFingerprintPacketExtension().apply {
-                        hash = "sha-256"
-                        text = "AC:58:2D:03:40:89:87:30:6C:25:2C:50:17:5C:5C:2E:" +
-                            "1F:A1:19:19:4D:74:A5:37:35:22:6E:8E:DF:55:13:8E"
+            /** Incremented on each in-place ICE restart, i.e. each time the bridge rotates its credentials. */
+            var iceGeneration = 0
+
+            fun describeTransport(): IceUdpTransportPacketExtension {
+                // Note: bound outside the apply{} below, where `iceGeneration` would resolve to the transport's own
+                // property rather than this endpoint's.
+                val generation = iceGeneration
+                return IceUdpTransportPacketExtension().apply {
+                    password = "password-$meetingId-$id-$generation"
+                    ufrag = "ufrag-$meetingId-$id-$generation"
+                    if (generation > 0) {
+                        setIceGeneration(generation)
                     }
-                )
+                    // TODO add some candidates?
+                    addChildExtension(
+                        DtlsFingerprintPacketExtension().apply {
+                            hash = "sha-256"
+                            text = "AC:58:2D:03:40:89:87:30:6C:25:2C:50:17:5C:5C:2E:" +
+                                "1F:A1:19:19:4D:74:A5:37:35:22:6E:8E:DF:55:13:8E"
+                        }
+                    )
+                }
             }
         }
     }

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -28,12 +28,14 @@ import org.jitsi.jicofo.bridge.*;
 import org.jitsi.jicofo.bridge.colibri.*;
 import org.jitsi.jicofo.conference.source.*;
 import org.jitsi.jicofo.conference.translation.*;
+import org.jitsi.jicofo.metrics.IceRestartMetrics;
 import org.jitsi.jicofo.util.*;
 import org.jitsi.jicofo.util.TracingUtil;
 import org.jitsi.jicofo.version.*;
 import org.jitsi.jicofo.visitors.*;
 import org.jitsi.jicofo.xmpp.*;
 import org.jitsi.jicofo.xmpp.UtilKt;
+import org.jitsi.jicofo.xmpp.jingle.JingleSession;
 import org.jitsi.jicofo.xmpp.muc.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.node.*;
@@ -2907,6 +2909,45 @@ public class JitsiMeetConferenceImpl
         {
             logger.info("Endpoint " + endpointId + " was removed from the conference. Re-inviting participant.");
             reInviteParticipantsById(Collections.singletonList(endpointId), false);
+        }
+
+        @Override
+        public void endpointIceRestarted(
+                @NotNull String endpointId,
+                @NotNull IceUdpTransportPacketExtension transport)
+        {
+            Participant participant = null;
+            synchronized (participantLock)
+            {
+                for (Participant p : participants.values())
+                {
+                    if (endpointId.equals(p.getEndpointId()))
+                    {
+                        participant = p;
+                        break;
+                    }
+                }
+            }
+
+            if (participant == null)
+            {
+                logger.warn("ICE restart: can not signal the bridge's transport, no participant for " + endpointId);
+                IceRestartMetrics.failed.inc();
+                return;
+            }
+
+            JingleSession jingleSession = participant.getJingleSession();
+            if (jingleSession == null)
+            {
+                logger.warn("ICE restart: can not signal the bridge's transport, no Jingle session for " + endpointId);
+                IceRestartMetrics.failed.inc();
+                return;
+            }
+
+            logger.info("ICE restart: relaying the bridge's transport to " + endpointId
+                    + ", generation=" + transport.getIceGeneration());
+            jingleSession.sendTransportInfo(transport);
+            IceRestartMetrics.relayed.inc();
         }
     }
 

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -1295,6 +1295,35 @@ public class JitsiMeetConferenceImpl
     }
 
     /**
+     * Handles a request from a {@link Participant} for an in-place ICE restart. The bridge is asked to create a new
+     * ICE agent with fresh credentials while the existing one keeps carrying media; its response is handled
+     * asynchronously and relayed back to the participant via
+     * {@link ColibriSessionManager.Listener#endpointIceRestarted}.
+     *
+     * @param bridgeSessionId the ID of the bridge session the participant wants restarted.
+     *
+     * @throws InvalidBridgeSessionIdException if bridgeSessionId doesn't match the ID of the (colibri) session that
+     * the participant currently has.
+     */
+    void iceRestart(@NotNull Participant participant, String bridgeSessionId)
+    throws InvalidBridgeSessionIdException
+    {
+        Pair<Bridge, String> existingBridgeSession
+                = getColibriSessionManager().getBridgeSessionId(participant.getEndpointId());
+        if (!Objects.equals(bridgeSessionId, existingBridgeSession.getSecond()))
+        {
+            throw new InvalidBridgeSessionIdException(bridgeSessionId + " is not a currently active session");
+        }
+
+        // Note that unlike a full restart request we intentionally do not call Bridge.endpointRequestedRestart(): an
+        // in-place ICE restart is normally triggered by the client's network changing and is not a signal that the
+        // bridge is failing ICE.
+        logger.info("ICE restart: requesting one from the bridge for " + participant.getEndpointId()
+                + ", bridge-session ID: " + bridgeSessionId);
+        getColibriSessionManager().restartIce(participant.getEndpointId());
+    }
+
+    /**
      * Handles a request from a {@link Participant} to terminate its session and optionally start it again.
      *
      * @param bridgeSessionId the ID of the bridge session that the participant requested to be terminated.

--- a/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.java
@@ -2978,6 +2978,21 @@ public class JitsiMeetConferenceImpl
             jingleSession.sendTransportInfo(transport);
             IceRestartMetrics.relayed.inc();
         }
+
+        @Override
+        public void endpointIceRestartFailed(@NotNull String endpointId)
+        {
+            // The participant asked for an in-place ICE restart and the bridge declined it, so nothing will be
+            // signalled back and the participant would sit on a broken connection until its own timeout. Recover
+            // it the way it would have been recovered if it had never asked: a full re-invite.
+            //
+            // As in iceRestart(), Bridge.endpointRequestedRestart() is intentionally not called - the bridge
+            // declining a restart (typically because the feature is disabled on it) is not evidence that it is
+            // failing ICE, and counting it would feed the bridge-selection penalty.
+            logger.info("ICE restart: the bridge did not restart ICE for " + endpointId
+                    + ", re-inviting the participant.");
+            reInviteParticipantsById(Collections.singletonList(endpointId));
+        }
     }
 
     public static class SenderCountExceededException extends Exception

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/ConferenceConfig.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/ConferenceConfig.kt
@@ -105,6 +105,14 @@ class ConferenceConfig private constructor() {
     }
 
     /**
+     * Whether to honor in-place ICE restart requests (a `session-info` with `<bridge-session ice-restart="true"/>`).
+     * When disabled such requests are rejected and the client is expected to fall back to a full session restart.
+     */
+    val enableIceRestart: Boolean by config {
+        "jicofo.conference.enable-ice-restart".from(newConfig)
+    }
+
+    /**
      * Get the number of milliseconds to delay signaling of Jingle sources given a certain [conferenceSize].
      */
     fun getSourceSignalingDelayMs(conferenceSize: Int) = sourceSignalingDelays.floorEntry(conferenceSize)?.value ?: 0

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/conference/Participant.kt
@@ -28,6 +28,7 @@ import org.jitsi.jicofo.conference.source.ConferenceSourceMap
 import org.jitsi.jicofo.conference.source.EndpointSourceSet
 import org.jitsi.jicofo.conference.source.EndpointSourceSet.Companion.fromJingle
 import org.jitsi.jicofo.conference.source.ValidationFailedException
+import org.jitsi.jicofo.metrics.IceRestartMetrics
 import org.jitsi.jicofo.util.Cancelable
 import org.jitsi.jicofo.xmpp.Features
 import org.jitsi.jicofo.xmpp.jingle.JingleIqRequestHandler
@@ -113,6 +114,17 @@ open class Participant @JvmOverloads constructor(
     private var inviteRunnable: Cancelable? = null
 
     private val restartRequestsRateLimit = RateLimit(
+        defaultMinInterval = ConferenceConfig.config.restartRequestMinInterval,
+        maxRequests = ConferenceConfig.config.restartRequestMaxRequests,
+        interval = ConferenceConfig.config.restartRequestInterval,
+        clock = clock
+    )
+
+    /**
+     * A separate budget for in-place ICE restart requests, so that a burst of them can not exhaust the budget for full
+     * session restarts (and vice versa). It uses the same configured limits.
+     */
+    private val iceRestartRequestsRateLimit = RateLimit(
         defaultMinInterval = ConferenceConfig.config.restartRequestMinInterval,
         maxRequests = ConferenceConfig.config.restartRequestMaxRequests,
         interval = ConferenceConfig.config.restartRequestInterval,
@@ -213,6 +225,9 @@ open class Participant @JvmOverloads constructor(
 
     /** Return true if a restart request should be accepted and false otherwise. */
     fun acceptRestartRequest(): Boolean = restartRequestsRateLimit.accept()
+
+    /** Return true if an in-place ICE restart request should be accepted and false otherwise. */
+    fun acceptIceRestartRequest(): Boolean = iceRestartRequestsRateLimit.accept()
 
     /** The stats ID of the participant. */
     val statId: String?
@@ -452,6 +467,11 @@ open class Participant @JvmOverloads constructor(
         override fun onSessionInfo(jingleSession: JingleSession, iq: JingleIQ): StanzaError? {
             checkJingleSession(jingleSession)?.let { return it }
 
+            val bridgeSession = iq.getExtension(BridgeSessionPacketExtension::class.java)
+            if (bridgeSession?.isIceRestart == true) {
+                return onIceRestartRequest(bridgeSession.id)
+            }
+
             val iceState = iq.getExtension(IceStatePacketExtension::class.java)?.text
             if (!iceState.equals("failed", ignoreCase = true)) {
                 logger.info("Ignored unknown ice-state: $iceState")
@@ -459,9 +479,45 @@ open class Participant @JvmOverloads constructor(
             }
             ConferenceMetrics.participantsIceFailed.inc()
 
-            val bridgeSessionId = iq.getExtension(BridgeSessionPacketExtension::class.java)?.id
+            conference.iceFailed(this@Participant, bridgeSession?.id)
+            return null
+        }
 
-            conference.iceFailed(this@Participant, bridgeSessionId)
+        /**
+         * Handle a request for an in-place ICE restart, i.e. a `session-info` with
+         * `<bridge-session ice-restart="true"/>`. Unlike the full session restart requested via `session-terminate`
+         * this does not tear the session down: the bridge rotates its ICE credentials in place, and the resulting
+         * transport is signaled back to the participant in a `transport-info`.
+         *
+         * @return a [StanzaError] to respond with if the request was rejected, or null if it was accepted.
+         */
+        private fun onIceRestartRequest(bridgeSessionId: String?): StanzaError? {
+            logger.info("ICE restart: received a request, bsId=$bridgeSessionId")
+            IceRestartMetrics.requested.inc()
+
+            if (!ConferenceConfig.config.enableIceRestart) {
+                logger.info("ICE restart: rejecting the request, disabled in configuration.")
+                IceRestartMetrics.failed.inc()
+                return StanzaError.from(
+                    StanzaError.Condition.feature_not_implemented,
+                    "in-place ICE restart is disabled"
+                ).build()
+            }
+
+            if (!acceptIceRestartRequest()) {
+                logger.warn("ICE restart: rejecting the request, rate-limited.")
+                IceRestartMetrics.failed.inc()
+                return StanzaError.from(StanzaError.Condition.resource_constraint, "rate-limited").build()
+            }
+
+            try {
+                conference.iceRestart(this@Participant, bridgeSessionId)
+            } catch (e: InvalidBridgeSessionIdException) {
+                logger.warn("ICE restart: rejecting the request, ${e.message}")
+                IceRestartMetrics.failed.inc()
+                return StanzaError.from(StanzaError.Condition.item_not_found, e.message).build()
+            }
+
             return null
         }
 

--- a/jicofo/src/main/resources/reference.conf
+++ b/jicofo/src/main/resources/reference.conf
@@ -77,7 +77,15 @@ jicofo {
     // session) or ReplaceTransport (send a transport-replace).
     reinvite-method = "RestartJingle"
 
-    // Rate limits for a participant requesting an ICE restart.
+    // Whether to honor in-place ICE restart requests, i.e. a session-info with <bridge-session ice-restart="true"/>.
+    // With this the bridge rotates its ICE credentials in place and the new transport is signaled to the participant
+    // in a transport-info, without tearing the session down. If disabled such requests are rejected and the client is
+    // expected to fall back to a full session restart (session-terminate with <bridge-session restart="true"/>).
+    enable-ice-restart = true
+
+    // Rate limits for a participant requesting a restart. Applied separately to full session restarts
+    // (session-terminate) and in-place ICE restarts (session-info), so that a burst of one can not exhaust the other's
+    // budget.
     restart-request-rate-limits {
         // Never accept a request unless at least `min-interval` has passed since the last request
         min-interval = 5 seconds

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/IceRestartTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/conference/IceRestartTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.jicofo.conference
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.jitsi.config.withNewConfig
+import org.jitsi.jicofo.TaskPools
+import org.jitsi.jicofo.mock.ConferenceHarness
+import org.jitsi.jicofo.mock.inPlaceExecutor
+import org.jitsi.jicofo.mock.inPlaceScheduledExecutor
+import org.jitsi.xmpp.extensions.colibri2.ConferenceModifyIQ
+import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
+import org.jitsi.xmpp.extensions.jingle.JingleAction
+import org.jitsi.xmpp.extensions.jingle.JingleIQ
+import org.jitsi.xmpp.extensions.jitsimeet.BridgeSessionPacketExtension
+import org.jivesoftware.smack.packet.IQ
+import org.jivesoftware.smack.packet.StanzaError
+
+/**
+ * Tests the in-place ICE restart flow end to end within jicofo: a client `session-info` with
+ * `<bridge-session ice-restart="true"/>` results in a colibri2 request to the bridge, and the bridge's rotated
+ * transport is relayed back to the client in a Jingle `transport-info`.
+ */
+class IceRestartTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
+
+    private val harness = ConferenceHarness()
+    private val xmppConnection = harness.xmppConnection
+
+    override suspend fun beforeAny(testCase: TestCase) = super.beforeAny(testCase).also {
+        TaskPools.ioPool = inPlaceExecutor
+        TaskPools.scheduledPool = inPlaceScheduledExecutor
+    }
+
+    override suspend fun afterAny(testCase: TestCase, result: TestResult) = super.afterAny(testCase, result).also {
+        TaskPools.resetIoPool()
+        TaskPools.resetScheduledPool()
+    }
+
+    /** The colibri2 requests jicofo sent which ask for an ICE restart. */
+    private fun iceRestartRequests() = xmppConnection.requests.filterIsInstance<ConferenceModifyIQ>()
+        .flatMap { it.endpoints }.filter { it.transport?.iceRestart == true }
+
+    /** The error condition of the response jicofo sent to a request, or null if it was accepted. */
+    private fun errorConditionOf(request: IQ) = xmppConnection.requests
+        .find { it.stanzaId == request.stanzaId && it.type == IQ.Type.error }?.error?.condition
+
+    init {
+        context("A conference with two participants") {
+            // min-participants is 2, so nothing is invited before the second one joins.
+            val member = harness.addParticipants(2).first()
+            val participant = harness.getParticipant(member).shouldNotBeNull()
+            val remoteParticipant = harness.getRemoteParticipant(member).shouldNotBeNull()
+            val sessionInitiate = remoteParticipant.sessionInitiate
+            val jingleSession = harness.jingleSessions.find { it.sid == sessionInitiate.sid }.shouldNotBeNull()
+            val bridgeSessionId = sessionInitiate.getExtension(BridgeSessionPacketExtension::class.java)
+                .shouldNotBeNull().id.shouldNotBeNull()
+
+            /** The `transport-info`s jicofo sent to the client (the session-initiate does not use one). */
+            fun transportInfosToClient() =
+                remoteParticipant.requests.filter { it.action == JingleAction.TRANSPORT_INFO }
+
+            fun createIceRestartRequest(bsId: String? = bridgeSessionId) =
+                JingleIQ(JingleAction.SESSION_INFO, sessionInitiate.sid).apply {
+                    from = sessionInitiate.to
+                    to = sessionInitiate.from
+                    type = IQ.Type.set
+                    stanzaId = "ice-restart-request-$bsId"
+                    addExtension(
+                        BridgeSessionPacketExtension().apply {
+                            id = bsId
+                            setIceRestart(true)
+                        }
+                    )
+                }
+
+            context("A valid request") {
+                val request = createIceRestartRequest()
+                jingleSession.processIq(request)
+
+                should("be accepted") {
+                    errorConditionOf(request) shouldBe null
+                }
+                should("result in a colibri2 ICE restart request for the endpoint") {
+                    iceRestartRequests().map { it.id } shouldBe listOf(participant.endpointId)
+                }
+                should("relay the bridge's rotated transport to the client in a transport-info") {
+                    val transportInfos = transportInfosToClient()
+                    transportInfos.size shouldBe 1
+                    val transport = transportInfos.first().contentList
+                        .firstNotNullOf { it.getFirstChildOfType(IceUdpTransportPacketExtension::class.java) }
+                    // The mock bridge rotates its credentials and tags them with the generation.
+                    transport.iceGeneration shouldBe 1
+                    transport.ufrag shouldBe "ufrag-${harness.conference.meetingId}-${participant.endpointId}-1"
+                }
+                should("not terminate the Jingle session") {
+                    participant.jingleSession shouldBe jingleSession
+                    remoteParticipant.requests.none { it.action == JingleAction.SESSION_TERMINATE } shouldBe true
+                }
+            }
+
+            context("A request with a stale bridge-session ID") {
+                val request = createIceRestartRequest("not-the-current-bridge-session")
+                jingleSession.processIq(request)
+
+                should("be rejected with item-not-found") {
+                    errorConditionOf(request) shouldBe StanzaError.Condition.item_not_found
+                }
+                should("not ask the bridge for anything") {
+                    iceRestartRequests().size shouldBe 0
+                }
+                should("not signal anything to the client") {
+                    transportInfosToClient().size shouldBe 0
+                }
+            }
+
+            context("A request when the feature is disabled") {
+                withNewConfig("jicofo.conference.enable-ice-restart=false") {
+                    val request = createIceRestartRequest()
+                    jingleSession.processIq(request)
+
+                    should("be rejected with feature-not-implemented") {
+                        errorConditionOf(request) shouldBe StanzaError.Condition.feature_not_implemented
+                    }
+                    should("not ask the bridge for anything") {
+                        iceRestartRequests().size shouldBe 0
+                    }
+                }
+            }
+
+            context("Repeated requests") {
+                // The configured limits allow 5 requests per minute, but never two within 5 seconds of each other.
+                val first = createIceRestartRequest()
+                jingleSession.processIq(first)
+                val second = JingleIQ(JingleAction.SESSION_INFO, sessionInitiate.sid).apply {
+                    from = sessionInitiate.to
+                    to = sessionInitiate.from
+                    type = IQ.Type.set
+                    stanzaId = "second-ice-restart-request"
+                    addExtension(
+                        BridgeSessionPacketExtension().apply {
+                            id = bridgeSessionId
+                            setIceRestart(true)
+                        }
+                    )
+                }
+                jingleSession.processIq(second)
+
+                should("rate-limit the second one") {
+                    errorConditionOf(first) shouldBe null
+                    errorConditionOf(second) shouldBe StanzaError.Condition.resource_constraint
+                }
+                should("only ask the bridge once") {
+                    iceRestartRequests().size shouldBe 1
+                }
+            }
+
+            context("A session-info without the ice-restart flag") {
+                // The existing ice-state=failed path must be unaffected.
+                val request = JingleIQ(JingleAction.SESSION_INFO, sessionInitiate.sid).apply {
+                    from = sessionInitiate.to
+                    to = sessionInitiate.from
+                    type = IQ.Type.set
+                    stanzaId = "plain-session-info"
+                    addExtension(BridgeSessionPacketExtension().apply { id = bridgeSessionId })
+                }
+                jingleSession.processIq(request)
+
+                should("not trigger an ICE restart") {
+                    iceRestartRequests().size shouldBe 0
+                    transportInfosToClient().size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-118-g64ecd07</version>
+        <version>1.0-119-gc67bc81</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Implements the jicofo side of an in-place ICE restart, in which the bridge creates a new ICE agent with fresh credentials while the existing one keeps carrying media until the new one connects (make-before-break). Jicofo receives the client's request, asks the bridge, and relays the bridge's new transport back to the client.

### Intake

The client asks for a restart with a Jingle `session-info` carrying `<bridge-session ice-restart="true"/>`. `session-info` is the action for in-session informational messages and implies no state change, which is right here: the session is explicitly not being torn down. The existing modes on the neighbouring paths are unchanged and still trigger a full re-invite — `<ice-state>failed</ice-state>` on `session-info`, and `restart="true"` on `session-terminate`, which remains the client's fallback when an in-place restart does not work out.

The request is validated against the bridge-session ID and rate limited. The rate limiter is a separate instance reusing the existing `jicofo.conference.restart-request-rate-limits.*` keys, so ICE restarts and full-session restarts do not share a budget.

### Relay

`Colibri2Session.restartIce()` sends a conference-modify with `<transport ice-restart="true"/>`. The bridge answers with its new transport, which `ColibriV2SessionManager.endpointIceRestarted()` picks up and forwards to the participant as a plain Jingle `transport-info` (not `transport-replace`, so the client stays the answerer).

Colibri2 responses are handled on `TaskPools.ioPool` and can reorder, so a latest-wins guard on the transport's `ice-generation` (tracked per participant) drops anything not newer than what was already relayed.

The reverse leg needs no new code: the client's own new credentials come back through the existing `onTransportInfo` to `updateTransport` to `updateParticipant` path, and the `ice-generation` attribute survives it unchanged.

### Config and metrics

`jicofo.conference.enable-ice-restart` (default true). When disabled, the request is answered with `feature-not-implemented` and the client falls back on its own.

`IceRestartMetrics` counts requests received, transports relayed, and failures. Failures currently share one counter across several causes (disabled, rate limited, stale bridge-session ID, unknown endpoint, no transport in the response, stale generation, no Jingle session); the log lines distinguish them.

`Bridge.endpointRequestedRestart()` is deliberately not called here, unlike the `iceFailed` and `terminateSession` paths. An in-place restart is normally a client network change rather than evidence the bridge is failing ICE, so counting it would feed the bridge-selection penalty unfairly.

Part of a multi-repo change; all PRs share the `in-place-ice-restart` branch name so CI tests them together:

- jitsi-xmpp-extensions: https://github.com/jitsi/jitsi-xmpp-extensions/pull/148
- jitsi-videobridge: https://github.com/jitsi/jitsi-videobridge/pull/2438
- lib-jitsi-meet: https://github.com/jitsi/lib-jitsi-meet/pull/3083
- jitsi-meet: https://github.com/jitsi/jitsi-meet/pull/17700
