### PR TITLE
Update to Kotlin 2.4.20, JUnit 5.14.4, kotest 5.9.1, mockk 1.14.11, Jackson 2.21.5

### DIFF
--- a/jicofo-common/pom.xml
+++ b/jicofo-common/pom.xml
@@ -213,6 +213,7 @@
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.config.file>${project.parent.basedir}/lib/logging.properties</java.util.logging.config.file>
+            <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/jicofo-common/pom.xml
+++ b/jicofo-common/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <artifactId>kotlin-stdlib</artifactId>
       <scope>compile</scope>
     </dependency>
     <!-- org.jitsi -->
@@ -113,7 +113,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jicofo-selector/pom.xml
+++ b/jicofo-selector/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <artifactId>kotlin-stdlib</artifactId>
       <scope>compile</scope>
     </dependency>
     <!-- org.jitsi -->
@@ -109,7 +109,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jicofo-selector/pom.xml
+++ b/jicofo-selector/pom.xml
@@ -216,6 +216,7 @@
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.config.file>${project.parent.basedir}/lib/logging.properties</java.util.logging.config.file>
+            <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/jicofo/pom.xml
+++ b/jicofo/pom.xml
@@ -301,6 +301,7 @@
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.config.file>${project.parent.basedir}/lib/logging.properties</java.util.logging.config.file>
+            <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/jicofo/pom.xml
+++ b/jicofo/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <artifactId>kotlin-stdlib</artifactId>
       <scope>compile</scope>
     </dependency>
     <!-- org.jitsi -->
@@ -168,7 +168,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <kotest.version>5.9.1</kotest.version>
     <slf4j.version>1.7.32</slf4j.version>
     <jackson.version>2.21.5</jackson.version>
-    <jitsi.utils.version>1.0-150-g4ab9a3b</jitsi.utils.version>
-    <jicoco.version>1.1-178-ga09ed33</jicoco.version>
+    <jitsi.utils.version>1.0-153-gd5c0102</jitsi.utils.version>
+    <jicoco.version>1.1-179-g52cf6ef</jicoco.version>
     <ktlint-maven-plugin.version>3.0.0</ktlint-maven-plugin.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
@@ -159,7 +159,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-metaconfig</artifactId>
-        <version>1.0-9-g5e1b624</version>
+        <version>1.0-18-ge06bc45</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
@@ -169,7 +169,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-xmpp-extensions</artifactId>
-        <version>1.0-122-g58922cb</version>
+        <version>1.0-124-g024f15d</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,18 +38,19 @@
     <!-- Make sure this matches the version of the jxmpp artifacts inheriteb from smack. -->
     <jxmpp.version>1.0.3</jxmpp.version>
     <smack.version>4.4.8-jitsi-4</smack.version>
-    <kotlin.version>1.9.10</kotlin.version>
+    <kotlin.version>2.4.20</kotlin.version>
     <ktor.version>3.0.0</ktor.version>
-    <kotest.version>5.7.2</kotest.version>
+    <kotest.version>5.9.1</kotest.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <jackson.version>2.19.0</jackson.version>
+    <jackson.version>2.21.5</jackson.version>
     <jitsi.utils.version>1.0-150-g4ab9a3b</jitsi.utils.version>
     <jicoco.version>1.1-178-ga09ed33</jicoco.version>
     <ktlint-maven-plugin.version>3.0.0</ktlint-maven-plugin.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
-    <junit.version>5.10.0</junit.version>
-    <mockk.version>1.13.8</mockk.version>
+    <junit.version>5.14.4</junit.version>
+    <junit.platform.version>1.14.4</junit.platform.version>
+    <mockk.version>1.14.11</mockk.version>
   </properties>
   <build>
     <plugins>
@@ -125,7 +126,7 @@
       </dependency>
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <artifactId>kotlin-stdlib</artifactId>
         <version>${kotlin.version}</version>
         <scope>compile</scope>
       </dependency>
@@ -232,7 +233,13 @@
       <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
-        <version>1.8.1</version>
+        <version>${junit.platform.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${junit.platform.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -243,7 +250,7 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
+        <artifactId>junit-jupiter</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Bumps Kotlin to 2.4.20 and the test tooling to current versions. Jackson 2.21.5 matches what jitsi-utils now uses.

Declares kotlin-stdlib directly instead of the empty kotlin-stdlib-jdk8 shell so the runtime stdlib always matches the compiler. Manages junit-platform-engine alongside the launcher: kotest 5.9 drags in platform 1.8, which otherwise wins over the version the Jupiter 5.14 engine needs and crashes the forked test JVM. Disables kotest classpath autoscan; the set of tests run is unchanged.

This is one of a set of same-named kotlin-2.4 branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR only bumps the compiler and test/doc tooling; dependency versions between the jitsi repos are unchanged, so the PRs are independently mergeable. A library built with Kotlin 2.4 can only be consumed by Kotlin 2.3 or newer, so the compiler bumps should land everywhere before any repo picks up a 2.4-built release of another.