### PR TITLE
Add tracing for jigasi dial requests, join remote traces

### DIFF
--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/util/TracingUtil.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/util/TracingUtil.kt
@@ -1,8 +1,17 @@
 package org.jitsi.jicofo.util
 
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.SpanId
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceId
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.context.Context
 import org.jitsi.jicofo.xmpp.muc.ChatRoom
 import org.jitsi.jicofo.xmpp.muc.ChatRoomMember
+import org.jitsi.xmpp.extensions.TraceParent
+import org.jivesoftware.smack.packet.IQ
 import java.util.Objects
 
 class TracingUtil {
@@ -24,6 +33,66 @@ class TracingUtil {
                 .put("room.members", room.memberCount.toString())
                 .put("room.visitors", room.visitorCount.toString())
                 .build()
+        }
+
+        /**
+         * Extracts a remote [Span] from the `traceparent` extension of an IQ, if present.
+         *
+         * Inlined from jicoco-tracing's TracingUtil, which was removed because it pulled in a Smack
+         * dependency that isn't available on Maven Central: https://github.com/jitsi/jicoco/pull/241
+         */
+        @JvmStatic
+        fun remoteSpanFromIq(iq: IQ): Span? {
+            val extension = iq.getExtension(TraceParent::class.java) ?: return null
+            return remoteSpan(extension.traceId, extension.parentId, extension.traceFlags)
+        }
+
+        /**
+         * Extracts a remote [Context] from the `traceparent` extension of an IQ, if present, or the root
+         * context otherwise.
+         */
+        @JvmStatic
+        fun remoteContextFromIq(iq: IQ): Context {
+            val root = Context.root()
+            val span = remoteSpanFromIq(iq) ?: return root
+            return root.with(span)
+        }
+
+        /**
+         * Parses a W3C trace context `traceparent` value ("00-<trace-id>-<parent-id>-<flags>") as
+         * carried in SIP/HTTP headers, rayo headers or conference properties. Returns the root
+         * context when the value is missing or malformed.
+         */
+        @JvmStatic
+        fun remoteContextFromW3CHeader(value: String?): Context {
+            val root = Context.root()
+            val parts = value?.trim()?.split("-") ?: return root
+            if (parts.size < 4) {
+                return root
+            }
+            val span = remoteSpan(parts[1], parts[2], parts[3]) ?: return root
+            return root.with(span)
+        }
+
+        /**
+         * Formats a span context as a W3C trace context `traceparent` value.
+         */
+        @JvmStatic
+        fun toW3CHeader(spanContext: SpanContext): String =
+            "00-${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceFlags.asHex()}"
+
+        private fun remoteSpan(traceId: String, spanId: String, flagsHex: String): Span? {
+            if (!TraceId.isValid(traceId) || !SpanId.isValid(spanId)) {
+                return null
+            }
+            val flags = try {
+                TraceFlags.fromHex(flagsHex, 0)
+            } catch (e: Exception) {
+                TraceFlags.getDefault()
+            }
+            return Span.wrap(
+                SpanContext.createFromRemoteParent(traceId, spanId, flags, TraceState.getDefault())
+            )
         }
     }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -20,14 +20,12 @@ package org.jitsi.jicofo.xmpp.jingle
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.api.trace.TraceFlags
-import io.opentelemetry.api.trace.TraceState
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.conference.source.ConferenceSourceMap
+import org.jitsi.jicofo.util.TracingUtil
 import org.jitsi.jicofo.xmpp.IqProcessingResult
 import org.jitsi.jicofo.xmpp.createSessionInitiate
 import org.jitsi.jicofo.xmpp.createTransportReplace
@@ -54,34 +52,6 @@ import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.packet.StanzaError
 import org.jxmpp.jid.Jid
 import java.util.Objects
-
-/**
- * Extracts a remote [Span] from the `traceparent` extension of an IQ, if present.
- *
- * Inlined from jicoco-tracing's TracingUtil, which was removed because it pulled in a Smack
- * dependency that isn't available on Maven Central: https://github.com/jitsi/jicoco/pull/241
- */
-private fun remoteSpanFromIq(iq: IQ): Span? {
-    val extension = iq.getExtension(TraceParent::class.java) ?: return null
-    return Span.wrap(
-        SpanContext.createFromRemoteParent(
-            extension.traceId,
-            extension.parentId,
-            TraceFlags.fromHex(extension.traceFlags, 0),
-            TraceState.getDefault()
-        )
-    )
-}
-
-/**
- * Extracts a remote [Context] from the `traceparent` extension of an IQ, if present, or the root
- * context otherwise.
- */
-private fun remoteContextFromIq(iq: IQ): Context {
-    val root = Context.root()
-    val span = remoteSpanFromIq(iq) ?: return root
-    return root.with(span)
-}
 
 /**
  * Class describes Jingle session.
@@ -114,7 +84,7 @@ class JingleSession(
         "jingle-iq-queue",
         { iq ->
             val span = tracer.spanBuilder("jingle.${iq.action}")
-                .setParent(remoteContextFromIq(iq))
+                .setParent(TracingUtil.remoteContextFromIq(iq))
                 .setAttribute("initiator.id", Objects.toString(iq.initiator))
                 .setAttribute("responder.id", Objects.toString(iq.responder))
                 .setAttribute("session.id", Objects.toString(iq.sid))

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/ConferenceIqHandler.kt
@@ -19,6 +19,7 @@ package org.jitsi.jicofo.xmpp
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import org.jitsi.jicofo.FocusManager
@@ -26,6 +27,7 @@ import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.auth.AuthenticationAuthority
 import org.jitsi.jicofo.auth.ErrorFactory
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
+import org.jitsi.jicofo.util.TracingUtil
 import org.jitsi.jwt.JitsiToken
 import org.jitsi.tracing.TracingGlobal.Companion.sdk
 import org.jitsi.utils.logging2.createLogger
@@ -78,7 +80,16 @@ class ConferenceIqHandler(
 
     /** Handle a [ConferenceIq] synchronously and return a response. */
     fun handleConferenceIq(query: ConferenceIq): IQ {
+        // Join the sender's trace (e.g. jigasi dial-in) when the IQ carries a trace context, either
+        // as a traceparent extension or as a "traceparent" property in W3C format (the property is
+        // what ConferenceIqProvider preserves when parsing).
+        var remoteContext = TracingUtil.remoteContextFromIq(query)
+        if (Span.fromContextOrNull(remoteContext) == null) {
+            remoteContext = TracingUtil.remoteContextFromW3CHeader(query.propertiesMap["traceparent"])
+        }
+
         val span = tracer.spanBuilder("xmpp.conference")
+            .setParent(remoteContext)
             .setAttribute("client.id", Objects.toString(query.from))
             .setAttribute("room.id", Objects.toString(query.room))
             .startSpan()

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/JigasiIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/JigasiIqHandler.kt
@@ -19,13 +19,19 @@ package org.jitsi.jicofo.xmpp
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
 import org.jitsi.jicofo.ConferenceStore
 import org.jitsi.jicofo.TaskPools
 import org.jitsi.jicofo.conference.JitsiMeetConference
 import org.jitsi.jicofo.jigasi.JigasiDetector
 import org.jitsi.jicofo.metrics.JicofoMetricsContainer
+import org.jitsi.jicofo.util.TracingUtil
 import org.jitsi.jicofo.xmpp.IqProcessingResult.AcceptedWithNoResponse
 import org.jitsi.jicofo.xmpp.IqProcessingResult.RejectedWithError
+import org.jitsi.tracing.TracingGlobal
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.xmpp.extensions.rayo.DialIq
 import org.jivesoftware.smack.AbstractXMPPConnection
@@ -35,6 +41,7 @@ import org.jivesoftware.smack.packet.StanzaError
 import org.jivesoftware.smack.packet.id.StandardStanzaIdSource
 import org.jxmpp.jid.Jid
 import org.jxmpp.jid.impl.JidCreate
+import java.util.Objects
 import java.util.concurrent.atomic.AtomicInteger
 
 class JigasiIqHandler(
@@ -48,6 +55,8 @@ class JigasiIqHandler(
     setOf(IQ.Type.set)
 ) {
     private val logger = createLogger()
+
+    private val tracer: Tracer = TracingGlobal.sdk.getTracer("org.jitsi.jicofo.jigasi")
 
     private val stanzaIdSource = stanzaIdSourceFactory.constructStanzaIdSource()
 
@@ -92,13 +101,35 @@ class JigasiIqHandler(
         Stats.acceptedRequests.inc()
 
         TaskPools.ioPool.execute {
+            // Join the sender's trace when the dial IQ carries a trace context, either as a
+            // traceparent extension or as an X-Traceparent rayo header in W3C format (the header is
+            // what RayoIqProvider preserves when parsing).
+            var remoteContext = TracingUtil.remoteContextFromIq(request.iq)
+            if (Span.fromContextOrNull(remoteContext) == null) {
+                remoteContext = TracingUtil.remoteContextFromW3CHeader(request.iq.getHeader("X-Traceparent"))
+            }
+
+            val span = tracer.spanBuilder("jigasi.dial")
+                .setParent(remoteContext)
+                .setAttribute("client.id", Objects.toString(request.iq.from))
+                .setAttribute("room.id", Objects.toString(conference.roomName))
+                .setAttribute(
+                    "dial.type",
+                    if (request.iq.destination == "jitsi_meet_transcribe") "transcription" else "sip"
+                )
+                .startSpan()
             try {
-                inviteJigasi(request, conference)
+                span.makeCurrent().use {
+                    inviteJigasi(request, conference)
+                }
             } catch (e: Exception) {
+                span.setStatus(StatusCode.ERROR, e.message ?: "")
                 logger.warn("Failed to invite jigasi", e)
                 request.connection.tryToSendStanza(
                     IQ.createErrorResponse(request.iq, StanzaError.Condition.internal_server_error)
                 )
+            } finally {
+                span.end()
             }
         }
         return AcceptedWithNoResponse()
@@ -147,6 +178,11 @@ class JigasiIqHandler(
             from = null
             to = jigasiJid
             stanzaId = stanzaIdSource.newStanzaId
+            // Stamp our trace context on the forwarded IQ as an X-Traceparent rayo header, which
+            // jigasi parents its dial-out span from.
+            Span.fromContextOrNull(Context.current())?.let {
+                setHeader("X-Traceparent", TracingUtil.toW3CHeader(it.spanContext))
+            }
         }
         val responseFromJigasi = try {
             jigasiDetector.xmppConnection.sendIqAndGetResponse(requestToJigasi)


### PR DESCRIPTION
Follow-up to #1294/#1301, companion to jitsi/jigasi#646 and jitsi/jitsi-meet#17734.

## What

- **JigasiIqHandler**: adds a `jigasi.dial` span around dial IQ handling (mirroring the jibri tracing), parented from a trace context on the incoming IQ when present. The forwarded dial IQ is stamped with an `X-Traceparent` rayo header in W3C trace context format, which jigasi parents its `dial.out` span from. The rayo header form is used because `RayoIqProvider` only parses `header` children of `<dial>` — a `traceparent` extension element is dropped at parse time.
- **ConferenceIqHandler**: the `xmpp.conference` span now parents from a trace context on the incoming conference IQ instead of always starting a new root, so it joins e.g. jigasi's `dial.in` trace. Accepted either as a `traceparent` extension or as a `traceparent` conference property in W3C format — the property is what `ConferenceIqProvider` preserves when parsing (jigasi sends both).
- Moves the traceparent IQ helpers from `JingleSession` to `TracingUtil` (jicofo-common) so both handlers can share them, and adds W3C `traceparent` value parsing/formatting.

## Testing

`mvn clean verify` passes. With `tracing.enabled=true` on jicofo and jigasi, a dial-out produces a single trace: client dial → `jigasi.dial` (jicofo) → `dial.out` (jigasi) → SIP INVITE (`X-Traceparent` forwarded on the INVITE); a jigasi dial-in joins `xmpp.conference` to jigasi's `dial.in` trace via the conference property.