### PR TITLE
Redact JWT token in PacketDebugger logging

### DIFF
--- a/jicofo-common/src/main/java/org/jitsi/impl/protocol/xmpp/log/PacketDebugger.java
+++ b/jicofo-common/src/main/java/org/jitsi/impl/protocol/xmpp/log/PacketDebugger.java
@@ -17,6 +17,7 @@ package org.jitsi.impl.protocol.xmpp.log;
 
 import edu.umd.cs.findbugs.annotations.*;
 import org.jitsi.utils.logging2.*;
+import org.jitsi.xmpp.util.RedactColibri;
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.debugger.*;
 import org.jivesoftware.smack.packet.*;
@@ -66,13 +67,18 @@ public class PacketDebugger
     @Override
     public void onIncomingStreamElement(TopLevelStreamElement streamElement)
     {
-        logger.debug(() -> "RCV PKT (" + id + "): " + streamElement.toXML());
+        logger.debug(() -> "RCV PKT (" + id + "): " + redact(streamElement));
     }
 
     @Override
     public void onOutgoingStreamElement(TopLevelStreamElement streamElement)
     {
-        logger.debug(() -> "SENT PKT (" + id + "): " + streamElement.toXML());
+        logger.debug(() -> "SENT PKT (" + id + "): " + redact(streamElement));
+    }
+
+    private static String redact(TopLevelStreamElement streamElement)
+    {
+        return RedactColibri.Companion.redactToken(streamElement.toXML().toString());
     }
 
     /**

--- a/jicofo-common/src/test/kotlin/org/jitsi/impl/protocol/xmpp/log/PacketDebuggerTest.kt
+++ b/jicofo-common/src/test/kotlin/org/jitsi/impl/protocol/xmpp/log/PacketDebuggerTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Jicofo, the Jitsi Conference Focus.
+ *
+ * Copyright @ 2026 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.protocol.xmpp.log
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.jitsi.xmpp.extensions.jitsimeet.ConferenceIq
+import org.jitsi.xmpp.util.RedactColibri.Companion.redactToken
+import org.jxmpp.jid.impl.JidCreate
+
+class PacketDebuggerTest : ShouldSpec({
+    should("redact the token attribute of a logged ConferenceIq, as done by PacketDebugger") {
+        val token = "eyJhbGciOiJIUzI1NiJ9.super-secret-jwt"
+        val iq = ConferenceIq().apply {
+            room = JidCreate.entityBareFrom("room@conference.example.com")
+            this.token = token
+            stanzaId = "id1"
+        }
+
+        val redacted = redactToken(iq.toXML().toString())
+
+        redacted shouldNotContain token
+        redacted shouldContain "room=\"room@conference.example.com\""
+        redacted shouldContain "token=\"[redacted]\""
+    }
+})


### PR DESCRIPTION
## Summary
- `PacketDebugger` logs raw XMPP stanza XML at debug level, which exposed the JWT auth token carried by `ConferenceIq`
- Redact the token before logging, using the `RedactColibri` utility from jitsi-xmpp-extensions

Depends on jitsi/jitsi-xmpp-extensions#150 (adds `RedactColibri.redactToken()`). No version bump included; the pin will be updated once that PR is released.
