### PR TITLE
Add jibri_no_instance_failures metric

### DIFF
--- a/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
+++ b/jicofo/src/main/java/org/jitsi/jicofo/jibri/JibriSession.java
@@ -295,6 +295,11 @@ public class JibriSession
         {
             JibriStats.sessionFailed(getJibriType());
 
+            if (e instanceof StartException.NotAvailable)
+            {
+                JibriStats.noInstanceFailed();
+            }
+
             throw e;
         }
     }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriStats.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriStats.kt
@@ -42,6 +42,12 @@ class JibriStats {
         )
 
         @JvmField
+        val noInstanceFailures = JicofoMetricsContainer.instance.registerCounter(
+            "jibri_no_instance_failures",
+            "Number of failures to start a jibri session because no instance was available"
+        )
+
+        @JvmField
         val liveStreamingActive = JicofoMetricsContainer.instance.registerLongGauge(
             "jibri_live_streaming_active",
             "Current number of active jibris in live-streaming mode"
@@ -65,5 +71,8 @@ class JibriStats {
             JibriSession.Type.LIVE_STREAMING -> liveStreamingFailures.inc()
             JibriSession.Type.RECORDING -> recordingFailures.inc()
         }
+
+        @JvmStatic
+        fun noInstanceFailed() = noInstanceFailures.inc()
     }
 }


### PR DESCRIPTION
## Summary
- Adds a new counter, jibri_no_instance_failures, incremented only when a jibri session fails to start because no instance was available (StartException.NotAvailable).
- Existing per-type failure counters (jibri_sip_failures, jibri_recording_failures, jibri_live_streaming_failures) increment for all failure reasons and cannot isolate this case.