### PR TITLE
Run ktlint 1.8.0 directly via exec-maven-plugin and reformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,6 @@
 [*.{kt,kts}]
+# Keep constructor parameters wrapped one per line, and kotest specs unindented.
+ktlint_standard_class-signature = disabled
 max_line_length=120
 ktlint_code_style = intellij_idea
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ mvn test -Dtest=BridgeSelectorTest   # Run specific test class
 
 ### Code Quality
 ```bash
-mvn ktlint:check                     # Run ktlint (must be run for individual modules e.g. in ./jicofo-selector/)
+mvn exec:exec@ktlint-check           # Run ktlint (must be run for individual modules e.g. in ./jicofo-selector/; sibling modules must
+                                     # be resolvable, so run "mvn install -DskipTests" from the root first if they are not)
+mvn exec:exec@ktlint-format          # Auto-format Kotlin code with ktlint (same restriction)
 mvn checkstyle:check                 # Run checkstyle (config: checkstyle.xml)
 ```
 

--- a/jicofo-common/pom.xml
+++ b/jicofo-common/pom.xml
@@ -294,24 +294,61 @@
           </dependency>
         </dependencies>
       </plugin>
+      <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
       <plugin>
-        <groupId>com.github.gantsign.maven</groupId>
-        <artifactId>ktlint-maven-plugin</artifactId>
-        <version>${ktlint-maven-plugin.version}</version>
-        <configuration>
-          <sourceRoots>
-            <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-          </sourceRoots>
-          <testSourceRoots>
-            <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-          </testSourceRoots>
-        </configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.pinterest.ktlint</groupId>
+            <artifactId>ktlint-cli</artifactId>
+            <version>${ktlint.version}</version>
+            <classifier>all</classifier>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
-            <id>check</id>
+            <id>ktlint-check</id>
+            <phase>verify</phase>
             <goals>
-              <goal>check</goal>
+              <goal>exec</goal>
             </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>ktlint-format</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--format</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/EndpointSourceSet.kt
@@ -237,8 +237,11 @@ private fun ContentPacketExtension.getOrCreateRtpDescription() =
 
 operator fun EndpointSourceSet?.plus(other: EndpointSourceSet?): EndpointSourceSet = when {
     this == null && other == null -> EndpointSourceSet.EMPTY
+
     this == null -> other!!
+
     other == null -> this
+
     else -> EndpointSourceSet(
         sources + other.sources,
         ssrcGroups + other.ssrcGroups

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/conference/source/Source.kt
@@ -114,8 +114,7 @@ data class Source(
          * For example "endpointA-a0" is the first audio source of "endpointA" or "endpointA-v0" for the first video
          * source.
          */
-        fun nameForIdAndMediaType(endpointId: String, mediaType: MediaType, idx: Int): String {
-            return "$endpointId-${(mediaType.toString()[0])}$idx"
-        }
+        fun nameForIdAndMediaType(endpointId: String, mediaType: MediaType, idx: Int): String =
+            "$endpointId-${(mediaType.toString()[0])}$idx"
     }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/util/TracingUtil.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/util/TracingUtil.kt
@@ -8,22 +8,18 @@ import java.util.Objects
 class TracingUtil {
     companion object {
         @JvmStatic
-        fun memberAttributes(member: ChatRoomMember): Attributes {
-            return Attributes.builder()
-                .put("member.name", member.name)
-                .put("member.id", Objects.toString(member.jid))
-                .put("member.role", member.role.toString())
-                .put("member.region", Objects.toString(member.region))
-                .build()
-        }
+        fun memberAttributes(member: ChatRoomMember): Attributes = Attributes.builder()
+            .put("member.name", member.name)
+            .put("member.id", Objects.toString(member.jid))
+            .put("member.role", member.role.toString())
+            .put("member.region", Objects.toString(member.region))
+            .build()
 
         @JvmStatic
-        fun roomAttributes(room: ChatRoom): Attributes {
-            return Attributes.builder()
-                .put("room.id", Objects.toString(room.roomJid))
-                .put("room.members", room.memberCount.toString())
-                .put("room.visitors", room.visitorCount.toString())
-                .build()
-        }
+        fun roomAttributes(room: ChatRoom): Attributes = Attributes.builder()
+            .put("room.id", Objects.toString(room.roomJid))
+            .put("room.members", room.memberCount.toString())
+            .put("room.visitors", room.visitorCount.toString())
+            .build()
     }
 }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/AbstractIqHandler.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/AbstractIqHandler.kt
@@ -95,8 +95,11 @@ abstract class AbstractIqHandler<T : IQ>(
             )
             return when (result) {
                 is AcceptedWithResponse -> result.response
+
                 is IqProcessingResult.AcceptedWithNoResponse -> null
+
                 is IqProcessingResult.RejectedWithError -> result.response
+
                 is IqProcessingResult.NotProcessed ->
                     IQ.createErrorResponse(iq, StanzaError.Condition.feature_not_implemented)
             }

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/JsonMessage.kt
@@ -43,9 +43,7 @@ sealed class JsonMessage(val type: String) {
 
         @JvmStatic
         @Throws(JsonProcessingException::class, JsonMappingException::class)
-        fun parse(string: String): JsonMessage {
-            return mapper.readValue(string)
-        }
+        fun parse(string: String): JsonMessage = mapper.readValue(string)
     }
 }
 

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/jingle/JingleSession.kt
@@ -182,18 +182,22 @@ class JingleSession(
             }
 
             JingleAction.SESSION_INFO -> requestHandler.onSessionInfo(this, iq)
+
             JingleAction.SESSION_TERMINATE -> requestHandler.onSessionTerminate(this, iq).also {
                 state = State.ENDED
             }
 
             JingleAction.TRANSPORT_ACCEPT -> requestHandler.onTransportAccept(this, iq.contentList)
+
             JingleAction.TRANSPORT_INFO -> requestHandler.onTransportInfo(this, iq.contentList)
+
             JingleAction.TRANSPORT_REJECT -> {
                 requestHandler.onTransportReject(this, iq)
                 null
             }
 
             JingleAction.ADDSOURCE, JingleAction.SOURCEADD -> requestHandler.onAddSource(this, iq.contentList)
+
             JingleAction.REMOVESOURCE, JingleAction.SOURCEREMOVE -> requestHandler.onRemoveSource(
                 this,
                 iq.contentList

--- a/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/MemberRole.kt
+++ b/jicofo-common/src/main/kotlin/org/jitsi/jicofo/xmpp/muc/MemberRole.kt
@@ -38,7 +38,9 @@ enum class MemberRole {
         @JvmStatic
         fun fromSmack(mucRole: MUCRole?, mucAffiliation: MUCAffiliation?) = when (mucAffiliation) {
             MUCAffiliation.admin -> MODERATOR
+
             MUCAffiliation.owner -> OWNER
+
             else -> when (mucRole) {
                 MUCRole.moderator -> MODERATOR
                 MUCRole.participant -> PARTICIPANT

--- a/jicofo-common/src/test/kotlin/org/jitsi/jicofo/xmpp/muc/MemberRoleTest.kt
+++ b/jicofo-common/src/test/kotlin/org/jitsi/jicofo/xmpp/muc/MemberRoleTest.kt
@@ -56,7 +56,9 @@ class MemberRoleTest : ShouldSpec() {
                 withClue("mucRole=$mucRole, mucAffiliation=$mucAffiliation") {
                     MemberRole.fromSmack(mucRole, mucAffiliation) shouldBe when (mucAffiliation) {
                         MUCAffiliation.admin -> MODERATOR
+
                         MUCAffiliation.owner -> OWNER
+
                         else -> when (mucRole) {
                             MUCRole.moderator -> MODERATOR
                             MUCRole.participant -> PARTICIPANT

--- a/jicofo-selector/pom.xml
+++ b/jicofo-selector/pom.xml
@@ -297,24 +297,61 @@
           </dependency>
         </dependencies>
       </plugin>
+      <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
       <plugin>
-        <groupId>com.github.gantsign.maven</groupId>
-        <artifactId>ktlint-maven-plugin</artifactId>
-        <version>${ktlint-maven-plugin.version}</version>
-        <configuration>
-          <sourceRoots>
-            <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-          </sourceRoots>
-          <testSourceRoots>
-            <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-          </testSourceRoots>
-        </configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.pinterest.ktlint</groupId>
+            <artifactId>ktlint-cli</artifactId>
+            <version>${ktlint.version}</version>
+            <classifier>all</classifier>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
-            <id>check</id>
+            <id>ktlint-check</id>
+            <phase>verify</phase>
             <goals>
-              <goal>check</goal>
+              <goal>exec</goal>
             </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>ktlint-format</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--format</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/Bridge.kt
@@ -234,9 +234,7 @@ class Bridge @JvmOverloads internal constructor(
      *
      * @return a negative number if this instance is more able to serve conferences than o
      */
-    override fun compareTo(other: Bridge): Int {
-        return compare(this, other)
-    }
+    override fun compareTo(other: Bridge): Int = compare(this, other)
 
     /** Notifies this [Bridge] that it was used for a new endpoint. */
     fun endpointAdded() {
@@ -305,16 +303,14 @@ class Bridge @JvmOverloads internal constructor(
     val fullVersion: String?
         get() = if (version != null && releaseId != null) "$version-$releaseId" else version
 
-    override fun toString(): String {
-        return String.format(
-            "Bridge[jid=%s, version=%s, relayId=%s, region=%s, correctedStress=%.2f]",
-            jid.toString(),
-            fullVersion,
-            relayId,
-            region,
-            correctedStress
-        )
-    }
+    override fun toString(): String = String.format(
+        "Bridge[jid=%s, version=%s, relayId=%s, region=%s, correctedStress=%.2f]",
+        jid.toString(),
+        fullVersion,
+        relayId,
+        region,
+        correctedStress
+    )
 
     /**
      * Gets the "stress" of the bridge, represented as a double between 0 and 1 (though technically the value
@@ -379,12 +375,10 @@ class Bridge @JvmOverloads internal constructor(
             }
         }
 
-        private fun getPriority(b: Bridge): Int {
-            return if (b.isOperational) {
-                if (b.isInGracefulShutdown) 2 else 1
-            } else {
-                3
-            }
+        private fun getPriority(b: Bridge): Int = if (b.isOperational) {
+            if (b.isInGracefulShutdown) 2 else 1
+        } else {
+            3
         }
     }
 }

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeConfig.kt
@@ -97,14 +97,12 @@ class BridgeConfig private constructor() {
             .convertFrom<String> { createTopologyStrategy(it) }
     }
 
-    private fun <T> createClassInstance(className: String): T {
-        return try {
-            val clazz = Class.forName("${javaClass.getPackage().name}.$className")
-            clazz.getConstructor().newInstance() as T
-        } catch (e: Exception) {
-            val clazz = Class.forName(className)
-            clazz.getConstructor().newInstance() as T
-        }
+    private fun <T> createClassInstance(className: String): T = try {
+        val clazz = Class.forName("${javaClass.getPackage().name}.$className")
+        clazz.getConstructor().newInstance() as T
+    } catch (e: Exception) {
+        val clazz = Class.forName(className)
+        clazz.getConstructor().newInstance() as T
     }
 
     private fun createSelectionStrategy(className: String): BridgeSelectionStrategy = createClassInstance(className)

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategy.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/BridgeSelectionStrategy.kt
@@ -319,19 +319,16 @@ abstract class BridgeSelectionStrategy {
      * @param conferenceBridges the bridges in the conference
      * @return `true` if the bridge should be considered overloaded.
      */
-    private fun Bridge.isOverloaded(conferenceBridges: Map<Bridge, ConferenceBridgeProperties>): Boolean {
-        return isOverloaded ||
+    private fun Bridge.isOverloaded(conferenceBridges: Map<Bridge, ConferenceBridgeProperties>): Boolean =
+        isOverloaded ||
             hasMaxParticipantsInConference(conferenceBridges) ||
             hasMaxRecentParticipantsInConference(conferenceBridges)
-    }
 
     private fun Bridge.hasMaxParticipantsInConference(
         conferenceBridges: Map<Bridge, ConferenceBridgeProperties>
-    ): Boolean {
-        return config.maxBridgeParticipants > 0 &&
-            conferenceBridges.containsKey(this) &&
-            conferenceBridges[this]!!.participantCount >= config.maxBridgeParticipants
-    }
+    ): Boolean = config.maxBridgeParticipants > 0 &&
+        conferenceBridges.containsKey(this) &&
+        conferenceBridges[this]!!.participantCount >= config.maxBridgeParticipants
 
     /**
      * Whether the conference has recently added too many endpoints to this bridge, i.e. it is growing on this bridge
@@ -340,11 +337,9 @@ abstract class BridgeSelectionStrategy {
      */
     private fun Bridge.hasMaxRecentParticipantsInConference(
         conferenceBridges: Map<Bridge, ConferenceBridgeProperties>
-    ): Boolean {
-        return config.maxBridgeParticipantsPerInterval > 0 &&
-            (conferenceBridges[this]?.recentlyAddedParticipantCount ?: 0) >=
-            config.maxBridgeParticipantsPerInterval
-    }
+    ): Boolean = config.maxBridgeParticipantsPerInterval > 0 &&
+        (conferenceBridges[this]?.recentlyAddedParticipantCount ?: 0) >=
+        config.maxBridgeParticipantsPerInterval
 
     /**
      * Log (and count) the bridges on which the conference has hit the [config.maxBridgeParticipantsPerInterval] limit.

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/RegionBasedBridgeSelectionStrategy.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/RegionBasedBridgeSelectionStrategy.kt
@@ -100,9 +100,7 @@ class RegionBasedBridgeSelectionStrategy : BridgeSelectionStrategy() {
             ?: leastLoaded(bridges, conferenceBridges, participantProperties)
     }
 
-    override fun toString(): String {
-        return "${javaClass.simpleName} with region groups: ${BridgeConfig.config.regionGroups}"
-    }
+    override fun toString(): String = "${javaClass.simpleName} with region groups: ${BridgeConfig.config.regionGroups}"
 
     override fun select(
         bridges: List<Bridge>,

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Colibri2Session.kt
@@ -327,6 +327,7 @@ class Colibri2Session(
                     request.addConnect(spec.toConnect(create = true))
                     hasDelta = true
                 }
+
                 !current.sameAs(spec) -> {
                     logger.info("Updating connect id=$id")
                     request.addConnect(spec.toConnect())

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/ColibriV2SessionManager.kt
@@ -286,8 +286,8 @@ class ColibriV2SessionManager @JvmOverloads constructor(
                     return@forEach
                 }
 
-                if (mediaType == MediaType.AUDIO && participantInfo.audioMuted == doMute ||
-                    mediaType == MediaType.VIDEO && participantInfo.videoMuted == doMute
+                if ((mediaType == MediaType.AUDIO && participantInfo.audioMuted == doMute) ||
+                    (mediaType == MediaType.VIDEO && participantInfo.videoMuted == doMute)
                 ) {
                     // No change required.
                     return@forEach
@@ -398,6 +398,7 @@ class ColibriV2SessionManager @JvmOverloads constructor(
             when (TranslationConfig.config.mode) {
                 TranslationConfig.Mode.SINGLE_BRIDGE ->
                     if (session == connectSession) add(buildSingleBridgeTranslatorSpec(session, url))
+
                 TranslationConfig.Mode.PER_SOURCE ->
                     addAll(buildPerSourceTranslatorSpecs(session, url))
             }
@@ -719,6 +720,7 @@ class ColibriV2SessionManager @JvmOverloads constructor(
                     // If we trigger a re-invite we may cause the same error repeating.
                     throw ColibriAllocationFailedException("Bad request: ${error.toXML()}", false)
                 }
+
                 item_not_found -> {
                     if (reason == Colibri2Error.Reason.CONFERENCE_NOT_FOUND) {
                         // The conference on the bridge has expired. The state between jicofo and the bridge is out of
@@ -732,6 +734,7 @@ class ColibriV2SessionManager @JvmOverloads constructor(
                         throw ColibriAllocationFailedException("Item not found, bridge unavailable?", false)
                     }
                 }
+
                 conflict -> {
                     if (reason == null) {
                         // An error NOT coming from the bridge.
@@ -752,6 +755,7 @@ class ColibriV2SessionManager @JvmOverloads constructor(
                         throw ColibriAllocationFailedException("Colibri error: ${error.toXML()}", true)
                     }
                 }
+
                 service_unavailable -> {
                     if (reason == Colibri2Error.Reason.GRACEFUL_SHUTDOWN) {
                         // The fact that this bridge was selected means that we haven't received its updated presence yet,
@@ -763,6 +767,7 @@ class ColibriV2SessionManager @JvmOverloads constructor(
                         throw ColibriAllocationFailedException("Bridge failed with service_unavailable.", true)
                     }
                 }
+
                 else -> {
                     session.bridge.isOperational = false
                     throw ColibriAllocationFailedException("Error: ${error.toXML()}", true)

--- a/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
+++ b/jicofo-selector/src/main/kotlin/org/jitsi/jicofo/bridge/colibri/Extensions.kt
@@ -33,9 +33,8 @@ import org.jivesoftware.smack.AbstractXMPPConnection
 import org.jivesoftware.smack.packet.IQ
 
 /** Read the [IceUdpTransportPacketExtension] for an endpoint with ID [endpointId] (or null if missing). */
-fun ConferenceModifiedIQ.parseTransport(endpointId: String): Transport? {
-    return endpoints.find { it.id == endpointId }?.transport
-}
+fun ConferenceModifiedIQ.parseTransport(endpointId: String): Transport? =
+    endpoints.find { it.id == endpointId }?.transport
 
 /**
  * Reads the feedback sources (at the "conference" level) and parses them into a [ConferenceSourceMap].

--- a/jicofo/pom.xml
+++ b/jicofo/pom.xml
@@ -305,13 +305,66 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.6.3</version>
         <configuration>
           <mainClass>org.jitsi.jicofo.Main</mainClass>
         </configuration>
+        <executions>
+          <execution>
+            <id>ktlint-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>ktlint-format</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--format</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.pinterest.ktlint</groupId>
+            <artifactId>ktlint-cli</artifactId>
+            <version>${ktlint.version}</version>
+            <classifier>all</classifier>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <!-- Instructs the plugin to add the current package version in the jar manifest
@@ -373,27 +426,6 @@
             <version>${spotbugs.version}</version>
           </dependency>
         </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>com.github.gantsign.maven</groupId>
-        <artifactId>ktlint-maven-plugin</artifactId>
-        <version>${ktlint-maven-plugin.version}</version>
-        <configuration>
-          <sourceRoots>
-            <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-          </sourceRoots>
-          <testSourceRoots>
-            <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-          </testSourceRoots>
-        </configuration>
-        <executions>
-          <execution>
-            <id>check</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/JicofoServices.kt
@@ -184,8 +184,8 @@ class JicofoServices {
         xmppServices.shutdown()
     }
 
-    private fun createAuthenticationAuthority(): AbstractAuthAuthority? {
-        return if (AuthConfig.config.type != AuthConfig.Type.NONE) {
+    private fun createAuthenticationAuthority(): AbstractAuthAuthority? =
+        if (AuthConfig.config.type != AuthConfig.Type.NONE) {
             logger.info("Starting authentication service with config=$authConfig.")
             val authAuthority = when (authConfig.type) {
                 AuthConfig.Type.XMPP -> XMPPDomainAuthAuthority(
@@ -197,6 +197,7 @@ class JicofoServices {
                 AuthConfig.Type.JWT -> ExternalJWTAuthority(
                     JidCreate.domainBareFrom(authConfig.loginUrl)
                 )
+
                 AuthConfig.Type.NONE -> null
             }
             authAuthority
@@ -204,7 +205,6 @@ class JicofoServices {
             logger.info("Authentication service disabled.")
             null
         }
-    }
 
     /** Gets statistics for the /stats HTTP interface. */
     private fun getStats(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/auth/AuthConfig.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/auth/AuthConfig.kt
@@ -65,10 +65,8 @@ class AuthConfig private constructor() {
         "jicofo.authentication.type".from(newConfig)
     }
 
-    override fun toString(): String {
-        return "AuthConfig[enabled=$enabled, type=$type, loginUrl=$loginUrl, " +
-            "authenticationLifetime=$authenticationLifetime, enableAutoLogin=$enableAutoLogin]"
-    }
+    override fun toString(): String = "AuthConfig[enabled=$enabled, type=$type, loginUrl=$loginUrl, " +
+        "authenticationLifetime=$authenticationLifetime, enableAutoLogin=$enableAutoLogin]"
 
     companion object {
         @JvmField

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/BaseJibri.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/BaseJibri.kt
@@ -169,6 +169,7 @@ abstract class BaseJibri internal constructor(
         return when (iq.action) {
             Action.START -> when (session) {
                 null -> handleStartRequest(iq)
+
                 else -> {
                     logger.info("Will not start a Jibri session, a session is already active")
                     error(
@@ -178,16 +179,19 @@ abstract class BaseJibri internal constructor(
                     )
                 }
             }
+
             Action.STOP -> when (session) {
                 null -> {
                     logger.warn("Rejecting STOP request for an unknown session.: ${iq.toXML()}")
                     error(iq, StanzaError.Condition.item_not_found, "Unknown session")
                 }
+
                 else -> {
                     session.stop(iq.from)
                     IQ.createResultIQ(iq)
                 }
             }
+
             Action.UNDEFINED, null -> {
                 return error(iq, StanzaError.Condition.bad_request, "undefined action ${iq.toXML()}")
             }
@@ -199,7 +203,10 @@ abstract class BaseJibri internal constructor(
         return when {
             // XXX do we need to keep the difference between `forbidden` and `not_allowed`?
             role == null -> StanzaError.getBuilder(StanzaError.Condition.forbidden).build()
-            role.hasModeratorRights() -> null // no error
+
+            role.hasModeratorRights() -> null
+
+            // no error
             else -> StanzaError.getBuilder(StanzaError.Condition.not_allowed).build()
         }
     }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriRecorder.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/jibri/JibriRecorder.kt
@@ -122,10 +122,12 @@ class JibriRecorder(
                         logger.info("Failed to start a Jibri session, all Jibris were busy")
                         error(iq, StanzaError.Condition.resource_constraint, "all Jibris are busy")
                     }
+
                     is NotAvailable -> {
                         logger.info("Failed to start a Jibri session, no Jibris available")
                         error(iq, StanzaError.Condition.service_unavailable, "no Jibris available")
                     }
+
                     else -> {
                         logger.warn("Failed to start a Jibri session: ${exc.message}", exc)
                         error(iq, StanzaError.Condition.internal_server_error, exc.message)

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/ktor/Application.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/ktor/Application.kt
@@ -335,24 +335,20 @@ private suspend fun RoutingCall.respondJson(json: JsonNode) {
     respondText(ContentType.Application.Json, HttpStatusCode.OK) { json.toString() }
 }
 
-private fun translateException(block: () -> MoveResult): MoveResult {
-    return try {
-        block()
-    } catch (e: MoveFailedException) {
-        throw when (e) {
-            is BridgeNotFoundException -> NotFound("Bridge not found")
-            is ConferenceNotFoundException -> NotFound("Conference not found")
-            is MissingParameterException, is InvalidParameterException -> BadRequest(e.message)
-        }
+private fun translateException(block: () -> MoveResult): MoveResult = try {
+    block()
+} catch (e: MoveFailedException) {
+    throw when (e) {
+        is BridgeNotFoundException -> NotFound("Bridge not found")
+        is ConferenceNotFoundException -> NotFound("Conference not found")
+        is MissingParameterException, is InvalidParameterException -> BadRequest(e.message)
     }
 }
 
-private fun RoutingRequest.getToken(): String? {
-    return this.headers["Authorization"]?.let {
-        if (it.startsWith("Bearer ")) {
-            it.substring("Bearer ".length)
-        } else {
-            it
-        }
+private fun RoutingRequest.getToken(): String? = this.headers["Authorization"]?.let {
+    if (it.startsWith("Bearer ")) {
+        it.substring("Bearer ".length)
+    } else {
+        it
     }
 }

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/AuthenticationIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/AuthenticationIqHandler.kt
@@ -58,18 +58,16 @@ class AuthenticationIqHandler(private val authAuthority: AuthenticationAuthority
         IQ.Type.get,
         IQRequestHandler.Mode.sync
     ) {
-        override fun handleIQRequest(iqRequest: IQ): IQ {
-            return if (iqRequest is LoginUrlIq) {
-                // If the IQ comes from mod_client_proxy, parse and substitute the original sender's JID.
-                val originalFrom = iqRequest.from
-                iqRequest.from = parseJidFromClientProxyJid(XmppConfig.client.clientProxy, originalFrom)
-                handleLoginUrlIq(iqRequest).also {
-                    it.to = originalFrom
-                }
-            } else {
-                logger.error("Received an unexpected IQ type: $iqRequest")
-                createInternalServerErrorResponse(iqRequest)
+        override fun handleIQRequest(iqRequest: IQ): IQ = if (iqRequest is LoginUrlIq) {
+            // If the IQ comes from mod_client_proxy, parse and substitute the original sender's JID.
+            val originalFrom = iqRequest.from
+            iqRequest.from = parseJidFromClientProxyJid(XmppConfig.client.clientProxy, originalFrom)
+            handleLoginUrlIq(iqRequest).also {
+                it.to = originalFrom
             }
+        } else {
+            logger.error("Received an unexpected IQ type: $iqRequest")
+            createInternalServerErrorResponse(iqRequest)
         }
     }
 
@@ -79,18 +77,16 @@ class AuthenticationIqHandler(private val authAuthority: AuthenticationAuthority
         IQ.Type.set,
         IQRequestHandler.Mode.sync
     ) {
-        override fun handleIQRequest(iqRequest: IQ): IQ {
-            return if (iqRequest is LogoutIq) {
-                // If the IQ comes from mod_client_proxy, parse and substitute the original sender's JID.
-                val originalFrom = iqRequest.from
-                iqRequest.from = parseJidFromClientProxyJid(XmppConfig.client.clientProxy, originalFrom)
-                handleLogoutIq(iqRequest).also {
-                    it.to = originalFrom
-                }
-            } else {
-                logger.error("Received an unexpected IQ type: $iqRequest")
-                createInternalServerErrorResponse(iqRequest)
+        override fun handleIQRequest(iqRequest: IQ): IQ = if (iqRequest is LogoutIq) {
+            // If the IQ comes from mod_client_proxy, parse and substitute the original sender's JID.
+            val originalFrom = iqRequest.from
+            iqRequest.from = parseJidFromClientProxyJid(XmppConfig.client.clientProxy, originalFrom)
+            handleLogoutIq(iqRequest).also {
+                it.to = originalFrom
             }
+        } else {
+            logger.error("Received an unexpected IQ type: $iqRequest")
+            createInternalServerErrorResponse(iqRequest)
         }
     }
 

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/MuteIqHandler.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/MuteIqHandler.kt
@@ -44,18 +44,16 @@ class AudioMuteIqHandler(
         setOf(IQ.Type.set),
         IQRequestHandler.Mode.sync
     ) {
-    override fun handleRequest(request: IqRequest<MuteIq>): IqProcessingResult {
-        return handleRequest(
-            MuteRequest(
-                request.iq,
-                request.connection,
-                conferenceStore,
-                request.iq.mute,
-                request.iq.jid,
-                MediaType.AUDIO
-            )
+    override fun handleRequest(request: IqRequest<MuteIq>): IqProcessingResult = handleRequest(
+        MuteRequest(
+            request.iq,
+            request.connection,
+            conferenceStore,
+            request.iq.mute,
+            request.iq.jid,
+            MediaType.AUDIO
         )
-    }
+    )
 }
 
 class VideoMuteIqHandler(
@@ -69,18 +67,16 @@ class VideoMuteIqHandler(
         setOf(IQ.Type.set),
         IQRequestHandler.Mode.sync
     ) {
-    override fun handleRequest(request: IqRequest<MuteVideoIq>): IqProcessingResult {
-        return handleRequest(
-            MuteRequest(
-                request.iq,
-                request.connection,
-                conferenceStore,
-                request.iq.mute,
-                request.iq.jid,
-                MediaType.VIDEO
-            )
+    override fun handleRequest(request: IqRequest<MuteVideoIq>): IqProcessingResult = handleRequest(
+        MuteRequest(
+            request.iq,
+            request.connection,
+            conferenceStore,
+            request.iq.mute,
+            request.iq.jid,
+            MediaType.VIDEO
         )
-    }
+    )
 }
 
 class DesktopMuteIqHandler(
@@ -94,18 +90,16 @@ class DesktopMuteIqHandler(
         setOf(IQ.Type.set),
         IQRequestHandler.Mode.sync
     ) {
-    override fun handleRequest(request: IqRequest<MuteDesktopIq>): IqProcessingResult {
-        return handleRequest(
-            MuteRequest(
-                request.iq,
-                request.connection,
-                conferenceStore,
-                request.iq.mute,
-                request.iq.jid,
-                MediaType.DESKTOP
-            )
+    override fun handleRequest(request: IqRequest<MuteDesktopIq>): IqProcessingResult = handleRequest(
+        MuteRequest(
+            request.iq,
+            request.connection,
+            conferenceStore,
+            request.iq.mute,
+            request.iq.jid,
+            MediaType.DESKTOP
         )
-    }
+    )
 }
 
 private val logger = LoggerImpl("org.jitsi.jicofo.xmpp.MuteIqHandler")
@@ -147,12 +141,14 @@ private fun handleRequest(request: MuteRequest): IqProcessingResult {
                         )
                     }
                 }
+
                 MuteResult.NOT_ALLOWED -> request.connection.tryToSendStanza(
                     IQ.createErrorResponse(
                         request.iq,
                         StanzaError.getBuilder(StanzaError.Condition.not_allowed).build()
                     )
                 )
+
                 MuteResult.ERROR -> request.connection.tryToSendStanza(
                     IQ.createErrorResponse(
                         request.iq,

--- a/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
+++ b/jicofo/src/main/kotlin/org/jitsi/jicofo/xmpp/VisitorsManager.kt
@@ -76,9 +76,11 @@ class VisitorsManager(
             val response = sendIqToComponentAndGetResponse(roomJid, extensions)
             when {
                 response == null -> logger.warn("Timeout waiting for VisitorsIq response.")
+
                 response.type == IQ.Type.result -> {
                     logger.info("Received VisitorsIq response: ${response.toXML()}")
                 }
+
                 else -> logger.warn("Received error response: ${response.toXML()}")
             }
         }

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/mock/ColibriAndJingleXmppConnection.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/mock/ColibriAndJingleXmppConnection.kt
@@ -43,7 +43,9 @@ class ColibriAndJingleXmppConnection : MockXmppConnection() {
 
     override fun handleIq(iq: IQ): IQ? = when (iq) {
         is ConferenceModifyIQ -> colibri2Server.handleConferenceModifyIq(iq)
+
         is JingleIQ -> remoteParticipants.computeIfAbsent(iq.to) { RemoteParticipant(iq.to) }.handleJingleIq(iq)
+
         else -> {
             println("Not handling ${iq.toXML()}")
             null

--- a/jicofo/src/test/kotlin/org/jitsi/jicofo/xmpp/jigasi/JigasiIqHandlerTest.kt
+++ b/jicofo/src/test/kotlin/org/jitsi/jicofo/xmpp/jigasi/JigasiIqHandlerTest.kt
@@ -183,6 +183,7 @@ class JigasiXmppConnection : MockXmppConnection() {
                 Response.Timeout -> null
             }
         }
+
         else -> {
             println("Not handling ${iq.toXML()}")
             null

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <jackson.version>2.21.5</jackson.version>
     <jitsi.utils.version>1.0-153-gd5c0102</jitsi.utils.version>
     <jicoco.version>1.1-179-g52cf6ef</jicoco.version>
-    <ktlint-maven-plugin.version>3.0.0</ktlint-maven-plugin.version>
+    <ktlint.version>1.8.0</ktlint.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
     <junit.version>5.14.4</junit.version>


### PR DESCRIPTION
Replaces the third-party ktlint-maven-plugin, which tends to trail ktlint releases, with the integration ktlint documents itself: the ktlint CLI jar (1.8.0) as an exec-maven-plugin dependency, with the classpath restricted to that jar. The check still runs in the `verify` phase and fails the build on violations. Autoformat with `mvn exec:exec@ktlint-format` instead of `mvn ktlint:format`. Run it inside a module directory; sibling modules must be resolvable, so run `mvn install -DskipTests` from the root first on a fresh clone.

The `class-signature` rule added in ktlint 1.x is disabled in `.editorconfig`: it joins wrapped constructor parameter lists onto one line when they fit and re-indents every kotest spec, which we do not want. All other new rules are applied.

The second commit is the resulting reformat: 293 lines in 25 Kotlin files, almost entirely single-`return` function bodies becoming expression bodies and blank lines between multi-line `when` branches; plus conditions mixing `&&` and `||` get explicit parentheses. Behaviour-neutral.

This is one of a set of same-named `ktlint-1.8` branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR is independent; they only change how ktlint is run and apply its formatting.